### PR TITLE
Fix lang reference for requiremodintro

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -31,7 +31,7 @@ $settings = new admin_settingpage($section, get_string('settings', 'mod_surveypr
 
 if ($ADMIN->fulltree) {
     $name = new lang_string('requiremodintro', 'admin');
-    $description = new lang_string('configrequiremodintro', 'admin');
+    $description = new lang_string('requiremodintro', 'admin');
     $settings->add(new admin_setting_configcheckbox('surveypro/requiremodintro', $name, $description, 0));
 
     $name = new lang_string('maxinputdelay', 'mod_surveypro');


### PR DESCRIPTION
In 2.8 and 2.9:
```
String does not exist. Please check your string definition for configrequiremodintro/admin
line 9406 of /lib/moodlelib.php: call to debugging()
line 34 of /mod/surveypro/settings.php: call to lang_string->__construct()
line 89 of /lib/classes/plugininfo/mod.php: call to include()
line 45 of /admin/settings/plugins.php: call to core\plugininfo\mod->load_settings()
line 6730 of /lib/adminlib.php: call to require()
line 19 of /admin/settings.php: call to admin_get_root()
```