### PR TITLE
NOBUG mod_surveypro: fixed error when submitting mandatory multiselect

### DIFF
--- a/field/multiselect/classes/plugin.class.php
+++ b/field/multiselect/classes/plugin.class.php
@@ -561,7 +561,7 @@ EOS;
         if ($this->minimumrequired) {
             $errorkey = $this->itemname;
 
-            $answercount = count($data[$this->itemname]);
+            $answercount = (isset($data[$this->itemname])) ? count($data[$this->itemname]) : 0;
             if ($answercount < $this->minimumrequired) {
                 if ($this->minimumrequired == 1) {
                     $errors[$errorkey] = get_string('lowerthanminimum_one', 'surveyprofield_multiselect');


### PR DESCRIPTION
if a mandatory multiselect item was submitted while still completely untouched an error was rose up claiming for not existing element $data[$this->itemname]