### PR TITLE
NOBUG mod_surveypro: fixed issue in get_item when $itemseed is not set

### DIFF
--- a/classes/itembase.class.php
+++ b/classes/itembase.class.php
@@ -184,14 +184,14 @@ class mod_surveypro_itembase {
     }
 
     /**
-     * item_validate_record_coherence
+     * item_force_coherence
      * verify the validity of contents of the record
      * for instance: age not greater than maximumage
      *
      * @param stdClass $record
      * @return stdClass $record
      */
-    public function item_validate_record_coherence($record) {
+    public function item_force_coherence($record) {
         // nothing to do here
     }
 

--- a/classes/templatebase.class.php
+++ b/classes/templatebase.class.php
@@ -623,7 +623,7 @@ class mod_surveypro_templatebase {
                     // before adding the item, ask to its class to check its coherence
                     require_once($CFG->dirroot.'/mod/surveypro/'.$currenttype.'/'.$currentplugin.'/classes/plugin.class.php');
                     $item = surveypro_get_item($this->cm, 0, $currenttype, $currentplugin);
-                    $item->item_validate_record_coherence($record);
+                    $item->item_force_coherence($record);
 
                     if ($currenttype == SURVEYPRO_TYPEFIELD) {
                         $item->item_validate_variablename($record, $itemid);

--- a/documentation.txt
+++ b/documentation.txt
@@ -122,4 +122,12 @@ and they are:
 • <<element type>> specific settings->
 • Validation options
 
+Relevant not so common features:
+    -> relational db creation
+    -> possibility to use "values" different from "labels" for checkboxes, radiobutton, select, multiselect and rate
+    -> conditional branching
+    -> export format
+    -> user templates to store and quickly paste sets of items
+    -> very close input validation
+
 How to create a surveypro

--- a/field/age/classes/plugin.class.php
+++ b/field/age/classes/plugin.class.php
@@ -192,14 +192,14 @@ class mod_surveypro_field_age extends mod_surveypro_itembase {
     }
 
     /**
-     * item_validate_record_coherence
+     * item_force_coherence
      * verify the validity of contents of the record
      * for instance: age not greater than maximumage
      *
      * @param stdClass $record
      * @return stdClass $record
      */
-    public function item_validate_record_coherence($record) {
+    public function item_force_coherence($record) {
         if (isset($record->defaultvalue)) {
             $maxyear = get_config('surveyprofield_age', 'maximumage');
             $maximumage = $this->item_age_to_unix_time($maxyear, 11);

--- a/field/date/classes/plugin.class.php
+++ b/field/date/classes/plugin.class.php
@@ -225,14 +225,14 @@ class mod_surveypro_field_date extends mod_surveypro_itembase {
     }
 
     /**
-     * item_validate_record_coherence
+     * item_force_coherence
      * verify the validity of contents of the record
      * for instance: age not greater than maximumage
      *
      * @param stdClass $record
      * @return stdClass $record
      */
-    public function item_validate_record_coherence($record) {
+    public function item_force_coherence($record) {
         if (isset($record->defaultvalue)) {
             $mindate = $this->item_date_to_unix_time($this->surveypro->startyear, 1, 1);
             if ($record->defaultvalue < $mindate) {

--- a/field/datetime/classes/plugin.class.php
+++ b/field/datetime/classes/plugin.class.php
@@ -238,14 +238,14 @@ class mod_surveypro_field_datetime extends mod_surveypro_itembase {
     }
 
     /**
-     * item_validate_record_coherence
+     * item_force_coherence
      * verify the validity of contents of the record
      * for instance: age not greater than maximumage
      *
      * @param stdClass $record
      * @return stdClass $record
      */
-    public function item_validate_record_coherence($record) {
+    public function item_force_coherence($record) {
         if (isset($record->defaultvalue)) {
             $mindatetime = $item->item_date_to_unix_time($this->surveypro->startyear, 1, 1);
             if ($record->defaultvalue < $mindatetime) {

--- a/field/integer/classes/plugin.class.php
+++ b/field/integer/classes/plugin.class.php
@@ -185,14 +185,14 @@ class mod_surveypro_field_integer extends mod_surveypro_itembase {
     }
 
     /**
-     * item_validate_record_coherence
+     * item_force_coherence
      * verify the validity of contents of the record
      * for instance: age not greater than maximumage
      *
      * @param stdClass $record
      * @return stdClass $record
      */
-    public function item_validate_record_coherence($record) {
+    public function item_force_coherence($record) {
         if (isset($record->defaultvalue)) {
             $maximuminteger = get_config('surveyprofield_integer', 'maximuminteger');
             if ($record->defaultvalue > $maximuminteger) {

--- a/locallib.php
+++ b/locallib.php
@@ -42,18 +42,24 @@ require_once($CFG->dirroot.'/mod/surveypro/lib.php');
 function surveypro_get_item($cm, $itemid=0, $type='', $plugin='', $evaluateparentcontent=false) {
     global $CFG, $DB;
 
+    if (!empty($itemid)) {
+        $itemseed = $DB->get_record('surveypro_item', array('id' => $itemid), 'surveyproid, type, plugin', MUST_EXIST);
+        if ($cm->instance != $itemseed->surveyproid) {
+            $message = 'Mismatch between passed itemid ('.$itemid.') and corresponding cm->instanceid ('.$cm->instanceid.')';
+            debugging('Error at line '.__LINE__.' of '.__FILE__.'. '.$message , DEBUG_DEVELOPER);
+        }
+    }
+
     if (empty($type) || empty($plugin)) {
         if (empty($itemid)) {
             $message = 'Unexpected empty($itemid)';
             debugging('Error at line '.__LINE__.' of '.__FILE__.'. '.$message , DEBUG_DEVELOPER);
         }
 
-        $itemseed = $DB->get_record('surveypro_item', array('id' => $itemid), 'surveyproid, type, plugin', MUST_EXIST);
         $type = $itemseed->type;
         $plugin = $itemseed->plugin;
     } else {
-        if (!empty($itemid)) {
-            $itemseed = $DB->get_record('surveypro_item', array('id' => $itemid), 'surveyproid, type, plugin', MUST_EXIST);
+        if (isset($itemseed)) {
             if ($type != $itemseed->type) {
                 $message = 'Mismatch between passed type ('.$type.') and found type ('.$itemseed->type.')';
                 debugging('Error at line '.__LINE__.' of '.__FILE__.'. '.$message , DEBUG_DEVELOPER);
@@ -65,10 +71,6 @@ function surveypro_get_item($cm, $itemid=0, $type='', $plugin='', $evaluateparen
         }
     }
 
-    if ($cm->instance != $itemseed->surveyproid) {
-        $message = 'Mismatch between passed itemid ('.$itemid.') and corresponding cm->instanceid ('.$cm->instanceid.')';
-        debugging('Error at line '.__LINE__.' of '.__FILE__.'. '.$message , DEBUG_DEVELOPER);
-    }
 
     require_once($CFG->dirroot.'/mod/surveypro/'.$type.'/'.$plugin.'/classes/plugin.class.php');
     $itemclassname = 'mod_surveypro_'.$type.'_'.$plugin;

--- a/tests/behat/duplicate.feature
+++ b/tests/behat/duplicate.feature
@@ -25,6 +25,7 @@ Feature: Backup and restore of surveyspro
       | format | pagebreak   |
       | field  | boolean     |
       | field  | select      |
+
     And I am on site homepage
     When I follow "Course 1"
     And I turn editing mode on


### PR DESCRIPTION
Behat tests are still running but each executed test passed regularly. So I believe the correction is working fine.
As before, the only failing test is duplicate.feature. Well... it is not completely failing. Mac terminal simply describe it with a "-" (minus) instead of the usual "." (dot) but, actually no "F" appear in the terminal feedback.

Some very silly detail has been changed to let the code simpler to read.