### PR TITLE
CONTRIB-6165 mod_surveypro: usetemplate_appied event upgraded

### DIFF
--- a/classes/event/usertemplate_applied.php
+++ b/classes/event/usertemplate_applied.php
@@ -51,7 +51,7 @@ class usertemplate_applied extends \core\event\base {
      * @return string
      */
     public function get_description() {
-        return "User with id '{$this->userid}' has applied the user template '{$this->other['templatename']}'.";
+        return "User with id '{$this->userid}' has applied the user template '{$this->other['templatename']}' with action: '{$this->other['action']}'.";
     }
 
     /**
@@ -107,6 +107,9 @@ class usertemplate_applied extends \core\event\base {
     protected function validate_data() {
         if (!isset($this->other['templatename'])) {
             throw new \coding_exception('templatename is a mandatory property.');
+        }
+        if (!isset($this->other['action'])) {
+            throw new \coding_exception('action is a mandatory property.');
         }
     }
 }

--- a/classes/utemplate.class.php
+++ b/classes/utemplate.class.php
@@ -441,7 +441,14 @@ class mod_surveypro_usertemplate extends mod_surveypro_templatebase {
             surveypro_reset_items_pages($this->surveypro->id);
         }
 
-        $this->trigger_event('usertemplate_applied');
+        if (empty($this->utemplateid)) {
+            // If $action == SURVEYPRO_IGNOREITEMS don't add any log.
+            if ($action != SURVEYPRO_IGNOREITEMS) {
+                $this->trigger_event('usertemplate_appliedempty', $action);
+            }
+        } else {
+            $this->trigger_event('usertemplate_applied', $action);
+        }
 
         switch ($action) {
             case SURVEYPRO_IGNOREITEMS:
@@ -1209,14 +1216,48 @@ class mod_surveypro_usertemplate extends mod_surveypro_templatebase {
      * @param string $event: event to trigger
      * @return none
      */
-    public function trigger_event($eventname) {
+    public function trigger_event($eventname, $action=null) {
         $eventdata = array('context' => $this->context, 'objectid' => $this->surveypro->id);
         switch ($eventname) {
             case 'all_usertemplates_viewed':
                 $event = \mod_surveypro\event\all_usertemplates_viewed::create($eventdata);
                 break;
+            case 'usertemplate_appliedempty':
+                if ($action == SURVEYPRO_HIDEITEMS) {
+                    $straction = get_string('hideitems', 'mod_surveypro');
+                }
+                if ($action == SURVEYPRO_DELETEALLITEMS) {
+                    $straction = get_string('deleteallitems', 'mod_surveypro');
+                }
+                if ($action == SURVEYPRO_DELETEVISIBLEITEMS) {
+                    $straction = get_string('deletevisibleitems', 'mod_surveypro');
+                }
+                if ($action == SURVEYPRO_DELETEHIDDENITEMS) {
+                    $straction = get_string('deletehiddenitems', 'mod_surveypro');
+                }
+                $eventdata['other'] = array('action' => $straction);
+                $event = \mod_surveypro\event\usertemplate_appliedempty::create($eventdata);
+                break;
             case 'usertemplate_applied':
-                $eventdata['other'] = array('templatename' => $this->get_utemplate_name());
+                if ($action == SURVEYPRO_IGNOREITEMS) {
+                    $straction = get_string('ignoreitems', 'mod_surveypro');
+                }
+                if ($action == SURVEYPRO_HIDEITEMS) {
+                    $straction = get_string('hideitems', 'mod_surveypro');
+                }
+                if ($action == SURVEYPRO_DELETEALLITEMS) {
+                    $straction = get_string('deleteallitems', 'mod_surveypro');
+                }
+                if ($action == SURVEYPRO_DELETEVISIBLEITEMS) {
+                    $straction = get_string('deletevisibleitems', 'mod_surveypro');
+                }
+                if ($action == SURVEYPRO_DELETEHIDDENITEMS) {
+                    $straction = get_string('deletehiddenitems', 'mod_surveypro');
+                }
+                $other = array();
+                $other['templatename'] = $this->get_utemplate_name();
+                $other['action'] = $straction;
+                $eventdata['other'] = $other;
                 $event = \mod_surveypro\event\usertemplate_applied::create($eventdata);
                 break;
             case 'usertemplate_exported':

--- a/lang/en/surveypro.php
+++ b/lang/en/surveypro.php
@@ -178,6 +178,7 @@ $string['event_submission_viewed'] = 'A response has been viewed';
 $string['event_submissioninpdf_downloaded'] = 'A response has been downloaded to pdf';
 $string['event_unattended_submissions_deleted'] = 'Unattended submissions were deleted by periodic sanity check';
 $string['event_usertemplate_applied'] = 'A user template has been applied';
+$string['event_usertemplate_appliedempty'] = 'An empty user template has been applied';
 $string['event_usertemplate_deleted'] = 'A user template has been deleted';
 $string['event_usertemplate_exported'] = 'A user template has been exported';
 $string['event_usertemplate_imported'] = 'A user template has been imported';


### PR DESCRIPTION
usetemplate_appied event always uses the name of the applied template but this is an error because at usertemplate apply time the editing teacher can choose to apply "nothing".
This is usually used to delete all the elements of a survey at once when the action bounded to the application of "nothing" is "delete all previous elements".