### PR TITLE
CONTRIB-6197 mod_surveypro: removed override_active_url

### DIFF
--- a/layout_manage.php
+++ b/layout_manage.php
@@ -155,9 +155,6 @@ $PAGE->set_cm($cm);
 $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
-// Make bold the navigation menu/link that refers to me.
-navigation_node::override_active_url($url);
-
 echo $OUTPUT->header();
 
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABITEMS, SURVEYPRO_ITEMS_MANAGE);

--- a/layout_preview.php
+++ b/layout_preview.php
@@ -64,7 +64,7 @@ $formparams->cm = $cm;
 $formparams->surveypro = $surveypro;
 $formparams->submissionid = $submissionid;
 $formparams->maxassignedpage = $previewman->get_maxassignedpage();
-$formparams->canaccessadvanceditems = has_capability('mod/surveypro:accessadvanceditems', $context, null, true); // Help selecting the fields to show
+$formparams->canaccessadvanceditems = has_capability('mod/surveypro:accessadvanceditems', $context, null, true);
 $formparams->formpage = $previewman->get_formpage(); // The page of the form to select subset of fields
 $formparams->modulepage = SURVEYPRO_ITEMS_PREVIEW; // This is the page of the TAB-PAGE structure.
 $formparams->readonly = false;
@@ -106,9 +106,6 @@ $PAGE->set_context($context);
 $PAGE->set_cm($cm);
 $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
-
-// Make bold the navigation menu/link that refers to me.
-navigation_node::override_active_url($url);
 
 echo $OUTPUT->header();
 

--- a/layout_validation.php
+++ b/layout_validation.php
@@ -99,9 +99,6 @@ $PAGE->set_cm($cm);
 $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
-// Make bold the navigation menu/link that refers to me.
-navigation_node::override_active_url($url);
-
 echo $OUTPUT->header();
 
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABITEMS, SURVEYPRO_ITEMS_VALIDATE);

--- a/lib.php
+++ b/lib.php
@@ -1154,7 +1154,7 @@ function surveypro_fetch_items_seeds($surveyproid, $canaccessadvanceditems, $sea
     $params['surveyproid'] = $surveyproid;
 
     if (!$canaccessadvanceditems) {
-        $sql .= ' AND si.advanced = 0';
+        // $sql .= ' AND si.advanced = 0';
     }
     if ($searchform) { // Advanced search.
         $sql .= ' AND si.insearchform = 1';

--- a/mtemplates_apply.php
+++ b/mtemplates_apply.php
@@ -84,9 +84,6 @@ $PAGE->set_cm($cm);
 $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
-// Make bold the navigation menu/link that refers to me.
-navigation_node::override_active_url($url);
-
 echo $OUTPUT->header();
 
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABMTEMPLATES, SURVEYPRO_MTEMPLATES_APPLY);

--- a/mtemplates_create.php
+++ b/mtemplates_create.php
@@ -71,9 +71,6 @@ $PAGE->set_cm($cm);
 $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
-// Make bold the navigation menu/link that refers to me.
-navigation_node::override_active_url($url);
-
 echo $OUTPUT->header();
 
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABMTEMPLATES, SURVEYPRO_MTEMPLATES_BUILD);

--- a/report/attachments_overview/uploads.php
+++ b/report/attachments_overview/uploads.php
@@ -77,13 +77,13 @@ $formparams->surveypro = $surveypro;
 $formparams->itemid = $itemid;
 $formparams->userid = $userid;
 $formparams->submissionid = $submissionid;
-$formparams->canaccessadvanceditems = $uploadsformman->canaccessadvanceditems; // Help selecting the fields to show
+$formparams->canaccessadvanceditems = has_capability('mod/surveypro:accessadvanceditems', $context, null, true);
 // End of: prepare params for the form.
 
 $filterform = new mod_surveypro_report_filterform($formurl, $formparams, 'post', '', array('id' => 'userentry'));
 
 // Output starts here.
-$url = new moodle_url('/mod/surveypro/report/attachments_overview/view.php', array('s' => $surveypro->id));
+$url = new moodle_url('/mod/surveypro/report/attachments_overview/upload.php', array('s' => $surveypro->id));
 $PAGE->set_url($url);
 $PAGE->set_context($context);
 $PAGE->set_cm($cm);
@@ -91,6 +91,7 @@ $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
 // Make bold the navigation menu/link that refers to me.
+$url = new moodle_url('/mod/surveypro/report/attachments_overview/view.php', array('s' => $surveypro->id));
 navigation_node::override_active_url($url);
 
 echo $OUTPUT->header();

--- a/report/attachments_overview/view.php
+++ b/report/attachments_overview/view.php
@@ -56,9 +56,6 @@ $PAGE->set_cm($cm);
 $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
-// Make bold the navigation menu/link that refers to me.
-navigation_node::override_active_url($url);
-
 echo $OUTPUT->header();
 
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABSUBMISSIONS, SURVEYPRO_SUBMISSION_REPORT);

--- a/report/colles/view.php
+++ b/report/colles/view.php
@@ -79,9 +79,6 @@ $PAGE->set_cm($cm);
 $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
-// Make bold the navigation menu/link that refers to me.
-navigation_node::override_active_url($url);
-
 echo $OUTPUT->header();
 
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABSUBMISSIONS, SURVEYPRO_SUBMISSION_REPORT);

--- a/report/count/view.php
+++ b/report/count/view.php
@@ -56,9 +56,6 @@ $PAGE->set_cm($cm);
 $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
-// Make bold the navigation menu/link that refers to me.
-navigation_node::override_active_url($url);
-
 echo $OUTPUT->header();
 
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABSUBMISSIONS, SURVEYPRO_SUBMISSION_REPORT);

--- a/report/frequency/view.php
+++ b/report/frequency/view.php
@@ -70,9 +70,6 @@ $PAGE->set_cm($cm);
 $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
-// Make bold the navigation menu/link that refers to me.
-navigation_node::override_active_url($url);
-
 echo $OUTPUT->header();
 
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABSUBMISSIONS, SURVEYPRO_SUBMISSION_REPORT);

--- a/report/missing/view.php
+++ b/report/missing/view.php
@@ -56,9 +56,6 @@ $PAGE->set_cm($cm);
 $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
-// Make bold the navigation menu/link that refers to me.
-navigation_node::override_active_url($url);
-
 echo $OUTPUT->header();
 
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABSUBMISSIONS, SURVEYPRO_SUBMISSION_REPORT);

--- a/report/submitting/view.php
+++ b/report/submitting/view.php
@@ -56,9 +56,6 @@ $PAGE->set_cm($cm);
 $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
-// Make bold the navigation menu/link that refers to me.
-navigation_node::override_active_url($url);
-
 echo $OUTPUT->header();
 
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABSUBMISSIONS, SURVEYPRO_SUBMISSION_REPORT);

--- a/utemplates_apply.php
+++ b/utemplates_apply.php
@@ -88,9 +88,6 @@ $PAGE->set_cm($cm);
 $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
-// Make bold the navigation menu/link that refers to me.
-navigation_node::override_active_url($url);
-
 echo $OUTPUT->header();
 
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABUTEMPLATES, SURVEYPRO_UTEMPLATES_APPLY);

--- a/utemplates_create.php
+++ b/utemplates_create.php
@@ -90,9 +90,6 @@ $PAGE->set_cm($cm);
 $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
-// Make bold the navigation menu/link that refers to me.
-navigation_node::override_active_url($url);
-
 echo $OUTPUT->header();
 
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABUTEMPLATES, SURVEYPRO_UTEMPLATES_BUILD);

--- a/utemplates_import.php
+++ b/utemplates_import.php
@@ -91,9 +91,6 @@ $PAGE->set_cm($cm);
 $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
-// Make bold the navigation menu/link that refers to me.
-navigation_node::override_active_url($url);
-
 echo $OUTPUT->header();
 
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABUTEMPLATES, SURVEYPRO_UTEMPLATES_IMPORT);

--- a/utemplates_manage.php
+++ b/utemplates_manage.php
@@ -68,9 +68,6 @@ $PAGE->set_cm($cm);
 $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
-// Make bold the navigation menu/link that refers to me.
-navigation_node::override_active_url($url);
-
 echo $OUTPUT->header();
 
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABUTEMPLATES, SURVEYPRO_UTEMPLATES_MANAGE);

--- a/view_cover.php
+++ b/view_cover.php
@@ -55,9 +55,6 @@ $PAGE->set_cm($cm);
 $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
-// Make bold the navigation menu/link that refers to me.
-navigation_node::override_active_url($url);
-
 echo $OUTPUT->header();
 
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABSUBMISSIONS, SURVEYPRO_SUBMISSION_CPANEL);

--- a/view_form.php
+++ b/view_form.php
@@ -65,7 +65,7 @@ $formparams->cm = $cm;
 $formparams->surveypro = $surveypro;
 $formparams->submissionid = $submissionid;
 $formparams->maxassignedpage = $userformman->get_maxassignedpage();
-$formparams->canaccessadvanceditems = has_capability('mod/surveypro:accessadvanceditems', $context, null, true); // Help selecting the fields to show
+$formparams->canaccessadvanceditems = has_capability('mod/surveypro:accessadvanceditems', $context, null, true);
 $formparams->formpage = $userformman->get_formpage(); // The page of the form to select subset of fields
 $formparams->modulepage = $userformman->get_modulepage(); // The page of the TAB-PAGE structure.
 $formparams->readonly = ($userformman->get_modulepage() == SURVEYPRO_SUBMISSION_READONLY);
@@ -137,9 +137,6 @@ $PAGE->set_context($context);
 $PAGE->set_cm($cm);
 $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
-
-// Make bold the navigation menu/link that refers to me.
-navigation_node::override_active_url($url);
 
 echo $OUTPUT->header();
 

--- a/view_search.php
+++ b/view_search.php
@@ -60,7 +60,7 @@ $formurl = new moodle_url('/mod/surveypro/view_search.php', $paramurl);
 $formparams = new stdClass();
 $formparams->cm = $cm;
 $formparams->surveypro = $surveypro;
-$formparams->canaccessadvanceditems = has_capability('mod/surveypro:accessadvanceditems', $context, null, true); // Help selecting the fields to show.
+$formparams->canaccessadvanceditems = has_capability('mod/surveypro:accessadvanceditems', $context, null, true);
 $searchform = new mod_surveypro_searchform($formurl, $formparams, 'post', '', array('id' => 'usersearch'));
 // End of: prepare params for the form.
 


### PR DESCRIPTION
The line of code:
navigation_node::override_active_url($url);
used in almost each landing page of the module
is useless.