### PR TITLE
CONTRIB-6204 mod_surveypro: changed .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,18 +11,20 @@ cache:
 
 php:
  - 5.4
- - 5.5
- - 5.6
  - 7.0
 
 # This section sets up the environment variables for the build.
 env:
- global:
+  - MOODLE_BRANCH=master           DB=pgsql
+  - MOODLE_BRANCH=master           DB=mysqli
+  - MOODLE_BRANCH=MOODLE_30_STABLE DB=pgsql
+  - MOODLE_BRANCH=MOODLE_30_STABLE DB=mysqli
+# global:
 # This line determines which version of Moodle to test against.
-  - MOODLE_BRANCH=MOODLE_30_STABLE
- matrix:
-  - DB=pgsql
-  - DB=mysqli
+#  - MOODLE_BRANCH=MOODLE_30_STABLE
+# matrix:
+#  - DB=pgsql
+#  - DB=mysqli
 
 # This lists steps that are run before the installation step.
 before_install:


### PR DESCRIPTION
I get rid of the php 5.5 and php 5.6 (keeping only 5.4 and 7.0, aka, min and max php versions supported) and I add the master branch, so I always know if there is some change in master that requires my attention in the module.