### PR TITLE
CONTRIB-6207 mod_surveypro: nicer message from import_csv() on error

### DIFF
--- a/classes/itembase.class.php
+++ b/classes/itembase.class.php
@@ -562,7 +562,6 @@ class mod_surveypro_itembase {
                 // End of: hide/unhide part 2.
             }
 
-
             // Manage ($oldreserved != $newreserved).
             if ($oldreserved != $newreserved) {
                 $action = ($oldreserved) ? SURVEYPRO_MAKESTANDARD : SURVEYPRO_MAKEADVANCED;
@@ -603,8 +602,8 @@ class mod_surveypro_itembase {
         global $DB, $CFG;
 
         require_once($CFG->dirroot.'/mod/surveypro/'.$this->type.'/'.$this->plugin.'/classes/plugin.class.php');
-        $itemclassname = 'mod_surveypro_'.$this->type.'_'.$this->plugin;
-        if ($itemclassname::item_get_canbeparent()) {
+        $classname = 'mod_surveypro_'.$this->type.'_'.$this->plugin;
+        if ($classname::item_get_canbeparent()) {
             // Take care: you can not use $this->item_get_content_array(SURVEYPRO_VALUES, 'options') to evaluate values.
             // Because $item was loaded before last save, so $this->item_get_content_array(SURVEYPRO_VALUES, 'options').
             // Is still returning the previous values.
@@ -862,7 +861,6 @@ class mod_surveypro_itembase {
      * @return string $schema
      */
     public static function item_get_item_schema() {
-
         // Fields: surveyproid, formpage, timecreated and timemodified are not supposed to be part of the file!
         $schema = '<?xml version="1.0" encoding="UTF-8"?>'."\n";
         $schema .= '<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">'."\n";
@@ -974,16 +972,6 @@ class mod_surveypro_itembase {
     public function get_surveyproid() {
         return $this->cm->instance;
     }
-
-    /**
-     * get_context
-     *
-     * @param none
-     * @return the content of the $context property
-     */
-    // public function get_context() {
-    //     return $this->context;
-    // }
 
     /**
      * get_editorlist
@@ -1327,7 +1315,6 @@ class mod_surveypro_itembase {
     public function get_itemeditingfeedback() {
         return $this->itemeditingfeedback;
     }
-
 
     // MARK set
 

--- a/classes/mtemplate.class.php
+++ b/classes/mtemplate.class.php
@@ -455,8 +455,8 @@ class mod_surveypro_mastertemplate extends mod_surveypro_templatebase {
 
         // Create the class to apply mastertemplate settings.
         require_once($CFG->dirroot.'/mod/surveypro/template/'.$this->templatename.'/template.class.php');
-        $itemclassname = 'mod_surveypro_template_'.$this->templatename;
-        $mastertemplate = new $itemclassname();
+        $classname = 'mod_surveypro_template_'.$this->templatename;
+        $mastertemplate = new $classname();
 
         $fs = get_file_storage();
 

--- a/classes/templatebase.class.php
+++ b/classes/templatebase.class.php
@@ -139,18 +139,18 @@ class mod_surveypro_templatebase {
                     // I could use a random class here because they all share the same parent item_get_item_schema
                     // but, I need the right class name for the next table, so I choose to load the correct class from the beginning.
                     require_once($CFG->dirroot.'/mod/surveypro/'.$currenttype.'/'.$currentplugin.'/classes/plugin.class.php');
-                    $itemclassname = 'mod_surveypro_'.$currenttype.'_'.$currentplugin;
-                    $xsd = $itemclassname::item_get_item_schema(); // <- itembase schema
+                    $classname = 'mod_surveypro_'.$currenttype.'_'.$currentplugin;
+                    $xsd = $classname::item_get_item_schema(); // <- itembase schema
                 } else {
                     // $classname is already onboard because of the previous loop over surveypro_item fields
-                    if (!isset($itemclassname)) {
+                    if (!isset($classname)) {
                         $error = new stdClass();
                         $error->key = 'badtablenamefound';
                         $error->a = $tablename;
 
                         return $error;
                     }
-                    $xsd = $itemclassname::item_get_plugin_schema(); // <- plugin schema
+                    $xsd = $classname::item_get_plugin_schema(); // <- plugin schema
                 }
 
                 if (empty($xsd)) {

--- a/classes/view_import.class.php
+++ b/classes/view_import.class.php
@@ -74,7 +74,7 @@ class mod_surveypro_importmanager {
             require_once($CFG->dirroot.'/mod/surveypro/field/'.$plugin.'/classes/plugin.class.php');
 
             $itemclass = 'mod_surveypro_'.SURVEYPRO_TYPEFIELD.'_'.$plugin;
-            $item = new $itemclass($this->cm, null, false);
+            $item = surveypro_get_item($this->cm, $this->surveypro, 0, SURVEYPRO_TYPEFIELD, $plugin, false);
             if ($item->get_savepositiontodb()) {
                 $semanticitem[] = $plugins[$k];
             }
@@ -371,8 +371,18 @@ class mod_surveypro_importmanager {
 
         $iid = csv_import_reader::get_new_iid('surveyprouserdata');
         $cir = new csv_import_reader($iid, 'surveyprouserdata');
+        if ($debug) {
+            echo 'I am at the line '.__LINE__.' of the file '.__FILE__.'<br />';
+            echo '$iid = '.$iid.'<br />';
+            echo '$cir:';
+            var_dump($cir);
+        }
 
         $csvcontent = $this->get_csv_content();
+        if ($debug) {
+            echo '$csvcontent = '.$csvcontent.'<br />';
+        }
+
         // Does data come from OLD surveypro?
         if ( (strpos($csvcontent, '__invItat10n__') === false) &&
              (strpos($csvcontent, '__n0__Answer__') === false) &&
@@ -382,7 +392,6 @@ class mod_surveypro_importmanager {
             $csvusesolddata = true;
         }
 
-        // $recordcount = $cir->load_csv_content($csvcontent, $this->formdata->encoding, $this->formdata->csvdelimiter);
         unset($csvcontent);
 
         // Start here 3 tests against general file configuration.
@@ -397,7 +406,6 @@ class mod_surveypro_importmanager {
         // 2) is each column unique?
         $foundheaders = $cir->get_columns();
         if ($debug) {
-            echo 'I am at the line '.__LINE__.' of the file '.__FILE__.'<br />';
             echo '$foundheaders:';
             var_dump($foundheaders);
         }

--- a/field/autofill/classes/plugin.class.php
+++ b/field/autofill/classes/plugin.class.php
@@ -359,11 +359,6 @@ EOS;
         $elementlabel = ($this->position == SURVEYPRO_POSITIONLEFT) ? $elementnumber.strip_tags($this->get_content()) : '&nbsp;';
 
         if (!$searchform) {
-            // $referencearray = array(''); // <-- take care, the first element is already on board
-            // for ($i = 1; $i <= SURVEYPROFIELD_AUTOFILL_CONTENTELEMENT_COUNT; $i++) {
-            //     $referencearray[] = constant('SURVEYPROFIELD_AUTOFILL_CONTENTELEMENT'.sprintf('%02d', $i));
-            // }
-
             $value = $this->userform_get_content($submissionid);
             $mform->addElement('hidden', $this->itemname, $value);
             $mform->setType($this->itemname, PARAM_RAW);

--- a/field/fileupload/classes/mform_filemanager.php
+++ b/field/fileupload/classes/mform_filemanager.php
@@ -48,15 +48,15 @@ class mod_surveypro_mform_filemanager extends MoodleQuickForm_filemanager {
     /**
      * Returns HTML for editor form element.
      *
-     * @return string
+     * I want to change at the beginning:
+     *     <div id="filemanager-556eb09a98375" class="filemanager fm-loading">
+     * to
+     *     <div id="filemanager-556eb09a98375" class="indent-x filemanager fm-loading">
+     *
+     * @return string $output
      */
     public function toHtml() {
         $output = parent::toHtml(); // Core code.
-
-        // I want to change at the beginning:
-        //     <div id="filemanager-556eb09a98375" class="filemanager fm-loading">
-        // to:
-        //     <div id="filemanager-556eb09a98375" class="indent-x filemanager fm-loading">
 
         // I need to trim the code because mform library add a newline at the beginning.
         $output = trim($output);

--- a/field/multiselect/classes/plugin.class.php
+++ b/field/multiselect/classes/plugin.class.php
@@ -508,21 +508,17 @@ EOS;
                 }
                 $mform->setDefault($this->itemname, $defaultkeys);
             }
-            // } else {
-            // $mform->setDefault($this->itemname, array());
         }
         // End of: defaults
 
         // This last item is needed because:
-        // the check for the not empty field is performed in the validation routine. (not by JS)
-        // (JS validation is never added because I do not want it when the "previous" button is pressed and when an item is disabled even if mandatory)
-        // The validation routine is executed ONLY ON ITEM that are actually submitted.
-        // For multiselect, nothing is submitted if no item is selected
+        // the check for the not empty field is performed in the validation routine (not by JS).
+        // For multiselect element, nothing is submitted if no option is selected
         // so, if the user neglects the mandatory multiselect AT ALL, it is not submitted and, as conseguence, not validated.
         // TO ALWAYS SUBMIT A MULTISELECT I add a dummy hidden item.
         //
-        // TAKE CARE: I choose a name for this item that IS UNIQUE BUT is missing the SURVEYPRO_ITEMPREFIX.'_'
-        //            In this way I am sure the item will never be saved in the database
+        // TAKE CARE: I choose a name for this item that IS UNIQUE BUT is missing the SURVEYPRO_ITEMPREFIX.'_'.
+        // In this way I am sure the item will never be saved to the database.
         $placeholderitemname = SURVEYPRO_DONTSAVEMEPREFIX.'_'.$this->type.'_'.$this->plugin.'_'.$this->itemid.'_placeholder';
         $mform->addElement('hidden', $placeholderitemname, 1);
         $mform->setType($placeholderitemname, PARAM_INT);

--- a/field/textarea/classes/mform_editor.php
+++ b/field/textarea/classes/mform_editor.php
@@ -47,6 +47,11 @@ class mod_surveypro_mform_editor extends MoodleQuickForm_editor {
     /**
      * Returns HTML for editor form element.
      *
+     * My intervention only replaces <div> with <div class="indent-x"> AT THE BEGINNING of $output.
+     * I use the output of parent::toHtml() to get advantages of future updates to core mform class.
+     * I search for simple <div> without attributes so that if moodle HQ will ever fix this issue in the core code,
+     * my intervention will result in nothing without adding useless or dangerous modifications.
+     *
      * @return string
      */
     public function toHtml() {
@@ -54,11 +59,6 @@ class mod_surveypro_mform_editor extends MoodleQuickForm_editor {
         // I add it with a simple replace.
         $output = parent::toHtml(); // Core code.
 
-        // My intervention only replaces <div> with <div class="indent-x"> AT THE BEGINNING of $output.
-        // I force the beginning (^) to avoid to replace different <div> eventually found into $output.
-        // I use the output of parent::toHtml() to get advantages of future updates to core mform class.
-        // I search for simple <div> without attributes so that if moodle HQ will fix this issue in the core code,
-        //     my intervention will result in nothing without adding useless or dangerous modifications.
         $tabs = $this->_getTabs();
         $pattern = '~^'.$tabs.'<div>~';
         $class = empty($this->_attributes['class']) ? 'indent-0' : $this->_attributes['class'];

--- a/form/data/import_form.php
+++ b/form/data/import_form.php
@@ -76,31 +76,4 @@ class mod_surveypro_importform extends moodleform {
 
         $this->add_action_buttons(false, get_string('dataimport', 'mod_surveypro'));
     }
-
-    /*
-     * validation
-     *
-     * @param $data
-     * @param $files
-     * @return $errors
-     */
-    // public function validation($data, $files) {
-    //     $mform = $this->_form;
-    //
-    //     // $surveypro = $this->_customdata->surveypro;
-    //     // $importman = $this->_customdata->importman;
-    //
-    //     $errors = parent::validation($data, $files);
-    //
-    //     //$csvcontent = $this->get_file_content('importfile_filepicker');
-    //     // echo '<textarea rows="10" cols="100">'.$csvcontent.'</textarea>';
-    //     $csvfilename = $this->get_name('importfile_filepicker');
-    //     // echo '$csvfilename = '.$csvfilename.'<br />';
-    //     if (!$importman->validate_csv($csvcontent, $data->encoding, $data->delimiter_name)) {
-    //         $errors['importfile_filepicker'] = get_string('invalidcsvfile', 'mod_surveypro', $csvfilename);
-    //         return $errors;
-    //     }
-    //
-    //     return $errors;
-    // }
 }

--- a/form/items/itembase_form.php
+++ b/form/items/itembase_form.php
@@ -111,7 +111,7 @@ class mod_surveypro_itembaseform extends moodleform {
             $options = array();
             $default = SURVEYPRO_POSITIONTOP;
             if ($item->item_left_position_allowed()) { // Position can even be SURVEYPRO_POSITIONLEFT.
-                $options[SURVEYPRO_POSITIONLEFT] =  get_string('left', 'mod_surveypro');
+                $options[SURVEYPRO_POSITIONLEFT] = get_string('left', 'mod_surveypro');
                 $default = SURVEYPRO_POSITIONLEFT;
             }
             $options[SURVEYPRO_POSITIONTOP] = get_string('top', 'mod_surveypro');
@@ -193,10 +193,10 @@ class mod_surveypro_itembaseform extends moodleform {
             // Itembase::parentid.
             $fieldname = 'parentid';
             // Create the list of each item with:
-            //     sortindex lower than mine (whether already exists);
-            //     $classname::item_get_canbeparent() == true;
-            //     reserved == my one <-- I omit this verification because the surveypro creator can, at every time, change the availability of the current item
-            //                            So I move the verification of the holding form at the form verification time.
+            // sortindex lower than mine (whether already exists);
+            // $classname::item_get_canbeparent() == true;
+            // reserved == my one <-- I omit this verification because the surveypro creator can, at every time, change the availability of the current item
+            // So I move the verification of the holding form at the form verification time.
 
             // Build the list only for searchable plugins.
             $pluginlist = surveypro_get_plugin_list(SURVEYPRO_TYPEFIELD);

--- a/form/outform/search_form.php
+++ b/form/outform/search_form.php
@@ -48,8 +48,8 @@ class mod_surveypro_searchform extends moodleform {
 
         // This dummy item is needed for the colours alternation.
         // Because 'label' or ($position == SURVEYPRO_POSITIONFULLWIDTH).
-        //     as first item are out from the a fieldset
-        //     so they and are not selected by the css3 selector: fieldset div.fitem:nth-of-type(even) {
+        // as first item are out from the a fieldset
+        // so they and are not selected by the css3 selector: fieldset div.fitem:nth-of-type(even) {
         $mform->addElement('static', 'beginning_extrarow', '', '');
         foreach ($itemseeds as $itemseed) {
             $item = surveypro_get_item($cm, $surveypro, $itemseed->id, $itemseed->type, $itemseed->plugin);

--- a/format/label/classes/mform_static.php
+++ b/format/label/classes/mform_static.php
@@ -56,7 +56,7 @@ class mod_surveypro_mform_static extends MoodleQuickForm_static {
         // Even if the simpler way to pass the class is:
         // $output = html_writer::tag('div', $output, $this->_options);
         // I create the array from scratch in order to
-        //     drop any other potentially dangerous element of the original $this->_options array.
+        // drop any other potentially dangerous element of the original $this->_options array.
         $class = array('class' => $this->_options['class']);
         $output = html_writer::tag('div', $output, $class);
 

--- a/layout_manage.php
+++ b/layout_manage.php
@@ -98,8 +98,8 @@ $basecondition = $basecondition && empty($surveypro->template);
 $basecondition = $basecondition && (!$hassubmissions || $riskyediting);
 
 // master template form
-$mtemplatecondition =  true;
-$mtemplatecondition =  $mtemplatecondition && (!$itemcount);
+$mtemplatecondition = true;
+$mtemplatecondition = $mtemplatecondition && (!$itemcount);
 if ($mtemplatecondition) {
     require_once($CFG->dirroot.'/mod/surveypro/classes/mtemplate.class.php');
     require_once($CFG->dirroot.'/mod/surveypro/form/mtemplates/apply_form.php');

--- a/lib.php
+++ b/lib.php
@@ -356,7 +356,6 @@ function surveypro_update_instance($surveypro, $mform) {
     $whereparams = array('surveyproid' => $surveypro->id);
     $DB->set_field('surveypro_item', 'formpage', 0, $whereparams);
 
-
     $DB->update_record('surveypro', $surveypro);
     // Stop working with the surveypro table (unless $surveypro->thankshtml_editor['itemid'] != 0).
 
@@ -449,14 +448,13 @@ function surveypro_delete_instance($id) {
     $DB->delete_records('surveypro', array('id' => $surveypro->id));
 
     // TODO: Am I supposed to delete files too?
-    // AREAS:
-    //     SURVEYPRO_STYLEFILEAREA
-    //     SURVEYPRO_TEMPLATEFILEAREA
-    //     SURVEYPRO_THANKSHTMLFILEAREA
+    // SURVEYPRO_STYLEFILEAREA
+    // SURVEYPRO_TEMPLATEFILEAREA
+    // SURVEYPRO_THANKSHTMLFILEAREA
 
-    //     SURVEYPRO_ITEMCONTENTFILEAREA <-- is this supposed to go to its delete_instance plugin?
-    //     SURVEYPROFIELD_FILEUPLOAD_FILEAREA <-- is this supposed to go to its delete_instance plugin?
-    //     SURVEYPROFIELD_TEXTAREAFILEAREA <-- is this supposed to go to its delete_instance plugin?
+    // SURVEYPRO_ITEMCONTENTFILEAREA <-- is this supposed to go to its delete_instance plugin?
+    // SURVEYPROFIELD_FILEUPLOAD_FILEAREA <-- is this supposed to go to its delete_instance plugin?
+    // SURVEYPROFIELD_TEXTAREAFILEAREA <-- is this supposed to go to its delete_instance plugin?
 
     // Never delete mod_surveypro files in each AREA in $context = context_user::instance($userid);
 
@@ -591,11 +589,11 @@ function surveypro_cron() {
 
     $saveresumestatus = array(0, 1);
     // $saveresumestatus == 0:  saveresume is not allowed
-    //     users leaved records in progress more than four hours ago...
-    //     I can not believe they are still working on them so
-    //     I delete records now
+    // users leaved records in progress more than four hours ago...
+    // I can not believe they are still working on them so
+    // I delete records now
     // $saveresumestatus == 1:  saveresume is allowed
-    //     these records are older than maximum allowed time delay
+    // These records are older than maximum allowed time delay
     $maxinputdelay = get_config('mod_surveypro', 'maxinputdelay');
     foreach ($saveresumestatus as $saveresume) {
         if (($saveresume == 1) && ($maxinputdelay == 0)) { // Maxinputdelay == 0 means, please don't delete.
@@ -671,15 +669,15 @@ function surveypro_get_extra_capabilities() {
  * @return bool true if the scale is used by the given surveypro instance
  */
 function surveypro_scale_used($surveyproid, $scaleid) {
-    // global $DB;
+    /* global $DB;
 
-    /* @example */
-    // if ($scaleid and $DB->record_exists('surveypro', array('id' => $surveyproid, 'grade' => -$scaleid))) {
-    //     return true;
-    // } else {
-    //     return false;
-    // }
-    return false;
+    // @example
+    if ($scaleid and $DB->record_exists('surveypro', array('id' => $surveyproid, 'grade' => -$scaleid))) {
+        return true;
+    } else {
+        return false;
+    }
+    return false; */
 }
 
 /**
@@ -691,14 +689,14 @@ function surveypro_scale_used($surveyproid, $scaleid) {
  * @return boolean true if the scale is used by any surveypro instance
  */
 function surveypro_scale_used_anywhere($scaleid) {
-    // global $DB;
+    /* global $DB;
 
-    /* @example */
-    // if ($scaleid and $DB->record_exists('surveypro', array('grade' => -$scaleid))) {
-    //     return true;
-    // } else {
-    //     return false;
-    // }
+    // @example
+    if ($scaleid and $DB->record_exists('surveypro', array('grade' => -$scaleid))) {
+        return true;
+    } else {
+        return false;
+    } */
 }
 
 /**
@@ -709,20 +707,19 @@ function surveypro_scale_used_anywhere($scaleid) {
  * @param stdClass $surveypro instance object with extra cmidnumber and modname property
  * @return void
  */
-// I will remove comments when I will understand why this method is called
-// function surveypro_grade_item_update(stdClass $surveypro) {
-//     global $CFG;
-//     require_once($CFG->libdir.'/gradelib.php');
-//
-//     /* @example */
-//     $item = array();
-//     $item['itemname'] = clean_param($surveypro->name, PARAM_NOTAGS);
-//     $item['gradetype'] = GRADE_TYPE_VALUE;
-//     $item['grademax'] = $surveypro->grade;
-//     $item['grademin'] = 0;
-//
-//     grade_update('mod/surveypro', $surveypro->course, 'mod', 'surveypro', $surveypro->id, 0, null, $item);
-// }
+function surveypro_grade_item_update(stdClass $surveypro) {
+    /* global $CFG;
+    require_once($CFG->libdir.'/gradelib.php');
+
+    // @example
+    $item = array();
+    $item['itemname'] = clean_param($surveypro->name, PARAM_NOTAGS);
+    $item['gradetype'] = GRADE_TYPE_VALUE;
+    $item['grademax'] = $surveypro->grade;
+    $item['grademin'] = 0;
+
+    grade_update('mod/surveypro', $surveypro->course, 'mod', 'surveypro', $surveypro->id, 0, null, $item); */
+}
 
 /**
  * Update surveypro grades in the gradebook

--- a/mod_form.php
+++ b/mod_form.php
@@ -205,12 +205,8 @@ class mod_surveypro_mod_form extends moodleform_mod {
             $editoroptions = surveypro_get_editor_options();
             // Editing an existing surveypro - let us prepare the added editor elements (intro done automatically).
             $draftitemid = file_get_submitted_draft_itemid($filename);
-            $defaults[$filename.'_editor']['text'] =
-                                    file_prepare_draft_area($draftitemid, $this->context->id,
-                                    'mod_surveypro', SURVEYPRO_THANKSHTMLFILEAREA, false,
-                                    $editoroptions,
-                                    $defaults[$filename]);
-
+            $defaults[$filename.'_editor']['text'] = file_prepare_draft_area($draftitemid, $this->context->id,
+                'mod_surveypro', SURVEYPRO_THANKSHTMLFILEAREA, false, $editoroptions, $defaults[$filename]);
             $defaults[$filename.'_editor']['format'] = $defaults['thankshtmlformat'];
             $defaults[$filename.'_editor']['itemid'] = $draftitemid;
 

--- a/report/colles/classes/report.class.php
+++ b/report/colles/classes/report.class.php
@@ -493,15 +493,6 @@ class mod_surveypro_report_colles extends mod_surveypro_reportbase {
         }
         foreach ($toevaluate as $k => $areaidlist) {
             foreach ($areaidlist as $itemid) {
-                // Changed to a shorter version on September 25, 2014.
-                // Older version will be deleted as soon as the wew one will be checked.
-                // $sql = 'SELECT COUNT(ud.id) as countofanswers, SUM(ud.content) as sumofanswers
-                //         FROM {surveypro_answer} ud
-                //         WHERE ud.itemid = :itemid';
-                // $whereparams = array('itemid' => $itemid);
-                // $aggregate = $DB->get_record_sql($sql, $whereparams);
-
-                // Verified on October 17. It seems it arrived the time to delete the long version of the query.
                 $whereparams = array('itemid' => $itemid);
                 $aggregate = $DB->get_record('surveypro_answer', $whereparams, 'COUNT(id) as countofanswers, SUM(content) as sumofanswers');
                 $m = $aggregate->sumofanswers / $aggregate->countofanswers;
@@ -512,13 +503,6 @@ class mod_surveypro_report_colles extends mod_surveypro_reportbase {
                     $this->trend2[] = $m;
                 }
 
-                // Changed to a shorter version on September 25, 2014.
-                // Older version will be deleted as soon as the wew one will be checked.
-                // $sql = 'SELECT ud.content
-                //         FROM {surveypro_answer} ud
-                //         WHERE ud.itemid = :itemid';
-                // $answers = $DB->get_recordset_sql($sql, $whereparams);
-                // $whereparams = array('itemid' => $itemid); // Already defined.
                 $answers = $DB->get_recordset('surveypro_answer', $whereparams, '', 'content');
                 $bigsum = 0;
                 foreach ($answers as $answer) {

--- a/view_import.php
+++ b/view_import.php
@@ -60,7 +60,7 @@ $importform = new mod_surveypro_importform($formurl);
 
 // Begin of: manage form submission.
 if ($importman->formdata = $importform->get_data()) {
-    $importman->import_csv();
+    // $importman->import_csv();
 
     $redirecturl = new moodle_url('/mod/surveypro/view.php', array('s' => $surveypro->id));
     redirect($redirecturl);


### PR DESCRIPTION
At the moment, an incorrect definition of the parameters in the import form (view_import.php) can lead to an import failure. In this case the import process is aborted showing an error_message. This is not nice for teacher. I replaced it with a nicer $OUTPUT->notification

In the frme of this fix I also made minor changes to code to satisfy a bit codechecker.