### PR TITLE
CONTRIB-6213 mod_surveypro: make code simpler

### DIFF
--- a/classes/formbase.class.php
+++ b/classes/formbase.class.php
@@ -102,8 +102,8 @@ class mod_surveypro_formbase {
         $prefill = array();
 
         if (!empty($this->submissionid)) {
-            list($sql, $whereparams) = surveypro_fetch_items_seeds($this->surveypro->id, $canaccessreserveditems, false, SURVEYPRO_TYPEFIELD, $this->formpage);
-            if ($itemseeds = $DB->get_recordset_sql($sql, $whereparams)) {
+            list($where, $params) = surveypro_fetch_items_seeds($this->surveypro->id, $canaccessreserveditems, null, SURVEYPRO_TYPEFIELD, $this->formpage);
+            if ($itemseeds = $DB->get_recordset_select('surveypro_item', $where, $params, 'sortindex', 'id, type, plugin')) {
                 foreach ($itemseeds as $itemseed) {
                     $item = surveypro_get_item($this->cm, $this->surveypro, $itemseed->id, $itemseed->type, $itemseed->plugin);
 

--- a/classes/itemlist.class.php
+++ b/classes/itemlist.class.php
@@ -225,12 +225,11 @@ class mod_surveypro_itemlist {
         $paramurlmove['itm'] = $this->itemtomove;
         // End of: $paramurlmove definition.
 
-        $where = array('surveyproid' => $this->surveypro->id);
-        if ($this->view == SURVEYPRO_CHANGEORDERASK) { // If you are reordering, force ordering to...
-            $itemseeds = $DB->get_records('surveypro_item', $where, 'sortindex ASC', '*, id as itemid');
-        } else {
-            $itemseeds = $DB->get_records('surveypro_item', $where, $table->get_sql_sort(), '*, id as itemid');
-        }
+
+        list($where, $params) = surveypro_fetch_items_seeds($this->surveypro->id, true, null, null, null, true);
+        // If you are reordering, force ordering to...
+        $orderby = ($this->view == SURVEYPRO_CHANGEORDERASK) ? 'sortindex ASC' : $table->get_sql_sort();
+        $itemseeds = $DB->get_recordset_select('surveypro_item', $where, $params, $orderby, 'id as itemid, type, plugin');
         $drawmovearrow = (count($itemseeds) > 1);
 
         // This is the very first position, so if the item has a parent, no "moveherebox" must appear.

--- a/classes/utils.class.php
+++ b/classes/utils.class.php
@@ -581,12 +581,12 @@ class mod_surveypro_utility {
     }
 
     /**
-     * warning_message
+     * has_submissions_warning
      *
      * @param none
      * @return void
      */
-    public function warning_message() {
+    public function has_submissions_warning() {
         global $COURSE;
 
         $message = get_string('hassubmissions_alert', 'mod_surveypro');
@@ -596,5 +596,33 @@ class mod_surveypro_utility {
         }
 
         return $message;
+    }
+
+    /**
+     * get_used_plugin_list
+     *
+     * This method provide the list af the plugin used in the current surveypro
+     * getting them from the items already added.
+     *
+     * @param type
+     * @return array $pluginlist;
+     */
+    public function get_used_plugin_list($type='') {
+        global $DB;
+
+        $whereparams = array();
+        $sql = 'SELECT MIN(id), plugin
+                FROM {surveypro_item}
+                WHERE surveyproid = :surveyproid';
+        $whereparams['surveyproid'] = $this->surveypro->id;
+        if (!empty($type)) {
+            $sql .= ' AND type = :type';
+            $whereparams['type'] = $type;
+        }
+        $sql .= ' GROUP BY plugin';
+
+        $pluginlist = $DB->get_records_sql_menu($sql, $whereparams);
+
+        return $pluginlist;
     }
 }

--- a/classes/view_cover.class.php
+++ b/classes/view_cover.class.php
@@ -165,19 +165,19 @@ class mod_surveypro_covermanager {
         } else {
             if (!$cansubmit) {
                 $message = get_string('canneversubmit', 'mod_surveypro');
-                echo $OUTPUT->container($message, 'centerpara');
+                echo $OUTPUT->notification($message, 'notifyproblem');
             } else if (($this->surveypro->timeopen) && ($this->surveypro->timeopen >= $timenow)) {
                 $message = get_string('cannotsubmittooearly', 'mod_surveypro', userdate($this->surveypro->timeopen));
-                echo $OUTPUT->container($message, 'centerpara');
+                echo $OUTPUT->notification($message, 'notifyproblem');
             } else if (($this->surveypro->timeclose) && ($this->surveypro->timeclose <= $timenow)) {
                 $message = get_string('cannotsubmittoolate', 'mod_surveypro', userdate($this->surveypro->timeclose));
-                echo $OUTPUT->container($message, 'centerpara');
+                echo $OUTPUT->notification($message, 'notifyproblem');
             } else if (($this->surveypro->maxentries > 0) && ($next >= $this->surveypro->maxentries)) {
                 $message = get_string('nomoresubmissionsallowed', 'mod_surveypro', $this->surveypro->maxentries);
-                echo $OUTPUT->container($message, 'centerpara');
+                echo $OUTPUT->notification($message, 'notifyproblem');
             } else if (!$itemcount) {
                 $message = get_string('noitemsfound', 'mod_surveypro');
-                echo $OUTPUT->container($message, 'centerpara');
+                echo $OUTPUT->notification($message, 'notifyproblem');
             }
         }
         // End of: the button to add one more surveypro.

--- a/classes/view_import.class.php
+++ b/classes/view_import.class.php
@@ -112,13 +112,9 @@ class mod_surveypro_importmanager {
     public function get_survey_infos() {
         global $CFG, $DB;
 
-        $sql = 'SELECT MIN(id), plugin
-            FROM {surveypro_item}
-            WHERE surveyproid = :surveyproid
-                AND type = :type
-            GROUP BY plugin';
-        $whereparams = array('surveyproid' => $this->surveypro->id, 'type' => SURVEYPRO_TYPEFIELD);
-        $pluginlist = $DB->get_records_sql_menu($sql, $whereparams);
+        // Get the list of used plugin.
+        $utilityman = new mod_surveypro_utility($this->cm, $this->surveypro);
+        $pluginlist = $utilityman->get_used_plugin_list(SURVEYPRO_TYPEFIELD);
 
         $requireditems = array();
         $surveyheaders = array();
@@ -133,17 +129,18 @@ class mod_surveypro_importmanager {
             $itemclass = 'mod_surveypro_'.SURVEYPRO_TYPEFIELD.'_'.$plugin;
             $canbemandatory = $itemclass::item_get_can_be_mandatory();
 
+            $tablename = 'surveypro'.SURVEYPRO_TYPEFIELD.'_'.$plugin;
             if ($canbemandatory) {
                 $sql = 'SELECT p.itemid, p.variable, p.required
                     FROM {surveypro_item} i
-                        JOIN {surveypro'.SURVEYPRO_TYPEFIELD.'_'.$plugin.'} p ON i.id = p.itemid
+                        JOIN {'.$tablename.'} p ON i.id = p.itemid
                     WHERE i.surveyproid = :surveyproid
                     ORDER BY p.itemid';
                 $itemvariables = $DB->get_records_sql($sql, $whereparams);
             } else {
                 $sql = 'SELECT p.itemid, p.variable
                     FROM {surveypro_item} i
-                        JOIN {surveypro'.SURVEYPRO_TYPEFIELD.'_'.$plugin.'} p ON i.id = p.itemid
+                        JOIN {'.$tablename.'} p ON i.id = p.itemid
                     WHERE i.surveyproid = :surveyproid
                     ORDER BY p.itemid';
                 $itemvariables = $DB->get_records_sql($sql, $whereparams);

--- a/classes/view_submissions.class.php
+++ b/classes/view_submissions.class.php
@@ -1221,11 +1221,11 @@ class mod_surveypro_submissionmanager {
         $userdatarecord = $DB->get_records('surveypro_answer', array('submissionid' => $this->submissionid), '', 'itemid, id, content');
 
         $canaccessreserveditems = has_capability('mod/surveypro:accessreserveditems', $this->context, $user->id, true);
-        list($sql, $whereparams) = surveypro_fetch_items_seeds($this->surveypro->id, $canaccessreserveditems, false);
+        list($where, $params) = surveypro_fetch_items_seeds($this->surveypro->id, $canaccessreserveditems);
 
         // I am not allowed to get ONLY answers from surveypro_answer
-        // because I also need to gather info about fieldset and label so:
-        $itemseeds = $DB->get_recordset_sql($sql, $whereparams);
+        // because I also need to gather info about fieldsets and labels.
+        $itemseeds = $DB->get_recordset_select('surveypro_item', $where, $params, 'sortindex', 'id, type, plugin');
 
         $pdf = new TCPDF('P', 'mm', 'A4', true, 'UTF-8', false);
 

--- a/form/outform/fill_form.php
+++ b/form/outform/fill_form.php
@@ -77,8 +77,8 @@ class mod_surveypro_outform extends moodleform {
 
         if ($formpage >= 0) {
             // $canaccessreserveditems, $searchform=false, $type=false, $formpage
-            list($sql, $whereparams) = surveypro_fetch_items_seeds($surveypro->id, $canaccessreserveditems, false, false, $formpage);
-            $itemseeds = $DB->get_recordset_sql($sql, $whereparams);
+            list($where, $params) = surveypro_fetch_items_seeds($surveypro->id, $canaccessreserveditems, null, null, $formpage);
+            $itemseeds = $DB->get_recordset_select('surveypro_item', $where, $params, 'sortindex', 'id, type, plugin, parentid, parentvalue');
 
             if (!$itemseeds->valid()) {
                 // No items are in this page.

--- a/form/outform/search_form.php
+++ b/form/outform/search_form.php
@@ -42,9 +42,8 @@ class mod_surveypro_searchform extends moodleform {
         $surveypro = $this->_customdata->surveypro;
         $canaccessreserveditems = $this->_customdata->canaccessreserveditems;
 
-        // $canaccessreserveditems, $searchform=true, $type=false, $formpage=false
-        list($sql, $whereparams) = surveypro_fetch_items_seeds($surveypro->id, $canaccessreserveditems, true);
-        $itemseeds = $DB->get_recordset_sql($sql, $whereparams);
+        list($where, $params) = surveypro_fetch_items_seeds($surveypro->id, $canaccessreserveditems, true);
+        $itemseeds = $DB->get_recordset_select('surveypro_item', $where, $params, 'sortindex', 'id, type, plugin');
 
         // This dummy item is needed for the colours alternation.
         // Because 'label' or ($position == SURVEYPRO_POSITIONFULLWIDTH).

--- a/layout_itemsetup.php
+++ b/layout_itemsetup.php
@@ -164,7 +164,7 @@ new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABITEMS, SURVEYPRO_
 
 $utilityman = new mod_surveypro_utility($cm, $surveypro);
 if ($hassubmissions) {
-    $message = $utilityman->warning_message();
+    $message = $utilityman->has_submissions_warning();
     echo $OUTPUT->notification($message, 'notifyproblem');
 }
 $itemlistman->item_fingerprint();

--- a/layout_manage.php
+++ b/layout_manage.php
@@ -160,7 +160,7 @@ echo $OUTPUT->header();
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABITEMS, SURVEYPRO_ITEMS_MANAGE);
 
 if ($hassubmissions) {
-    $message = $utilityman->warning_message();
+    $message = $utilityman->has_submissions_warning();
     echo $OUTPUT->notification($message, 'notifyproblem');
 }
 

--- a/lib.php
+++ b/lib.php
@@ -1137,34 +1137,43 @@ function surveypro_get_plugin_list($plugintype=null, $includetype=false, $count=
  * @param $searchform
  * @param $type
  * @param $formpage
- * @return void
+ * @return array($where, $params)
  */
-function surveypro_fetch_items_seeds($surveyproid, $canaccessreserveditems, $searchform, $type=false, $formpage=false) {
-    $sql = 'SELECT si.*
-               FROM {surveypro_item} si
-               WHERE si.surveyproid = :surveyproid
-                   AND si.hidden = 0';
+function surveypro_fetch_items_seeds($surveyproid, $canaccessreserveditems, $searchform=false, $type=false, $formpage=false, $pagebreak=false) {
     $params = array();
-    $params['surveyproid'] = $surveyproid;
+    $conditions = array();
+
+    $conditions[] = 'surveyproid = :surveyproid';
+    $params['surveyproid'] = (int)$surveyproid;
+
+    $conditions[] = 'hidden = :hidden';
+    $params['hidden'] = 0;
+
+    if (!$pagebreak) {
+        $conditions[] = 'plugin <> ":plugin"';
+        $params['plugin'] = "pagebreak";
+    }
 
     if (!$canaccessreserveditems) {
-        $sql .= ' AND si.reserved = 0';
+        $conditions[] = 'reserved = :reserved';
+        $params['reserved'] = 0;
     }
     if ($searchform) {
-        $sql .= ' AND si.insearchform = 1';
-        $sql .= ' AND si.plugin <> "pagebreak"';
+        $conditions[] = 'insearchform = :insearchform';
+        $params['insearchform'] = 1;
     }
     if ($type) {
-        $sql .= ' AND si.type = :type';
+        $conditions[] = 'type = :type';
         $params['type'] = $type;
     }
-    if ($formpage) { // If I am asking for a single page ONLY.
-        $sql .= ' AND si.formpage = :formpage';
+    if ($formpage) {
+        $conditions[] = 'formpage = :formpage';
         $params['formpage'] = $formpage;
     }
-    $sql .= ' ORDER BY si.sortindex';
 
-    return array($sql, $params);
+    $where = '( ('.implode(') AND (', $conditions).') )';
+
+    return array($where, $params);
 }
 
 /**

--- a/locallib.php
+++ b/locallib.php
@@ -45,7 +45,7 @@ function surveypro_get_item($cm, $surveypro, $itemid=0, $type='', $plugin='', $e
     if (!empty($itemid)) {
         $itemseed = $DB->get_record('surveypro_item', array('id' => $itemid), 'surveyproid, type, plugin', MUST_EXIST);
         if ($cm->instance != $itemseed->surveyproid) {
-            $message = 'Mismatch between passed itemid ('.$itemid.') and corresponding cm->instanceid ('.$cm->instanceid.')';
+            $message = 'Mismatch between passed itemid ('.$itemid.') and corresponding cm->instance ('.$cm->instance.')';
             debugging('Error at line '.__LINE__.' of '.__FILE__.'. '.$message , DEBUG_DEVELOPER);
         }
     }

--- a/mtemplates_apply.php
+++ b/mtemplates_apply.php
@@ -93,7 +93,7 @@ $mtemplateman->friendly_stop();
 $riskyediting = ($surveypro->riskyeditdeadline > time());
 $utilityman = new mod_surveypro_utility($cm, $surveypro);
 if ($utilityman->has_submissions() && $riskyediting) {
-    $message = $utilityman->warning_message();
+    $message = $utilityman->has_submissions_warning();
     echo $OUTPUT->notification($message, 'notifyproblem');
 }
 

--- a/report/attachments_overview/form/filter_form.php
+++ b/report/attachments_overview/form/filter_form.php
@@ -45,8 +45,8 @@ class mod_surveypro_report_filterform extends moodleform {
 
         $submissionidstring = get_string('submission', 'surveyproreport_attachments_overview');
 
-        list($sql, $whereparams) = surveypro_fetch_items_seeds($surveypro->id, $canaccessreserveditems, false);
-        $itemseeds = $DB->get_recordset_sql($sql, $whereparams);
+        list($where, $params) = surveypro_fetch_items_seeds($surveypro->id, $canaccessreserveditems);
+        $itemseeds = $DB->get_recordset_select('surveypro_item', $where, $params, 'sortindex', 'id, plugin');
 
         if (!$itemseeds->valid()) {
             // No items are in this page.
@@ -66,6 +66,8 @@ class mod_surveypro_report_filterform extends moodleform {
             $content = $DB->get_field('surveyprofield_fileupload', 'content', array('itemid' => $itemseed->id));
             $options[$itemseed->id] = strip_tags($content);
         }
+        $itemseeds->close();
+
         $elementgroup = array();
         $elementgroup[] = $mform->createElement('select', 'itemid', '', $options);
 

--- a/utemplates_apply.php
+++ b/utemplates_apply.php
@@ -97,7 +97,7 @@ $utemplateman->friendly_stop();
 $riskyediting = ($surveypro->riskyeditdeadline > time());
 $utilityman = new mod_surveypro_utility($cm, $surveypro);
 if ($utilityman->has_submissions() && $riskyediting) {
-    $message = $utilityman->warning_message();
+    $message = $utilityman->has_submissions_warning();
     echo $OUTPUT->notification($message, 'notifyproblem');
 }
 


### PR DESCRIPTION
During  code cleanup I found that
- surveypro_fetch_items_seeds was more complex than needed
- item_validate_variablename was more complex than needed too
and
- get_used_plugin_list was written three times in the code.

item_validate_variablename had also an error (with very low probability to occur, but my Editing Teacher are really nice :o) )

Yes, they should be three PR but they are all small changes.
I apologise in advance.