### PR TITLE
NOBUG: Fix multilanguage test to ensure UI is in the expected lang.

### DIFF
--- a/tests/behat/behat_mod_surveypro.php
+++ b/tests/behat/behat_mod_surveypro.php
@@ -108,4 +108,34 @@ class behat_mod_surveypro extends behat_base {
             $item->item_save($record);
         }
     }
+
+    /**
+     * Click on an entry in the language menu.
+     * @Given /^I follow "(?P<nodetext_string>(?:[^"]|\\")*)" in the language menu$/
+     *
+     * @param string $nodetext
+     * @return bool|void
+     */
+    public function i_follow_in_the_language_menu($nodetext) {
+        $steps = array();
+
+        if ($this->running_javascript()) {
+            // The language menu must be expanded when JS is enabled.
+            $xpath = "//li[contains(concat(' ', @class, ' '), ' langmenu ')]//a[contains(concat(' ', @class, ' '), ' dropdown-toggle ')]";
+            $steps[] = new Given('I click on "'.$xpath.'" "xpath_element"');
+        }
+
+        // Now select the link.
+        // The CSS path is always present, with or without JS.
+        $csspath = ".langmenu .dropdown-menu";
+        // We need this because the lang menu has some hidden chars and we'll need to match them if the original text
+        // has code between parenthesis. See get_list_of_translations() implementation.
+        $nodetext = str_replace(
+            array('(', ')'),
+            array(json_decode('"\u200E"') . '(', ')' . json_decode('"\u200E"')),
+            $nodetext);
+        $steps[] = new Given('I click on "'.$nodetext.'" "link" in the "'.$csspath.'" "css_element"');
+
+        return $steps;
+    }
 }

--- a/tests/behat/multilang_mastertemplate.feature
+++ b/tests/behat/multilang_mastertemplate.feature
@@ -5,7 +5,8 @@ Feature: verify multilang in ATTLS (20 item version) mastertemplate
   I display a mastertemplate                                                  // The feature we want
 
   Background:
-    Given the following "courses" exist:
+    Given remote langimport tests are enabled
+    And the following "courses" exist:
       | fullname                 | shortname    | category | groupmode |
       | Multilang mastertemplate | ML Mtemplate | 0        | 0         |
     And the following "users" exist:
@@ -33,13 +34,10 @@ Feature: verify multilang in ATTLS (20 item version) mastertemplate
     Then I should see "Language pack 'it' was successfully installed"
     And I log out
 
-    # Take care: you are in Italian now and "Log in" has been replaced by "Login"
-    And I follow "Login"
-    And I set the following fields to these values:
-      | Username | teacher1 |
-      | Password | teacher1 |
-    And I press "Login"
-
+    # Force English for UI.
+    And I follow "English" in the language menu
+    And I log in as "teacher1"
+    And I am on site homepage
     And I follow "Multilang mastertemplate"
     And I follow "Multilang in ATTLS"
     And I set the field "Master templates" to "ATTLS (20 item version)"
@@ -71,17 +69,14 @@ Feature: verify multilang in ATTLS (20 item version) mastertemplate
 
     And I log out
 
+    # Force Italiano for UI.
+    And I follow "Italiano (it)" in the language menu
     # Take care: you are in Italian now and "Log in" has been replaced by "Login"
     And I follow "Login"
     And I set the following fields to these values:
       | Username | student1 |
       | Password | student1 |
     And I press "Login"
-
-    And I follow "Preferences" in the user menu
-    And I follow "Preferred language"
-    And I set the field "Preferred language" to "Italiano"
-    And I press "Save changes"
 
     And I am on site homepage
     And I follow "Multilang mastertemplate"
@@ -107,3 +102,7 @@ Feature: verify multilang in ATTLS (20 item version) mastertemplate
     And I navigate to "Multilang in Critical Incidents" node in "Corso in uso > ML Mtemplate > Argomento 5"
     And I press "Nuova risposta"
     Then I should see "In classe in quale momento sei più partecipe come studente?"
+
+    # Force English for UI (at the end).
+    And I follow "English (en)" in the language menu
+    And I log out


### PR DESCRIPTION
Depending of browser language it may be possible for some tests
to be passing in some sites but not in others.

So I've created a new step:

   And I follow "languagename" in the language menu

In order to, always, ensure the desired language is being used.

That way, the teacher user sees everything in English and the student
user sees everything in Italian.

It's passing here now, and hope travis also will. For your consideration. Maybe you can try it in your Italian laptop....

Ciao :-)

PS: Note I don't really understand why it was passing for you, specially why the teacher had the Italian "login" when the survey is in English. Rare, rare. Anyway, now we explicitly set the desired language so mysteries are history.