### PR TITLE
NOBUG mod_surveypro: preserve from codechecker and minor phpdoc fix

### DIFF
--- a/field/checkbox/classes/mform_advcheckbox.php
+++ b/field/checkbox/classes/mform_advcheckbox.php
@@ -30,6 +30,8 @@ global $CFG;
 
 require_once($CFG->libdir.'/form/advcheckbox.php');
 
+// @codingStandardsIgnoreFile
+
 /**
  * advcheckbox mform element
  *
@@ -44,13 +46,15 @@ class mod_surveypro_mform_advcheckbox extends MoodleQuickForm_advcheckbox {
     /**
      * Class constructor
      *
-     * @param string $elementName
-     * @param string $elementLabel
-     * @param array $attributes
-     * @param array $options
+     * @param string $elementName (optional) name of the checkbox
+     * @param string $elementLabel (optional) checkbox label
+     * @param string $text (optional) Text to put after the checkbox
+     * @param mixed $attributes (optional) Either a typical HTML attribute string
+     *              or an associative array
+     * @param mixed $options (optional) Values to pass if checked or not checked
      */
-    public function __construct($elementName=null, $elementLabel=null, $attributes=null, $options=null) {
-        parent::__construct($elementName, $elementLabel, $attributes, $options);
+    public function __construct($elementName=null, $elementLabel=null, $text=null, $attributes=null, $options=null) {
+        parent::__construct($elementName, $elementLabel, $text, $attributes, $options);
     }
 
     /**

--- a/field/checkbox/classes/mform_checkbox.php
+++ b/field/checkbox/classes/mform_checkbox.php
@@ -30,6 +30,8 @@ global $CFG;
 
 require_once($CFG->libdir.'/form/checkbox.php');
 
+// @codingStandardsIgnoreFile
+
 /**
  * checkbox mform element
  *
@@ -42,15 +44,16 @@ require_once($CFG->libdir.'/form/checkbox.php');
 class mod_surveypro_mform_checkbox extends MoodleQuickForm_checkbox {
 
     /**
-     * Class constructor
+     * Constructor
      *
-     * @param string $elementName
-     * @param string $elementLabel
-     * @param array $attributes
-     * @param array $options
+     * @param string $elementName (optional) name of the checkbox
+     * @param string $elementLabel (optional) checkbox label
+     * @param string $text (optional) Text to put after the checkbox
+     * @param mixed $attributes (optional) Either a typical HTML attribute string
+     *              or an associative array
      */
-    public function __construct($elementName=null, $elementLabel=null, $attributes=null, $options=null) {
-        parent::__construct($elementName, $elementLabel, $attributes, $options);
+    public function __construct($elementName=null, $elementLabel=null, $text=null, $attributes=null) {
+        parent::__construct($elementName, $elementLabel, $text, $attributes);
     }
 
     /**

--- a/field/fileupload/classes/mform_filemanager.php
+++ b/field/fileupload/classes/mform_filemanager.php
@@ -30,6 +30,8 @@ global $CFG;
 
 require_once($CFG->libdir.'/form/filemanager.php');
 
+// @codingStandardsIgnoreFile
+
 /**
  * filemanager mform element
  *
@@ -42,12 +44,13 @@ require_once($CFG->libdir.'/form/filemanager.php');
 class mod_surveypro_mform_filemanager extends MoodleQuickForm_filemanager {
 
     /**
-     * Class constructor
+     * Constructor
      *
-     * @param string $elementName
-     * @param string $elementLabel
-     * @param array $attributes
-     * @param array $options
+     * @param string $elementName (optional) name of the filemanager
+     * @param string $elementLabel (optional) filemanager label
+     * @param array $attributes (optional) Either a typical HTML attribute string
+     *              or an associative array
+     * @param array $options set of options to initalize filemanager
      */
     public function __construct($elementName=null, $elementLabel=null, $attributes=null, $options=null) {
         parent::__construct($elementName, $elementLabel, $attributes, $options);

--- a/field/radiobutton/classes/mform_radio.php
+++ b/field/radiobutton/classes/mform_radio.php
@@ -28,6 +28,7 @@ global $CFG;
 
 require_once($CFG->libdir.'/form/radio.php');
 
+// @codingStandardsIgnoreFile
 /**
  * radio form element
  *
@@ -40,7 +41,7 @@ require_once($CFG->libdir.'/form/radio.php');
 class mod_surveypro_mform_radio extends MoodleQuickForm_radio {
 
     /**
-     * Class constructor.
+     * Class constructor
      *
      * @param string $elementName Optional name of the radio element
      * @param string $elementLabel Optional label for radio element

--- a/field/select/classes/mform_select.php
+++ b/field/select/classes/mform_select.php
@@ -30,6 +30,8 @@ global $CFG;
 
 require_once($CFG->libdir.'/form/select.php');
 
+// @codingStandardsIgnoreFile
+
 /**
  * select mform element
  *
@@ -44,10 +46,11 @@ class mod_surveypro_mform_select extends MoodleQuickForm_select {
     /**
      * Class constructor
      *
-     * @param string $elementName
-     * @param string $elementLabel
-     * @param array $attributes
-     * @param array $options
+     * @param string $elementName Select name attribute
+     * @param mixed $elementLabel Label(s) for the select
+     * @param mixed $options Data to be used to populate options
+     * @param mixed $attributes Either a typical HTML attribute string
+     *              or an associative array
      */
     public function __construct($elementName=null, $elementLabel=null, $options=null, $attributes=null) {
         parent::__construct($elementName, $elementLabel, $options, $attributes);

--- a/field/textarea/classes/mform_editor.php
+++ b/field/textarea/classes/mform_editor.php
@@ -30,6 +30,8 @@ global $CFG;
 
 require_once($CFG->libdir.'/form/editor.php');
 
+// @codingStandardsIgnoreFile
+
 /**
  * editor form element
  *
@@ -42,12 +44,13 @@ require_once($CFG->libdir.'/form/editor.php');
 class mod_surveypro_mform_editor extends MoodleQuickForm_editor {
 
     /**
-     * Class constructor
+     * Constructor
      *
-     * @param string $elementName
-     * @param string $elementLabel
-     * @param array $attributes
-     * @param array $options
+     * @param string $elementName (optional) name of the editor
+     * @param string $elementLabel (optional) editor label
+     * @param array $attributes (optional) Either a typical HTML attribute string
+     *              or an associative array
+     * @param array $options set of options to initalize filepicker
      */
     public function __construct($elementName=null, $elementLabel=null, $attributes=null, $options=null) {
         parent::__construct($elementName, $elementLabel, $attributes, $options);

--- a/format/label/classes/mform_static.php
+++ b/format/label/classes/mform_static.php
@@ -30,6 +30,8 @@ global $CFG;
 
 require_once($CFG->libdir.'/form/static.php');
 
+// @codingStandardsIgnoreFile
+
 /**
  * static form element
  *
@@ -44,14 +46,15 @@ class mod_surveypro_mform_static extends MoodleQuickForm_static {
     /**
      * Class constructor
      *
-     * @param string $elementName
-     * @param string $elementLabel
-     * @param array $attributes
-     * @param array $options
+     * @param string $elementName Select name attribute
+     * @param mixed $elementLabel Label(s) for the select
+     * @param mixed $options Data to be used to populate options
+     * @param mixed $attributes Either a typical HTML attribute string
+     *              or an associative array
      */
-    public function __construct($elementName=null, $elementLabel=null, $text=null, $options=null) {
-        parent::__construct($elementName, $elementLabel, $text);
-        $this->_options['class'] = !isset($options['class']) ? 'indent-0' : $options['class'];
+    public function __construct($elementName=null, $elementLabel=null, $options=null, $attributes=null) {
+        parent::__construct($elementName, $elementLabel, $options);
+        $this->_options['class'] = !isset($attributes['class']) ? 'indent-0' : $attributes['class'];
     }
 
     /**


### PR DESCRIPTION
As far as I understand, 
there was a deeeeeep error but, in spite of this, it never come out.
It is in surveypro/field/checkbox/classes/mform_advcheckbox.php
where I had:
    public function __construct($elementName=null, $elementLabel=null, $attributes=null, $options=null) {
        parent::__construct($elementName, $elementLabel, $attributes, $options);
    }
while the parent class had
    public function __construct($elementName=null, $elementLabel=null, $text=null, $attributes=null, $options=null)

I simply added $text=null to my constructor and to the call to the parent constructor and all still works fine.
I made a quick test and all seems to be fine.
Next week I will investigate more.