### PR TITLE
CONTRIB-6230 mod_surveypro: deleted saveasnew propery

### DIFF
--- a/classes/itemlist.class.php
+++ b/classes/itemlist.class.php
@@ -2063,16 +2063,6 @@ class mod_surveypro_itemlist {
     }
 
     /**
-     * Set saveasnew.
-     *
-     * @param int $saveasnew
-     * @return void
-     */
-    public function set_saveasnew($saveasnew) {
-        $this->saveasnew = $saveasnew;
-    }
-
-    /**
      * Set hassubmissions.
      *
      * @param int $hassubmissions

--- a/layout_itemsetup.php
+++ b/layout_itemsetup.php
@@ -89,9 +89,6 @@ $itemlistman->set_hassubmissions($hassubmissions);
 // Property itemeditingfeedback is useless (it is set to its default), do not set it.
 // $itemlistman->set_itemeditingfeedback(SURVEYPRO_NOFEEDBACK);
 
-// Property saveasnew is useless (it is set to its default), do not set it.
-// $itemlistman->set_saveasnew(0);
-
 // Property hassubmissions is useless (it is set to its default), do not set it.
 // $itemlistman->set_hassubmissions($hassubmissions);
 

--- a/layout_manage.php
+++ b/layout_manage.php
@@ -83,7 +83,6 @@ $itemlistman->set_confirm($confirm);
 $itemlistman->set_nextindent($nextindent);
 $itemlistman->set_parentid($parentid);
 $itemlistman->set_itemeditingfeedback($itemeditingfeedback);
-$itemlistman->set_saveasnew($saveasnew);
 $itemlistman->set_hassubmissions($hassubmissions);
 $itemlistman->set_itemcount($itemcount);
 

--- a/layout_validation.php
+++ b/layout_validation.php
@@ -82,9 +82,6 @@ $itemlistman = new mod_surveypro_itemlist($cm, $context, $surveypro);
 // Property itemeditingfeedback is useless (it is set to its default), do not set it
 // $itemlistman->set_itemeditingfeedback(SURVEYPRO_NOFEEDBACK);
 
-// Property saveasnew is useless (it is set to its default), do not set it
-// $itemlistman->set_saveasnew(0);
-
 // Property hassubmissions is useless (it is set to its default), do not set it.
 // $itemlistman->set_hassubmissions($hassubmissions);
 


### PR DESCRIPTION
it strongly seems that the property saveasnew of the mod_surveypro_itemlist class 
is 100% useless and never used.
I removed it and now I push the patch to verify the opinion of travis-ci.