### PR TITLE
CONTRIB-6259 surveypro: del. $surveypro from userform_mform_validation

### DIFF
--- a/classes/itembase.class.php
+++ b/classes/itembase.class.php
@@ -46,6 +46,11 @@ class mod_surveypro_itembase {
     protected $context;
 
     /**
+     * @var object $surveypro
+     */
+    public $surveypro;
+
+    /**
      * @var int Unique itemid of the surveyproitem in surveypro_item table
      */
     protected $itemid;

--- a/field/age/classes/plugin.class.php
+++ b/field/age/classes/plugin.class.php
@@ -527,11 +527,10 @@ EOS;
      *
      * @param array $data
      * @param array $errors
-     * @param array $surveypro
      * @param bool $searchform
      * @return void
      */
-    public function userform_mform_validation($data, &$errors, $surveypro, $searchform) {
+    public function userform_mform_validation($data, &$errors, $searchform) {
         // This plugin displays as dropdown menu. It will never return empty values.
         // Because of this, if ($this->required) { if (empty($data[$this->itemname])) { is useless.
 

--- a/field/autofill/classes/plugin.class.php
+++ b/field/autofill/classes/plugin.class.php
@@ -439,11 +439,10 @@ EOS;
      *
      * @param array $data
      * @param array $errors
-     * @param array $surveypro
      * @param bool $searchform
      * @return void
      */
-    public function userform_mform_validation($data, &$errors, $surveypro, $searchform) {
+    public function userform_mform_validation($data, &$errors, $searchform) {
         // Nothing to do here.
     }
 
@@ -510,10 +509,8 @@ EOS;
 
         if ($submissionid) {
             $submission = $DB->get_record('surveypro_submission', array('id' => $submissionid), '*', MUST_EXIST);
-            $surveypro = $DB->get_record('surveypro', array('id' => $submission->surveyproid), '*', MUST_EXIST);
             $user = $DB->get_record('user', array('id' => $submission->userid));
         } else {
-            $surveypro = $DB->get_record('surveypro', array('id' => $this->cm->instance), '*', MUST_EXIST);
             $user = $USER;
         }
 
@@ -592,10 +589,10 @@ EOS;
                         $label .= implode(', ', $names);
                         break;
                     case SURVEYPROFIELD_AUTOFILL_CONTENTELEMENT11: // Surveyproid.
-                        $label .= $surveypro->id;
+                        $label .= $this->surveypro->id;
                         break;
                     case SURVEYPROFIELD_AUTOFILL_CONTENTELEMENT12: // Surveyproname.
-                        $label .= $surveypro->name;
+                        $label .= $this->surveypro->name;
                         break;
                     case SURVEYPROFIELD_AUTOFILL_CONTENTELEMENT13: // Courseid.
                         $label .= $COURSE->id;

--- a/field/boolean/classes/plugin.class.php
+++ b/field/boolean/classes/plugin.class.php
@@ -589,11 +589,10 @@ EOS;
      *
      * @param array $data
      * @param array $errors
-     * @param array $surveypro
      * @param bool $searchform
      * @return void
      */
-    public function userform_mform_validation($data, &$errors, $surveypro, $searchform) {
+    public function userform_mform_validation($data, &$errors, $searchform) {
         // This plugin displays as dropdown menu or a radio buttons set. It will never return empty values.
         // If ($this->required) { if (empty($data[$this->itemname])) { is useless.
 

--- a/field/character/classes/plugin.class.php
+++ b/field/character/classes/plugin.class.php
@@ -437,11 +437,10 @@ EOS;
      *
      * @param array $data
      * @param array $errors
-     * @param array $surveypro
      * @param bool $searchform
      * @return void
      */
-    public function userform_mform_validation($data, &$errors, $surveypro, $searchform) {
+    public function userform_mform_validation($data, &$errors, $searchform) {
         if ($searchform) {
             return;
         }

--- a/field/checkbox/classes/plugin.class.php
+++ b/field/checkbox/classes/plugin.class.php
@@ -588,11 +588,10 @@ EOS;
      *
      * @param array $data
      * @param array $errors
-     * @param array $surveypro
      * @param bool $searchform
      * @return void
      */
-    public function userform_mform_validation($data, &$errors, $surveypro, $searchform) {
+    public function userform_mform_validation($data, &$errors, $searchform) {
         if ($searchform) {
             return;
         }

--- a/field/date/classes/plugin.class.php
+++ b/field/date/classes/plugin.class.php
@@ -37,11 +37,6 @@ require_once($CFG->dirroot.'/mod/surveypro/field/date/lib.php');
 class mod_surveypro_field_date extends mod_surveypro_itembase {
 
     /**
-     * @var object $surveypro
-     */
-    public $surveypro = null;
-
-    /**
      * @var string $content
      */
     public $content = '';
@@ -194,7 +189,6 @@ class mod_surveypro_field_date extends mod_surveypro_itembase {
         // No properties here.
 
         // Override properties depending from $surveypro settings.
-        $this->surveypro = $DB->get_record('surveypro', array('id' => $cm->instance), '*', MUST_EXIST);
         $this->lowerbound = $this->item_date_to_unix_time($this->surveypro->startyear, 1, 1);
         $this->upperbound = $this->item_date_to_unix_time($this->surveypro->stopyear, 12, 31);
         $this->defaultvalue = $this->lowerbound;
@@ -598,11 +592,10 @@ EOS;
      *
      * @param array $data
      * @param array $errors
-     * @param array $surveypro
      * @param bool $searchform
      * @return void
      */
-    public function userform_mform_validation($data, &$errors, $surveypro, $searchform) {
+    public function userform_mform_validation($data, &$errors, $searchform) {
         // This plugin displays as dropdown menu. It will never return empty values.
         // If ($this->required) { if (empty($data[$this->itemname])) { is useless.
 
@@ -646,8 +639,8 @@ EOS;
             return;
         }
 
-        $haslowerbound = ($this->lowerbound != $this->item_date_to_unix_time($surveypro->startyear, 1, 1));
-        $hasupperbound = ($this->upperbound != $this->item_date_to_unix_time($surveypro->stopyear, 12, 31));
+        $haslowerbound = ($this->lowerbound != $this->item_date_to_unix_time($this->surveypro->startyear, 1, 1));
+        $hasupperbound = ($this->upperbound != $this->item_date_to_unix_time($this->surveypro->stopyear, 12, 31));
 
         $userinput = $this->item_date_to_unix_time($data[$this->itemname.'_year'], $data[$this->itemname.'_month'], $data[$this->itemname.'_day']);
 

--- a/field/datetime/classes/plugin.class.php
+++ b/field/datetime/classes/plugin.class.php
@@ -37,11 +37,6 @@ require_once($CFG->dirroot.'/mod/surveypro/field/datetime/lib.php');
 class mod_surveypro_field_datetime extends mod_surveypro_itembase {
 
     /**
-     * @var object $surveypro
-     */
-    public $surveypro = null;
-
-    /**
      * @var string $content
      */
     public $content = '';
@@ -229,7 +224,6 @@ class mod_surveypro_field_datetime extends mod_surveypro_itembase {
         // No properties here.
 
         // Override properties depending from $surveypro settings.
-        $this->surveypro = $DB->get_record('surveypro', array('id' => $cm->instance), '*', MUST_EXIST);
         $this->lowerbound = $this->item_datetime_to_unix_time($this->surveypro->startyear, 1, 1, 0, 0);
         $this->upperbound = $this->item_datetime_to_unix_time($this->surveypro->stopyear, 12, 31, 23, 59);
         $this->defaultvalue = $this->lowerbound;
@@ -668,11 +662,10 @@ EOS;
      *
      * @param array $data
      * @param array $errors
-     * @param array $surveypro
      * @param bool $searchform
      * @return void
      */
-    public function userform_mform_validation($data, &$errors, $surveypro, $searchform) {
+    public function userform_mform_validation($data, &$errors, $searchform) {
         // This plugin displays as dropdown menu. It will never return empty values.
         // If ($this->required) { if (empty($data[$this->itemname])) { is useless.
 
@@ -722,8 +715,8 @@ EOS;
             return;
         }
 
-        $haslowerbound = ($this->lowerbound != $this->item_datetime_to_unix_time($surveypro->startyear, 1, 1, 0, 0));
-        $hasupperbound = ($this->upperbound != $this->item_datetime_to_unix_time($surveypro->stopyear, 12, 31, 23, 59));
+        $haslowerbound = ($this->lowerbound != $this->item_datetime_to_unix_time($this->surveypro->startyear, 1, 1, 0, 0));
+        $hasupperbound = ($this->upperbound != $this->item_datetime_to_unix_time($this->surveypro->stopyear, 12, 31, 23, 59));
 
         $userinput = $this->item_datetime_to_unix_time($data[$this->itemname.'_year'], $data[$this->itemname.'_month'],
                 $data[$this->itemname.'_day'], $data[$this->itemname.'_hour'], $data[$this->itemname.'_minute']);

--- a/field/fileupload/classes/plugin.class.php
+++ b/field/fileupload/classes/plugin.class.php
@@ -323,11 +323,10 @@ EOS;
      *
      * @param array $data
      * @param array $errors
-     * @param array $surveypro
      * @param bool $searchform
      * @return void
      */
-    public function userform_mform_validation($data, &$errors, $surveypro, $searchform) {
+    public function userform_mform_validation($data, &$errors, $searchform) {
         if ($searchform) {
             return;
         }

--- a/field/integer/classes/plugin.class.php
+++ b/field/integer/classes/plugin.class.php
@@ -491,11 +491,10 @@ EOS;
      *
      * @param array $data
      * @param array $errors
-     * @param array $surveypro
      * @param bool $searchform
      * @return void
      */
-    public function userform_mform_validation($data, &$errors, $surveypro, $searchform) {
+    public function userform_mform_validation($data, &$errors, $searchform) {
         if ($searchform) {
             return;
         }

--- a/field/multiselect/classes/plugin.class.php
+++ b/field/multiselect/classes/plugin.class.php
@@ -548,11 +548,10 @@ EOS;
      *
      * @param array $data
      * @param array $errors
-     * @param array $surveypro
      * @param bool $searchform
      * @return void
      */
-    public function userform_mform_validation($data, &$errors, $surveypro, $searchform) {
+    public function userform_mform_validation($data, &$errors, $searchform) {
         if ($searchform) {
             return;
         }

--- a/field/numeric/classes/plugin.class.php
+++ b/field/numeric/classes/plugin.class.php
@@ -422,11 +422,10 @@ EOS;
      *
      * @param array $data
      * @param array $errors
-     * @param array $surveypro
      * @param bool $searchform
      * @return void
      */
-    public function userform_mform_validation($data, &$errors, $surveypro, $searchform) {
+    public function userform_mform_validation($data, &$errors, $searchform) {
         if ($searchform) {
             return;
         }

--- a/field/radiobutton/classes/plugin.class.php
+++ b/field/radiobutton/classes/plugin.class.php
@@ -589,11 +589,10 @@ EOS;
      *
      * @param array $data
      * @param array $errors
-     * @param array $surveypro
      * @param bool $searchform
      * @return void
      */
-    public function userform_mform_validation($data, &$errors, $surveypro, $searchform) {
+    public function userform_mform_validation($data, &$errors, $searchform) {
         // This plugin displays as a set of radio buttons. It will never return empty values.
         // If ($this->required) { if (empty($data[$this->itemname])) { is useless
 

--- a/field/rate/classes/plugin.class.php
+++ b/field/rate/classes/plugin.class.php
@@ -462,11 +462,10 @@ EOS;
      *
      * @param array $data
      * @param array $errors
-     * @param array $surveypro
      * @param bool $searchform
      * @return void
      */
-    public function userform_mform_validation($data, &$errors, $surveypro, $searchform) {
+    public function userform_mform_validation($data, &$errors, $searchform) {
         // This plugin displays as a set of dropdown menu or radio buttons. It will never return empty values.
         // If ($this->required) { if (empty($data[$this->itemname])) { is useless
 

--- a/field/recurrence/classes/plugin.class.php
+++ b/field/recurrence/classes/plugin.class.php
@@ -552,11 +552,10 @@ EOS;
      *
      * @param array $data
      * @param array $errors
-     * @param array $surveypro
      * @param bool $searchform
      * @return void
      */
-    public function userform_mform_validation($data, &$errors, $surveypro, $searchform) {
+    public function userform_mform_validation($data, &$errors, $searchform) {
         // This plugin displays as dropdown menu. It will never return empty values.
         // If ($this->required) { if (empty($data[$this->itemname])) { is useless
 

--- a/field/select/classes/plugin.class.php
+++ b/field/select/classes/plugin.class.php
@@ -548,11 +548,10 @@ EOS;
      *
      * @param array $data
      * @param array $errors
-     * @param array $surveypro
      * @param bool $searchform
      * @return void
      */
-    public function userform_mform_validation($data, &$errors, $surveypro, $searchform) {
+    public function userform_mform_validation($data, &$errors, $searchform) {
         // This plugin displays as dropdown menu. It will never return empty values.
         // If ($this->required) { if (empty($data[$this->itemname])) { is useless
 

--- a/field/shortdate/classes/plugin.class.php
+++ b/field/shortdate/classes/plugin.class.php
@@ -37,11 +37,6 @@ require_once($CFG->dirroot.'/mod/surveypro/field/shortdate/lib.php');
 class mod_surveypro_field_shortdate extends mod_surveypro_itembase {
 
     /**
-     * @var object $surveypro
-     */
-    public $surveypro = null;
-
-    /**
      * @var string $content
      */
     public $content = '';
@@ -179,8 +174,6 @@ class mod_surveypro_field_shortdate extends mod_surveypro_itembase {
         // No properties here.
 
         // Override properties depending from $surveypro settings.
-        // Override properties depending from $surveypro settings.
-        $this->surveypro = $DB->get_record('surveypro', array('id' => $cm->instance), '*', MUST_EXIST);
         $this->lowerbound = $this->item_shortdate_to_unix_time(1, $this->surveypro->startyear);
         $this->upperbound = $this->item_shortdate_to_unix_time(12, $this->surveypro->stopyear);
         $this->defaultvalue = $this->lowerbound;
@@ -549,11 +542,10 @@ EOS;
      *
      * @param array $data
      * @param array $errors
-     * @param array $surveypro
      * @param bool $searchform
      * @return void
      */
-    public function userform_mform_validation($data, &$errors, $surveypro, $searchform) {
+    public function userform_mform_validation($data, &$errors, $searchform) {
         // This plugin displays as dropdown menu. It will never return empty values.
         // If ($this->required) { if (empty($data[$this->itemname])) { is useless
 
@@ -594,8 +586,8 @@ EOS;
             return;
         }
 
-        $haslowerbound = ($this->lowerbound != $this->item_shortdate_to_unix_time(1, $surveypro->startyear));
-        $hasupperbound = ($this->upperbound != $this->item_shortdate_to_unix_time(12, $surveypro->stopyear));
+        $haslowerbound = ($this->lowerbound != $this->item_shortdate_to_unix_time(1, $this->surveypro->startyear));
+        $hasupperbound = ($this->upperbound != $this->item_shortdate_to_unix_time(12, $this->surveypro->stopyear));
 
         $userinput = $this->item_shortdate_to_unix_time($data[$this->itemname.'_month'], $data[$this->itemname.'_year']);
 

--- a/field/textarea/classes/plugin.class.php
+++ b/field/textarea/classes/plugin.class.php
@@ -391,11 +391,10 @@ EOS;
      *
      * @param array $data
      * @param array $errors
-     * @param array $surveypro
      * @param bool $searchform
      * @return void
      */
-    public function userform_mform_validation($data, &$errors, $surveypro, $searchform) {
+    public function userform_mform_validation($data, &$errors, $searchform) {
         if ($searchform) {
             return;
         }

--- a/field/time/classes/plugin.class.php
+++ b/field/time/classes/plugin.class.php
@@ -555,11 +555,10 @@ EOS;
      *
      * @param array $data
      * @param array $errors
-     * @param array $surveypro
      * @param bool $searchform
      * @return void
      */
-    public function userform_mform_validation($data, &$errors, $surveypro, $searchform) {
+    public function userform_mform_validation($data, &$errors, $searchform) {
         // This plugin displays as dropdown menu. It will never return empty values.
         // If ($this->required) { if (empty($data[$this->itemname])) { is useless
 

--- a/form/outform/fill_form.php
+++ b/form/outform/fill_form.php
@@ -314,7 +314,7 @@ class mod_surveypro_outform extends moodleform {
                 }
 
                 if ($itemisenabled) {
-                    $item->userform_mform_validation($data, $errors, $surveypro, false);
+                    $item->userform_mform_validation($data, $errors, false);
                     // } else {
                     // echo 'parent item doesn\'t allow the validation of the child item '.$item->itemid.', plugin = '.$item->plugin.'('.$item->content.')<br />';
                 }

--- a/form/outform/search_form.php
+++ b/form/outform/search_form.php
@@ -153,7 +153,7 @@ class mod_surveypro_searchform extends moodleform {
                 $olditemid = $itemid;
 
                 $item = surveypro_get_item($cm, $surveypro, $itemid, $type, $plugin);
-                $item->userform_mform_validation($data, $errors, $surveypro, true);
+                $item->userform_mform_validation($data, $errors, true);
             }
         }
 

--- a/format/fieldset/classes/plugin.class.php
+++ b/format/fieldset/classes/plugin.class.php
@@ -205,11 +205,10 @@ EOS;
      *
      * @param array $data
      * @param array $errors
-     * @param array $surveypro
      * @param bool $searchform
      * @return void
      */
-    public function userform_mform_validation($data, &$errors, $surveypro, $searchform) {
+    public function userform_mform_validation($data, &$errors, $searchform) {
         // Nothing to do here.
     }
 

--- a/format/fieldsetend/classes/plugin.class.php
+++ b/format/fieldsetend/classes/plugin.class.php
@@ -204,11 +204,10 @@ EOS;
      *
      * @param array $data
      * @param array $errors
-     * @param array $surveypro
      * @param bool $searchform
      * @return void
      */
-    public function userform_mform_validation($data, &$errors, $surveypro, $searchform) {
+    public function userform_mform_validation($data, &$errors, $searchform) {
         // Nothing to do here.
     }
 

--- a/format/label/classes/plugin.class.php
+++ b/format/label/classes/plugin.class.php
@@ -293,11 +293,10 @@ EOS;
      *
      * @param array $data
      * @param array $errors
-     * @param array $surveypro
      * @param bool $searchform
      * @return void
      */
-    public function userform_mform_validation($data, &$errors, $surveypro, $searchform) {
+    public function userform_mform_validation($data, &$errors, $searchform) {
         // Nothing to do here.
     }
 

--- a/format/pagebreak/classes/plugin.class.php
+++ b/format/pagebreak/classes/plugin.class.php
@@ -204,11 +204,10 @@ EOS;
      *
      * @param array $data
      * @param array $errors
-     * @param array $surveypro
      * @param bool $searchform
      * @return void
      */
-    public function userform_mform_validation($data, &$errors, $surveypro, $searchform) {
+    public function userform_mform_validation($data, &$errors, $searchform) {
         // Nothing to do here.
     }
 


### PR DESCRIPTION
userform_mform_validation is the method of each item plugin
used to validate the mform element of the form that the student will fill and submit.

It gets as input a totally useless $surveypro because $surveypro is already a class property.

In the frame of this patch I also replaced EACH occurrence of $surveypro (in plugin.class.php) with $this->surveypro as this property is always defined by the parent constructor.