### PR TITLE
NOBUG mod_surveypro: silly code clean

### DIFF
--- a/classes/itembase.class.php
+++ b/classes/itembase.class.php
@@ -144,9 +144,9 @@ class mod_surveypro_itembase {
      * @param object $cm
      * @param object $surveypro
      * @param int $itemid
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      */
-    public function __construct($cm, $surveypro, $itemid, $evaluateparentcontent) {
+    public function __construct($cm, $surveypro, $itemid, $getparentcontent) {
         $this->cm = $cm;
         $this->surveypro = $surveypro;
     }
@@ -158,10 +158,10 @@ class mod_surveypro_itembase {
      * If evaluateparentcontent is true, load the parentitem parentcontent property too
      *
      * @param integer $itemid
-     * @param boolean $evaluateparentcontent To include among item elements the 'parentcontent' too
+     * @param boolean $getparentcontent To include among item elements the 'parentcontent' too
      * @return void
      */
-    protected function item_load($itemid, $evaluateparentcontent) {
+    protected function item_load($itemid, $getparentcontent) {
         global $DB;
 
         if (!$itemid) {
@@ -180,7 +180,7 @@ class mod_surveypro_itembase {
             }
             unset($this->id); // I do not care it. I already heave: itemid and pluginid.
             $this->itemname = SURVEYPRO_ITEMPREFIX.'_'.$this->type.'_'.$this->plugin.'_'.$this->itemid;
-            if ($evaluateparentcontent && $this->parentid) {
+            if ($getparentcontent && $this->parentid) {
                 $parentitem = surveypro_get_item($this->cm, $this->surveypro, $this->parentid);
                 $this->parentcontent = $parentitem->parent_decode_child_parentvalue($this->parentvalue);
             }

--- a/field/age/classes/plugin.class.php
+++ b/field/age/classes/plugin.class.php
@@ -147,10 +147,10 @@ class mod_surveypro_field_age extends mod_surveypro_itembase {
      * @param stdClass $cm
      * @param object $surveypro
      * @param int $itemid Optional item ID
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      */
-    public function __construct($cm, $surveypro, $itemid=0, $evaluateparentcontent) {
-        parent::__construct($cm, $surveypro, $itemid, $evaluateparentcontent);
+    public function __construct($cm, $surveypro, $itemid=0, $getparentcontent) {
+        parent::__construct($cm, $surveypro, $itemid, $getparentcontent);
 
         // List of properties set to static values..
         $this->type = SURVEYPRO_TYPEFIELD;
@@ -169,7 +169,7 @@ class mod_surveypro_field_age extends mod_surveypro_itembase {
         // Empty list.
 
         if (!empty($itemid)) {
-            $this->item_load($itemid, $evaluateparentcontent);
+            $this->item_load($itemid, $getparentcontent);
         }
     }
 
@@ -177,12 +177,11 @@ class mod_surveypro_field_age extends mod_surveypro_itembase {
      * Item load.
      *
      * @param int $itemid
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      * @return void
      */
-    public function item_load($itemid, $evaluateparentcontent) {
-        // Do parent item loading stuff here (mod_surveypro_itembase::item_load($itemid, $evaluateparentcontent)))
-        parent::item_load($itemid, $evaluateparentcontent);
+    public function item_load($itemid, $getparentcontent) {
+        parent::item_load($itemid, $getparentcontent);
 
         // Multilang load support for builtin surveypro.
         // Whether executed, the 'content' field is ALWAYS handled.

--- a/field/autofill/classes/plugin.class.php
+++ b/field/autofill/classes/plugin.class.php
@@ -177,10 +177,10 @@ class mod_surveypro_field_autofill extends mod_surveypro_itembase {
      * @param stdClass $cm
      * @param object $surveypro
      * @param int $itemid Optional item ID
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      */
-    public function __construct($cm, $surveypro, $itemid=0, $evaluateparentcontent) {
-        parent::__construct($cm, $surveypro, $itemid, $evaluateparentcontent);
+    public function __construct($cm, $surveypro, $itemid=0, $getparentcontent) {
+        parent::__construct($cm, $surveypro, $itemid, $getparentcontent);
 
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
@@ -199,7 +199,7 @@ class mod_surveypro_field_autofill extends mod_surveypro_itembase {
         $this->insetupform['hideinstructions'] = false;
 
         if (!empty($itemid)) {
-            $this->item_load($itemid, $evaluateparentcontent);
+            $this->item_load($itemid, $getparentcontent);
         }
     }
 
@@ -207,12 +207,11 @@ class mod_surveypro_field_autofill extends mod_surveypro_itembase {
      * Item load.
      *
      * @param int $itemid
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      * @return void
      */
-    public function item_load($itemid, $evaluateparentcontent) {
-        // Do parent item loading stuff here (mod_surveypro_itembase::item_load($itemid, $evaluateparentcontent)))
-        parent::item_load($itemid, $evaluateparentcontent);
+    public function item_load($itemid, $getparentcontent) {
+        parent::item_load($itemid, $getparentcontent);
 
         // Multilang load support for builtin surveypro.
         // Whether executed, the 'content' field is ALWAYS handled.

--- a/field/boolean/classes/plugin.class.php
+++ b/field/boolean/classes/plugin.class.php
@@ -117,10 +117,10 @@ class mod_surveypro_field_boolean extends mod_surveypro_itembase {
      * @param stdClass $cm
      * @param object $surveypro
      * @param int $itemid Optional item ID
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      */
-    public function __construct($cm, $surveypro, $itemid=0, $evaluateparentcontent) {
-        parent::__construct($cm, $surveypro, $itemid, $evaluateparentcontent);
+    public function __construct($cm, $surveypro, $itemid=0, $getparentcontent) {
+        parent::__construct($cm, $surveypro, $itemid, $getparentcontent);
 
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
@@ -138,7 +138,7 @@ class mod_surveypro_field_boolean extends mod_surveypro_itembase {
         $this->insetupform['hideinstructions'] = false;
 
         if (!empty($itemid)) {
-            $this->item_load($itemid, $evaluateparentcontent);
+            $this->item_load($itemid, $getparentcontent);
         }
     }
 
@@ -146,12 +146,11 @@ class mod_surveypro_field_boolean extends mod_surveypro_itembase {
      * Item load.
      *
      * @param int $itemid
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      * @return void
      */
-    public function item_load($itemid, $evaluateparentcontent) {
-        // Do parent item loading stuff here (mod_surveypro_itembase::item_load($itemid, $evaluateparentcontent)))
-        parent::item_load($itemid, $evaluateparentcontent);
+    public function item_load($itemid, $getparentcontent) {
+        parent::item_load($itemid, $getparentcontent);
 
         // Multilang load support for builtin surveypro.
         // Whether executed, the 'content' field is ALWAYS handled.

--- a/field/character/classes/plugin.class.php
+++ b/field/character/classes/plugin.class.php
@@ -133,10 +133,10 @@ class mod_surveypro_field_character extends mod_surveypro_itembase {
      * @param stdClass $cm
      * @param object $surveypro
      * @param int $itemid Optional item ID
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      */
-    public function __construct($cm, $surveypro, $itemid=0, $evaluateparentcontent) {
-        parent::__construct($cm, $surveypro, $itemid, $evaluateparentcontent);
+    public function __construct($cm, $surveypro, $itemid=0, $getparentcontent) {
+        parent::__construct($cm, $surveypro, $itemid, $getparentcontent);
 
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
@@ -154,7 +154,7 @@ class mod_surveypro_field_character extends mod_surveypro_itembase {
         // Empty list.
 
         if (!empty($itemid)) {
-            $this->item_load($itemid, $evaluateparentcontent);
+            $this->item_load($itemid, $getparentcontent);
         }
     }
 
@@ -162,12 +162,11 @@ class mod_surveypro_field_character extends mod_surveypro_itembase {
      * Item load.
      *
      * @param int $itemid
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      * @return void
      */
-    public function item_load($itemid, $evaluateparentcontent) {
-        // Do parent item loading stuff here (mod_surveypro_itembase::item_load($itemid, $evaluateparentcontent)))
-        parent::item_load($itemid, $evaluateparentcontent);
+    public function item_load($itemid, $getparentcontent) {
+        parent::item_load($itemid, $getparentcontent);
 
         // Multilang load support for builtin surveypro.
         // Whether executed, the 'content' field is ALWAYS handled.

--- a/field/checkbox/classes/plugin.class.php
+++ b/field/checkbox/classes/plugin.class.php
@@ -132,10 +132,10 @@ class mod_surveypro_field_checkbox extends mod_surveypro_itembase {
      * @param stdClass $cm
      * @param object $surveypro
      * @param int $itemid Optional item ID
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      */
-    public function __construct($cm, $surveypro, $itemid=0, $evaluateparentcontent) {
-        parent::__construct($cm, $surveypro, $itemid, $evaluateparentcontent);
+    public function __construct($cm, $surveypro, $itemid=0, $getparentcontent) {
+        parent::__construct($cm, $surveypro, $itemid, $getparentcontent);
 
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
@@ -153,7 +153,7 @@ class mod_surveypro_field_checkbox extends mod_surveypro_itembase {
         // Empty list.
 
         if (!empty($itemid)) {
-            $this->item_load($itemid, $evaluateparentcontent);
+            $this->item_load($itemid, $getparentcontent);
         }
     }
 
@@ -161,12 +161,11 @@ class mod_surveypro_field_checkbox extends mod_surveypro_itembase {
      * Item load.
      *
      * @param int $itemid
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      * @return void
      */
-    public function item_load($itemid, $evaluateparentcontent) {
-        // Do parent item loading stuff here (mod_surveypro_itembase::item_load($itemid, $evaluateparentcontent)))
-        parent::item_load($itemid, $evaluateparentcontent);
+    public function item_load($itemid, $getparentcontent) {
+        parent::item_load($itemid, $getparentcontent);
 
         // Multilang load support for builtin surveypro.
         // Whether executed, the 'content' field is ALWAYS handled.

--- a/field/date/classes/plugin.class.php
+++ b/field/date/classes/plugin.class.php
@@ -177,12 +177,12 @@ class mod_surveypro_field_date extends mod_surveypro_itembase {
      * @param stdClass $cm
      * @param object $surveypro
      * @param int $itemid Optional item ID
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      */
-    public function __construct($cm, $surveypro, $itemid=0, $evaluateparentcontent) {
+    public function __construct($cm, $surveypro, $itemid=0, $getparentcontent) {
         global $DB;
 
-        parent::__construct($cm, $surveypro, $itemid, $evaluateparentcontent);
+        parent::__construct($cm, $surveypro, $itemid, $getparentcontent);
 
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
@@ -203,7 +203,7 @@ class mod_surveypro_field_date extends mod_surveypro_itembase {
         // Empty list.
 
         if (!empty($itemid)) {
-            $this->item_load($itemid, $evaluateparentcontent);
+            $this->item_load($itemid, $getparentcontent);
         }
     }
 
@@ -211,12 +211,11 @@ class mod_surveypro_field_date extends mod_surveypro_itembase {
      * Item load.
      *
      * @param int $itemid
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      * @return void
      */
-    public function item_load($itemid, $evaluateparentcontent) {
-        // Do parent item loading stuff here (mod_surveypro_itembase::item_load($itemid, $evaluateparentcontent)))
-        parent::item_load($itemid, $evaluateparentcontent);
+    public function item_load($itemid, $getparentcontent) {
+        parent::item_load($itemid, $getparentcontent);
 
         // Multilang load support for builtin surveypro.
         // Whether executed, the 'content' field is ALWAYS handled.

--- a/field/datetime/classes/plugin.class.php
+++ b/field/datetime/classes/plugin.class.php
@@ -212,12 +212,12 @@ class mod_surveypro_field_datetime extends mod_surveypro_itembase {
      * @param stdClass $cm
      * @param object $surveypro
      * @param int $itemid Optional item ID
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      */
-    public function __construct($cm, $surveypro, $itemid=0, $evaluateparentcontent) {
+    public function __construct($cm, $surveypro, $itemid=0, $getparentcontent) {
         global $DB;
 
-        parent::__construct($cm, $surveypro, $itemid, $evaluateparentcontent);
+        parent::__construct($cm, $surveypro, $itemid, $getparentcontent);
 
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
@@ -238,7 +238,7 @@ class mod_surveypro_field_datetime extends mod_surveypro_itembase {
         // Empty list.
 
         if (!empty($itemid)) {
-            $this->item_load($itemid, $evaluateparentcontent);
+            $this->item_load($itemid, $getparentcontent);
         }
     }
 
@@ -246,12 +246,11 @@ class mod_surveypro_field_datetime extends mod_surveypro_itembase {
      * Item load.
      *
      * @param int $itemid
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      * @return void
      */
-    public function item_load($itemid, $evaluateparentcontent) {
-        // Do parent item loading stuff here (mod_surveypro_itembase::item_load($itemid, $evaluateparentcontent)))
-        parent::item_load($itemid, $evaluateparentcontent);
+    public function item_load($itemid, $getparentcontent) {
+        parent::item_load($itemid, $getparentcontent);
 
         // Multilang load support for builtin surveypro.
         // Whether executed, the 'content' field is ALWAYS handled.

--- a/field/fileupload/classes/plugin.class.php
+++ b/field/fileupload/classes/plugin.class.php
@@ -112,10 +112,10 @@ class mod_surveypro_field_fileupload extends mod_surveypro_itembase {
      * @param stdClass $cm
      * @param object $surveypro
      * @param int $itemid Optional item ID
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      */
-    public function __construct($cm, $surveypro, $itemid=0, $evaluateparentcontent) {
-        parent::__construct($cm, $surveypro, $itemid, $evaluateparentcontent);
+    public function __construct($cm, $surveypro, $itemid=0, $getparentcontent) {
+        parent::__construct($cm, $surveypro, $itemid, $getparentcontent);
 
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
@@ -133,7 +133,7 @@ class mod_surveypro_field_fileupload extends mod_surveypro_itembase {
         $this->insetupform['insearchform'] = false;
 
         if (!empty($itemid)) {
-            $this->item_load($itemid, $evaluateparentcontent);
+            $this->item_load($itemid, $getparentcontent);
         }
     }
 
@@ -141,12 +141,11 @@ class mod_surveypro_field_fileupload extends mod_surveypro_itembase {
      * Item load.
      *
      * @param int $itemid
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      * @return void
      */
-    public function item_load($itemid, $evaluateparentcontent) {
-        // Do parent item loading stuff here (mod_surveypro_itembase::item_load($itemid, $evaluateparentcontent)))
-        parent::item_load($itemid, $evaluateparentcontent);
+    public function item_load($itemid, $getparentcontent) {
+        parent::item_load($itemid, $getparentcontent);
 
         // Multilang load support for builtin surveypro.
         // Whether executed, the 'content' field is ALWAYS handled.

--- a/field/integer/classes/plugin.class.php
+++ b/field/integer/classes/plugin.class.php
@@ -117,10 +117,10 @@ class mod_surveypro_field_integer extends mod_surveypro_itembase {
      * @param stdClass $cm
      * @param object $surveypro
      * @param int $itemid Optional item ID
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      */
-    public function __construct($cm, $surveypro, $itemid=0, $evaluateparentcontent) {
-        parent::__construct($cm, $surveypro, $itemid, $evaluateparentcontent);
+    public function __construct($cm, $surveypro, $itemid=0, $getparentcontent) {
+        parent::__construct($cm, $surveypro, $itemid, $getparentcontent);
 
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
@@ -139,7 +139,7 @@ class mod_surveypro_field_integer extends mod_surveypro_itembase {
         // Empty list.
 
         if (!empty($itemid)) {
-            $this->item_load($itemid, $evaluateparentcontent);
+            $this->item_load($itemid, $getparentcontent);
         }
     }
 
@@ -147,12 +147,11 @@ class mod_surveypro_field_integer extends mod_surveypro_itembase {
      * Item load.
      *
      * @param int $itemid
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      * @return void
      */
-    public function item_load($itemid, $evaluateparentcontent) {
-        // Do parent item loading stuff here (mod_surveypro_itembase::item_load($itemid, $evaluateparentcontent)))
-        parent::item_load($itemid, $evaluateparentcontent);
+    public function item_load($itemid, $getparentcontent) {
+        parent::item_load($itemid, $getparentcontent);
 
         // Multilang load support for builtin surveypro.
         // Whether executed, the 'content' field is ALWAYS handled.

--- a/field/multiselect/classes/plugin.class.php
+++ b/field/multiselect/classes/plugin.class.php
@@ -122,10 +122,10 @@ class mod_surveypro_field_multiselect extends mod_surveypro_itembase {
      * @param stdClass $cm
      * @param object $surveypro
      * @param int $itemid Optional item ID
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      */
-    public function __construct($cm, $surveypro, $itemid=0, $evaluateparentcontent) {
-        parent::__construct($cm, $surveypro, $itemid, $evaluateparentcontent);
+    public function __construct($cm, $surveypro, $itemid=0, $getparentcontent) {
+        parent::__construct($cm, $surveypro, $itemid, $getparentcontent);
 
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
@@ -143,7 +143,7 @@ class mod_surveypro_field_multiselect extends mod_surveypro_itembase {
         // Empty list.
 
         if (!empty($itemid)) {
-            $this->item_load($itemid, $evaluateparentcontent);
+            $this->item_load($itemid, $getparentcontent);
         }
     }
 
@@ -151,12 +151,11 @@ class mod_surveypro_field_multiselect extends mod_surveypro_itembase {
      * Item load.
      *
      * @param int $itemid
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      * @return void
      */
-    public function item_load($itemid, $evaluateparentcontent) {
-        // Do parent item loading stuff here (mod_surveypro_itembase::item_load($itemid, $evaluateparentcontent)))
-        parent::item_load($itemid, $evaluateparentcontent);
+    public function item_load($itemid, $getparentcontent) {
+        parent::item_load($itemid, $getparentcontent);
 
         // Multilang load support for builtin surveypro.
         // Whether executed, the 'content' field is ALWAYS handled.

--- a/field/numeric/classes/plugin.class.php
+++ b/field/numeric/classes/plugin.class.php
@@ -132,10 +132,10 @@ class mod_surveypro_field_numeric extends mod_surveypro_itembase {
      * @param stdClass $cm
      * @param object $surveypro
      * @param int $itemid Optional item ID
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      */
-    public function __construct($cm, $surveypro, $itemid=0, $evaluateparentcontent) {
-        parent::__construct($cm, $surveypro, $itemid, $evaluateparentcontent);
+    public function __construct($cm, $surveypro, $itemid=0, $getparentcontent) {
+        parent::__construct($cm, $surveypro, $itemid, $getparentcontent);
 
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
@@ -153,7 +153,7 @@ class mod_surveypro_field_numeric extends mod_surveypro_itembase {
         // Empty list.
 
         if (!empty($itemid)) {
-            $this->item_load($itemid, $evaluateparentcontent);
+            $this->item_load($itemid, $getparentcontent);
         }
     }
 
@@ -161,12 +161,11 @@ class mod_surveypro_field_numeric extends mod_surveypro_itembase {
      * Item load.
      *
      * @param int $itemid
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      * @return void
      */
-    public function item_load($itemid, $evaluateparentcontent) {
-        // Do parent item loading stuff here (mod_surveypro_itembase::item_load($itemid, $evaluateparentcontent)))
-        parent::item_load($itemid, $evaluateparentcontent);
+    public function item_load($itemid, $getparentcontent) {
+        parent::item_load($itemid, $getparentcontent);
 
         // Multilang load support for builtin surveypro.
         // Whether executed, the 'content' field is ALWAYS handled.

--- a/field/radiobutton/classes/plugin.class.php
+++ b/field/radiobutton/classes/plugin.class.php
@@ -127,10 +127,10 @@ class mod_surveypro_field_radiobutton extends mod_surveypro_itembase {
      * @param stdClass $cm
      * @param object $surveypro
      * @param int $itemid Optional item ID
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      */
-    public function __construct($cm, $surveypro, $itemid=0, $evaluateparentcontent) {
-        parent::__construct($cm, $surveypro, $itemid, $evaluateparentcontent);
+    public function __construct($cm, $surveypro, $itemid=0, $getparentcontent) {
+        parent::__construct($cm, $surveypro, $itemid, $getparentcontent);
 
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
@@ -148,7 +148,7 @@ class mod_surveypro_field_radiobutton extends mod_surveypro_itembase {
         $this->insetupform['hideinstructions'] = false;
 
         if (!empty($itemid)) {
-            $this->item_load($itemid, $evaluateparentcontent);
+            $this->item_load($itemid, $getparentcontent);
         }
     }
 
@@ -156,12 +156,11 @@ class mod_surveypro_field_radiobutton extends mod_surveypro_itembase {
      * Item load.
      *
      * @param int $itemid
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      * @return void
      */
-    public function item_load($itemid, $evaluateparentcontent) {
-        // Do parent item loading stuff here (mod_surveypro_itembase::item_load($itemid, $evaluateparentcontent)))
-        parent::item_load($itemid, $evaluateparentcontent);
+    public function item_load($itemid, $getparentcontent) {
+        parent::item_load($itemid, $getparentcontent);
 
         // Multilang load support for builtin surveypro.
         // Whether executed, the 'content' field is ALWAYS handled.

--- a/field/rate/classes/plugin.class.php
+++ b/field/rate/classes/plugin.class.php
@@ -137,10 +137,10 @@ class mod_surveypro_field_rate extends mod_surveypro_itembase {
      * @param stdClass $cm
      * @param object $surveypro
      * @param int $itemid Optional item ID
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      */
-    public function __construct($cm, $surveypro, $itemid=0, $evaluateparentcontent) {
-        parent::__construct($cm, $surveypro, $itemid, $evaluateparentcontent);
+    public function __construct($cm, $surveypro, $itemid=0, $getparentcontent) {
+        parent::__construct($cm, $surveypro, $itemid, $getparentcontent);
 
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
@@ -159,7 +159,7 @@ class mod_surveypro_field_rate extends mod_surveypro_itembase {
         $this->insetupform['position'] = SURVEYPRO_POSITIONLEFT;
 
         if (!empty($itemid)) {
-            $this->item_load($itemid, $evaluateparentcontent);
+            $this->item_load($itemid, $getparentcontent);
         }
     }
 
@@ -167,12 +167,11 @@ class mod_surveypro_field_rate extends mod_surveypro_itembase {
      * Item load.
      *
      * @param int $itemid
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      * @return void
      */
-    public function item_load($itemid, $evaluateparentcontent) {
-        // Do parent item loading stuff here (mod_surveypro_itembase::item_load($itemid, $evaluateparentcontent)))
-        parent::item_load($itemid, $evaluateparentcontent);
+    public function item_load($itemid, $getparentcontent) {
+        parent::item_load($itemid, $getparentcontent);
 
         // Multilang load support for builtin surveypro.
         // Whether executed, the 'content' field is ALWAYS handled.

--- a/field/recurrence/classes/plugin.class.php
+++ b/field/recurrence/classes/plugin.class.php
@@ -157,10 +157,10 @@ class mod_surveypro_field_recurrence extends mod_surveypro_itembase {
      * @param stdClass $cm
      * @param object $surveypro
      * @param int $itemid Optional item ID
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      */
-    public function __construct($cm, $surveypro, $itemid=0, $evaluateparentcontent) {
-        parent::__construct($cm, $surveypro, $itemid, $evaluateparentcontent);
+    public function __construct($cm, $surveypro, $itemid=0, $getparentcontent) {
+        parent::__construct($cm, $surveypro, $itemid, $getparentcontent);
 
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
@@ -180,7 +180,7 @@ class mod_surveypro_field_recurrence extends mod_surveypro_itembase {
         // Empty list.
 
         if (!empty($itemid)) {
-            $this->item_load($itemid, $evaluateparentcontent);
+            $this->item_load($itemid, $getparentcontent);
         }
     }
 
@@ -188,12 +188,11 @@ class mod_surveypro_field_recurrence extends mod_surveypro_itembase {
      * Item load.
      *
      * @param int $itemid
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      * @return void
      */
-    public function item_load($itemid, $evaluateparentcontent) {
-        // Do parent item loading stuff here (mod_surveypro_itembase::item_load($itemid, $evaluateparentcontent)))
-        parent::item_load($itemid, $evaluateparentcontent);
+    public function item_load($itemid, $getparentcontent) {
+        parent::item_load($itemid, $getparentcontent);
 
         // Multilang load support for builtin surveypro.
         // Whether executed, the 'content' field is ALWAYS handled.

--- a/field/select/classes/plugin.class.php
+++ b/field/select/classes/plugin.class.php
@@ -122,10 +122,10 @@ class mod_surveypro_field_select extends mod_surveypro_itembase {
      * @param stdClass $cm
      * @param object $surveypro
      * @param int $itemid Optional item ID
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      */
-    public function __construct($cm, $surveypro, $itemid=0, $evaluateparentcontent) {
-        parent::__construct($cm, $surveypro, $itemid, $evaluateparentcontent);
+    public function __construct($cm, $surveypro, $itemid=0, $getparentcontent) {
+        parent::__construct($cm, $surveypro, $itemid, $getparentcontent);
 
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
@@ -143,7 +143,7 @@ class mod_surveypro_field_select extends mod_surveypro_itembase {
         $this->insetupform['hideinstructions'] = false;
 
         if (!empty($itemid)) {
-            $this->item_load($itemid, $evaluateparentcontent);
+            $this->item_load($itemid, $getparentcontent);
         }
     }
 
@@ -151,12 +151,11 @@ class mod_surveypro_field_select extends mod_surveypro_itembase {
      * Item load.
      *
      * @param int $itemid
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      * @return void
      */
-    public function item_load($itemid, $evaluateparentcontent) {
-        // Do parent item loading stuff here (mod_surveypro_itembase::item_load($itemid, $evaluateparentcontent)))
-        parent::item_load($itemid, $evaluateparentcontent);
+    public function item_load($itemid, $getparentcontent) {
+        parent::item_load($itemid, $getparentcontent);
 
         // Multilang load support for builtin surveypro.
         // Whether executed, the 'content' field is ALWAYS handled.

--- a/field/shortdate/classes/plugin.class.php
+++ b/field/shortdate/classes/plugin.class.php
@@ -162,12 +162,12 @@ class mod_surveypro_field_shortdate extends mod_surveypro_itembase {
      * @param stdClass $cm
      * @param object $surveypro
      * @param int $itemid Optional item ID
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      */
-    public function __construct($cm, $surveypro, $itemid=0, $evaluateparentcontent) {
+    public function __construct($cm, $surveypro, $itemid=0, $getparentcontent) {
         global $DB;
 
-        parent::__construct($cm, $surveypro, $itemid, $evaluateparentcontent);
+        parent::__construct($cm, $surveypro, $itemid, $getparentcontent);
 
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
@@ -189,7 +189,7 @@ class mod_surveypro_field_shortdate extends mod_surveypro_itembase {
         // Empty list.
 
         if (!empty($itemid)) {
-            $this->item_load($itemid, $evaluateparentcontent);
+            $this->item_load($itemid, $getparentcontent);
         }
     }
 
@@ -197,12 +197,11 @@ class mod_surveypro_field_shortdate extends mod_surveypro_itembase {
      * Item load.
      *
      * @param int $itemid
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      * @return void
      */
-    public function item_load($itemid, $evaluateparentcontent) {
-        // Do parent item loading stuff here (mod_surveypro_itembase::item_load($itemid, $evaluateparentcontent)))
-        parent::item_load($itemid, $evaluateparentcontent);
+    public function item_load($itemid, $getparentcontent) {
+        parent::item_load($itemid, $getparentcontent);
 
         // Multilang load support for builtin surveypro.
         // Whether executed, the 'content' field is ALWAYS handled.

--- a/field/textarea/classes/plugin.class.php
+++ b/field/textarea/classes/plugin.class.php
@@ -127,10 +127,10 @@ class mod_surveypro_field_textarea extends mod_surveypro_itembase {
      * @param stdClass $cm
      * @param object $surveypro
      * @param int $itemid Optional item ID
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      */
-    public function __construct($cm, $surveypro, $itemid=0, $evaluateparentcontent) {
-        parent::__construct($cm, $surveypro, $itemid, $evaluateparentcontent);
+    public function __construct($cm, $surveypro, $itemid=0, $getparentcontent) {
+        parent::__construct($cm, $surveypro, $itemid, $getparentcontent);
 
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
@@ -148,7 +148,7 @@ class mod_surveypro_field_textarea extends mod_surveypro_itembase {
         $this->insetupform['insearchform'] = false;
 
         if (!empty($itemid)) {
-            $this->item_load($itemid, $evaluateparentcontent);
+            $this->item_load($itemid, $getparentcontent);
         }
     }
 
@@ -156,12 +156,11 @@ class mod_surveypro_field_textarea extends mod_surveypro_itembase {
      * Item load.
      *
      * @param int $itemid
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      * @return void
      */
-    public function item_load($itemid, $evaluateparentcontent) {
-        // Do parent item loading stuff here (mod_surveypro_itembase::item_load($itemid, $evaluateparentcontent)))
-        parent::item_load($itemid, $evaluateparentcontent);
+    public function item_load($itemid, $getparentcontent) {
+        parent::item_load($itemid, $getparentcontent);
 
         // Multilang load support for builtin surveypro.
         // Whether executed, the 'content' field is ALWAYS handled.

--- a/field/time/classes/plugin.class.php
+++ b/field/time/classes/plugin.class.php
@@ -162,10 +162,10 @@ class mod_surveypro_field_time extends mod_surveypro_itembase {
      * @param stdClass $cm
      * @param object $surveypro
      * @param int $itemid Optional item ID
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      */
-    public function __construct($cm, $surveypro, $itemid=0, $evaluateparentcontent) {
-        parent::__construct($cm, $surveypro, $itemid, $evaluateparentcontent);
+    public function __construct($cm, $surveypro, $itemid=0, $getparentcontent) {
+        parent::__construct($cm, $surveypro, $itemid, $getparentcontent);
 
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
@@ -183,7 +183,7 @@ class mod_surveypro_field_time extends mod_surveypro_itembase {
         // Empty list.
 
         if (!empty($itemid)) {
-            $this->item_load($itemid, $evaluateparentcontent);
+            $this->item_load($itemid, $getparentcontent);
         }
     }
 
@@ -191,12 +191,11 @@ class mod_surveypro_field_time extends mod_surveypro_itembase {
      * Item load.
      *
      * @param int $itemid
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      * @return void
      */
-    public function item_load($itemid, $evaluateparentcontent) {
-        // Do parent item loading stuff here (mod_surveypro_itembase::item_load($itemid, $evaluateparentcontent)))
-        parent::item_load($itemid, $evaluateparentcontent);
+    public function item_load($itemid, $getparentcontent) {
+        parent::item_load($itemid, $getparentcontent);
 
         // Multilang load support for builtin surveypro.
         // Whether executed, the 'content' field is ALWAYS handled.

--- a/format/fieldset/classes/plugin.class.php
+++ b/format/fieldset/classes/plugin.class.php
@@ -55,10 +55,10 @@ class mod_surveypro_format_fieldset extends mod_surveypro_itembase {
      * @param stdClass $cm
      * @param object $surveypro
      * @param int $itemid Optional item ID
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      */
-    public function __construct($cm, $surveypro, $itemid=0, $evaluateparentcontent) {
-        parent::__construct($cm, $surveypro, $itemid, $evaluateparentcontent);
+    public function __construct($cm, $surveypro, $itemid=0, $getparentcontent) {
+        parent::__construct($cm, $surveypro, $itemid, $getparentcontent);
 
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFORMAT;
@@ -82,7 +82,7 @@ class mod_surveypro_format_fieldset extends mod_surveypro_itembase {
         $this->insetupform['hideinstructions'] = false;
 
         if (!empty($itemid)) {
-            $this->item_load($itemid, $evaluateparentcontent);
+            $this->item_load($itemid, $getparentcontent);
         }
     }
 
@@ -90,12 +90,11 @@ class mod_surveypro_format_fieldset extends mod_surveypro_itembase {
      * Item load.
      *
      * @param int $itemid
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      * @return void
      */
-    public function item_load($itemid, $evaluateparentcontent) {
-        // Do parent item loading stuff here (mod_surveypro_itembase::item_load($itemid, $evaluateparentcontent)))
-        parent::item_load($itemid, $evaluateparentcontent);
+    public function item_load($itemid, $getparentcontent) {
+        parent::item_load($itemid, $getparentcontent);
 
         // Multilang load support for builtin surveypro.
         // Whether executed, the 'content' field is ALWAYS handled.

--- a/format/fieldsetend/classes/plugin.class.php
+++ b/format/fieldsetend/classes/plugin.class.php
@@ -50,10 +50,10 @@ class mod_surveypro_format_fieldsetend extends mod_surveypro_itembase {
      * @param stdClass $cm
      * @param object $surveypro
      * @param int $itemid Optional item ID
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      */
-    public function __construct($cm, $surveypro, $itemid=0, $evaluateparentcontent) {
-        parent::__construct($cm, $surveypro, $itemid, $evaluateparentcontent);
+    public function __construct($cm, $surveypro, $itemid=0, $getparentcontent) {
+        parent::__construct($cm, $surveypro, $itemid, $getparentcontent);
 
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFORMAT;
@@ -79,7 +79,7 @@ class mod_surveypro_format_fieldsetend extends mod_surveypro_itembase {
         $this->insetupform['hideinstructions'] = false;
 
         if (!empty($itemid)) {
-            $this->item_load($itemid, $evaluateparentcontent);
+            $this->item_load($itemid, $getparentcontent);
         }
     }
 
@@ -87,12 +87,11 @@ class mod_surveypro_format_fieldsetend extends mod_surveypro_itembase {
      * Item load.
      *
      * @param int $itemid
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      * @return void
      */
-    public function item_load($itemid, $evaluateparentcontent) {
-        // Do parent item loading stuff here (mod_surveypro_itembase::item_load($itemid, $evaluateparentcontent)))
-        parent::item_load($itemid, $evaluateparentcontent);
+    public function item_load($itemid, $getparentcontent) {
+        parent::item_load($itemid, $getparentcontent);
     }
 
     /**

--- a/format/label/classes/plugin.class.php
+++ b/format/label/classes/plugin.class.php
@@ -82,10 +82,10 @@ class mod_surveypro_format_label extends mod_surveypro_itembase {
      * @param stdClass $cm
      * @param object $surveypro
      * @param int $itemid Optional item ID
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      */
-    public function __construct($cm, $surveypro, $itemid=0, $evaluateparentcontent) {
-        parent::__construct($cm, $surveypro, $itemid, $evaluateparentcontent);
+    public function __construct($cm, $surveypro, $itemid=0, $getparentcontent) {
+        parent::__construct($cm, $surveypro, $itemid, $getparentcontent);
 
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFORMAT;
@@ -107,7 +107,7 @@ class mod_surveypro_format_label extends mod_surveypro_itembase {
         $this->insetupform['hideinstructions'] = false;
 
         if (!empty($itemid)) {
-            $this->item_load($itemid, $evaluateparentcontent);
+            $this->item_load($itemid, $getparentcontent);
         }
     }
 
@@ -115,12 +115,11 @@ class mod_surveypro_format_label extends mod_surveypro_itembase {
      * Item load.
      *
      * @param int $itemid
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      * @return void
      */
-    public function item_load($itemid, $evaluateparentcontent) {
-        // Do parent item loading stuff here (mod_surveypro_itembase::item_load($itemid, $evaluateparentcontent)))
-        parent::item_load($itemid, $evaluateparentcontent);
+    public function item_load($itemid, $getparentcontent) {
+        parent::item_load($itemid, $getparentcontent);
 
         // Multilang load support for builtin surveypro.
         // Whether executed, the 'content' field is ALWAYS handled.

--- a/format/pagebreak/classes/plugin.class.php
+++ b/format/pagebreak/classes/plugin.class.php
@@ -50,10 +50,10 @@ class mod_surveypro_format_pagebreak extends mod_surveypro_itembase {
      * @param stdClass $cm
      * @param object $surveypro
      * @param int $itemid Optional item ID
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      */
-    public function __construct($cm, $surveypro, $itemid=0, $evaluateparentcontent) {
-        parent::__construct($cm, $surveypro, $itemid, $evaluateparentcontent);
+    public function __construct($cm, $surveypro, $itemid=0, $getparentcontent) {
+        parent::__construct($cm, $surveypro, $itemid, $getparentcontent);
 
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFORMAT;
@@ -82,7 +82,7 @@ class mod_surveypro_format_pagebreak extends mod_surveypro_itembase {
         $this->insetupform['parentid'] = false;
 
         if (!empty($itemid)) {
-            $this->item_load($itemid, $evaluateparentcontent);
+            $this->item_load($itemid, $getparentcontent);
         }
     }
 
@@ -90,12 +90,11 @@ class mod_surveypro_format_pagebreak extends mod_surveypro_itembase {
      * Item load.
      *
      * @param int $itemid
-     * @param bool $evaluateparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
+     * @param bool $getparentcontent True to include $item->parentcontent (as decoded by the parent item) too, false otherwise
      * @return void
      */
-    public function item_load($itemid, $evaluateparentcontent) {
-        // Do parent item loading stuff here (mod_surveypro_itembase::item_load($itemid, $evaluateparentcontent)))
-        parent::item_load($itemid, $evaluateparentcontent);
+    public function item_load($itemid, $getparentcontent) {
+        parent::item_load($itemid, $getparentcontent);
     }
 
     /**

--- a/locallib.php
+++ b/locallib.php
@@ -37,10 +37,10 @@ require_once($CFG->dirroot.'/mod/surveypro/lib.php');
  * @param int $itemid
  * @param string $type
  * @param string $plugin
- * @param bool $evaluateparentcontent
+ * @param bool $getparentcontent
  * @return $item object
  */
-function surveypro_get_item($cm, $surveypro, $itemid=0, $type='', $plugin='', $evaluateparentcontent=false) {
+function surveypro_get_item($cm, $surveypro, $itemid=0, $type='', $plugin='', $getparentcontent=false) {
     global $CFG, $DB;
 
     if (!empty($itemid)) {
@@ -74,7 +74,7 @@ function surveypro_get_item($cm, $surveypro, $itemid=0, $type='', $plugin='', $e
 
     require_once($CFG->dirroot.'/mod/surveypro/'.$type.'/'.$plugin.'/classes/plugin.class.php');
     $itemclassname = 'mod_surveypro_'.$type.'_'.$plugin;
-    $item = new $itemclassname($cm, $surveypro, $itemid, $evaluateparentcontent);
+    $item = new $itemclassname($cm, $surveypro, $itemid, $getparentcontent);
 
     return $item;
 }


### PR DESCRIPTION
Really silly code clean to fulfill:
Avoid excessively long variable names like $evaluateparentcontent. Keep variable name length under 20.