### PR TITLE
NOBUG: Delete phpcs remaining error (2 blank lines)

### DIFF
--- a/classes/view_submissions.class.php
+++ b/classes/view_submissions.class.php
@@ -579,7 +579,6 @@ class mod_surveypro_submissionmanager {
                 // Add row to the table.
                 $table->add_data($tablerow);
 
-
                 // Before looping, gather information for the "Submission overview".
                 if ($submission->status == SURVEYPRO_STATUSCLOSED) {
                     $countclosed++;


### PR DESCRIPTION
Not much to say, just it seems to be the unique remaining phpcs error in the module, heading to get it passing (apart from warnings).