### PR TITLE
CONTRIB-6268 mod_surveypro: added static styles per each item

### DIFF
--- a/classes/formbase.class.php
+++ b/classes/formbase.class.php
@@ -171,8 +171,8 @@ class mod_surveypro_formbase {
     public function warning_submission_copy() {
         global $OUTPUT;
 
-        if (!empty($this->surveypro->history)) {
-            echo $OUTPUT->notification('editingcopy', 'notifyproblem');
+        if ( (!empty($this->surveypro->history)) && (!empty($this->submissionid)) ) {
+            echo $OUTPUT->notification(get_string('editingcopy', 'mod_surveypro'), 'notifyproblem');
         }
     }
 

--- a/field/age/classes/plugin.class.php
+++ b/field/age/classes/plugin.class.php
@@ -462,13 +462,26 @@ EOS;
 
         // Begin of: mform element.
         $elementgroup = array();
-        $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_year', '', $years, array('class' => 'indent-'.$this->indent, 'id' => $idprefix.'_year'));
+        $attributes = array();
+
+        $attributes['id'] = $idprefix.'_year';
+        $attributes['class'] = 'indent-'.$this->indent.' age_select';
+        $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_year', '', $years, $attributes);
+
         if ($readonly) {
-            $elementgroup[] = $mform->createElement('mod_surveypro_static', 'yearlabel_'.$this->itemid, null, get_string('years'), array('class' => 'inline'));
+            $attributes['id'] = $idprefix.'_yearseparator';
+            $attributes['class'] = 'inline age_static';
+            $elementgroup[] = $mform->createElement('mod_surveypro_static', 'yearlabel_'.$this->itemid, null, get_string('years'), $attributes);
         }
-        $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_month', '', $months, array('id' => $idprefix.'_month'));
+
+        $attributes['id'] = $idprefix.'_month';
+        $attributes['class'] = 'age_select';
+        $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_month', '', $months, $attributes);
+
         if ($readonly) {
-            $elementgroup[] = $mform->createElement('mod_surveypro_static', 'monthlabel_'.$this->itemid, null, get_string('months', 'mod_surveypro'), array('class' => 'inline'));
+            $attributes['id'] = $idprefix.'_monthseparator';
+            $attributes['class'] = 'inline age_static';
+            $elementgroup[] = $mform->createElement('mod_surveypro_static', 'monthlabel_'.$this->itemid, null, get_string('months', 'mod_surveypro'), $attributes);
         }
 
         if ($this->required) {
@@ -483,7 +496,8 @@ EOS;
                 $mform->_required[] = $starplace;
             }
         } else {
-            $attributes = array('id' => $idprefix.'_noanswer');
+            $attributes['id'] = $idprefix.'_noanswer';
+            $attributes['class'] = 'age_check';
             $elementgroup[] = $mform->createElement('mod_surveypro_checkbox', $this->itemname.'_noanswer', '', get_string('noanswer', 'mod_surveypro'), $attributes);
             $mform->addGroup($elementgroup, $this->itemname.'_group', $elementlabel, ' ', false);
             $mform->disabledIf($this->itemname.'_group', $this->itemname.'_noanswer', 'checked');

--- a/field/autofill/classes/plugin.class.php
+++ b/field/autofill/classes/plugin.class.php
@@ -410,6 +410,8 @@ EOS;
         $elementnumber = $this->customnumber ? $this->customnumber.$labelsep : '';
         $elementlabel = ($this->position == SURVEYPRO_POSITIONLEFT) ? $elementnumber.strip_tags($this->get_content()) : '&nbsp;';
 
+        $idprefix = 'id_surveypro_field_autofill_'.$this->sortindex;
+
         if (!$searchform) {
             // At this level I ALWAYS write the content as if the record is new.
             // If the record is not new, this value will be overwritten later at default apply time.
@@ -420,15 +422,26 @@ EOS;
             $mform->setDefault($this->itemname, $value);
 
             if (!$this->hiddenfield) {
-                $attributes = array('class' => 'indent-'.$this->indent, 'disabled' => 'disabled');
+                $attributes = array();
+                $attributes['id'] = $idprefix;
+                $attributes['class'] = 'indent-'.$this->indent.' autofill_text';
+                $attributes['disabled'] = 'disabled';
                 $mform->addElement('text', $this->itemname.'_static', $elementlabel, $attributes);
                 $mform->setType($this->itemname.'_static', PARAM_RAW);
                 $mform->setDefault($this->itemname.'_static', $value);
             }
         } else {
+            $attributes = array();
             $elementgroup = array();
-            $elementgroup[] = $mform->createElement('text', $this->itemname, '', array('class' => 'indent-'.$this->indent));
-            $elementgroup[] = $mform->createElement('mod_surveypro_checkbox', $this->itemname.'_ignoreme', '', get_string('star', 'mod_surveypro'));
+
+            $attributes['id'] = $idprefix;
+            $attributes['class'] = 'indent-'.$this->indent.' autofill_text';
+            $elementgroup[] = $mform->createElement('text', $this->itemname, '', $attributes);
+
+            $attributes['id'] = $idprefix.'_ignoreme';
+            $attributes['class'] = 'autofill_check';
+            $elementgroup[] = $mform->createElement('mod_surveypro_checkbox', $this->itemname.'_ignoreme', '', get_string('star', 'mod_surveypro'), $attributes);
+
             $mform->setType($this->itemname, PARAM_RAW);
             $mform->addGroup($elementgroup, $this->itemname.'_group', $elementlabel, ' ', false);
             $mform->disabledIf($this->itemname.'_group', $this->itemname.'_ignoreme', 'checked');

--- a/field/boolean/classes/plugin.class.php
+++ b/field/boolean/classes/plugin.class.php
@@ -471,6 +471,9 @@ EOS;
         $yeslabel = get_string('yes');
         $nolabel = get_string('no');
 
+        $attributes = array();
+        $attributes['class'] = 'indent-'.$this->indent.' boolean_radio';
+
         if ($this->style == SURVEYPROFIELD_BOOLEAN_USESELECT) {
             // Begin of: element values.
             $options = array();
@@ -499,28 +502,27 @@ EOS;
                     $mform->_required[] = $starplace;
                 }
             }
-            $mform->addElement('mod_surveypro_select', $this->itemname, $elementlabel, $options, array('class' => 'indent-'.$this->indent, 'id' => $idprefix));
+            $attributes['id'] = $idprefix;
+            $mform->addElement('mod_surveypro_select', $this->itemname, $elementlabel, $options, $attributes);
             // End of: mform element.
         } else { // SURVEYPROFIELD_BOOLEAN_USERADIOV or SURVEYPROFIELD_BOOLEAN_USERADIOH.
             $separator = ($this->style == SURVEYPROFIELD_BOOLEAN_USERADIOV) ? '<br />' : ' ';
             $elementgroup = array();
 
             // Begin of: mform element.
-            $attributes = array('class' => 'indent-'.$this->indent);
-
             if (!$searchform) {
                 if ($this->defaultoption == SURVEYPRO_INVITEDEFAULT) {
                     $attributes['id'] = $idprefix.'_invite';
                     $elementgroup[] = $mform->createElement('mod_surveypro_radio', $this->itemname, '', get_string('choosedots'), SURVEYPRO_INVITEVALUE, $attributes);
                     if ($this->style == SURVEYPROFIELD_BOOLEAN_USERADIOH) {
-                        unset($attributes['class']);
+                        $attributes['class'] = 'boolean_radio';
                     }
                 }
             } else {
                 $attributes['id'] = $idprefix.'_ignoreme';
                 $elementgroup[] = $mform->createElement('mod_surveypro_radio', $this->itemname, '', get_string('star', 'mod_surveypro'), SURVEYPRO_IGNOREMEVALUE, $attributes);
                 if ($this->style == SURVEYPROFIELD_BOOLEAN_USERADIOH) {
-                    unset($attributes['class']);
+                    $attributes['class'] = 'boolean_radio';
                 }
             }
 
@@ -528,7 +530,7 @@ EOS;
             $elementgroup[] = $mform->createElement('mod_surveypro_radio', $this->itemname, '', $yeslabel, '1', $attributes);
 
             if ($this->style == SURVEYPROFIELD_BOOLEAN_USERADIOH) {
-                unset($attributes['class']);
+                $attributes['class'] = 'boolean_radio';
             }
 
             $attributes['id'] = $idprefix.'_0';

--- a/field/character/classes/plugin.class.php
+++ b/field/character/classes/plugin.class.php
@@ -390,7 +390,9 @@ EOS;
 
         $thresholdsize = 37;
         $lengthtochar = 1.3;
-        $attributes = array('class' => 'indent-'.$this->indent, 'id' => $idprefix);
+        $attributes = array();
+        $attributes['id'] = $idprefix;
+        $attributes['class'] = 'indent-'.$this->indent.' character_text';
         if (!empty($this->maxlength)) {
             $attributes['maxlength'] = $this->maxlength;
             if ($this->maxlength < $thresholdsize) {
@@ -416,11 +418,10 @@ EOS;
             }
         } else {
             $elementgroup = array();
-            $attributes['id'] = $idprefix.'_text';
             $elementgroup[] = $mform->createElement('text', $this->itemname, '', $attributes);
 
-            unset($attributes['class']);
             $attributes['id'] = $idprefix.'_ignoreme';
+            $attributes['class'] = 'character_text';
             $elementgroup[] = $mform->createElement('mod_surveypro_checkbox', $this->itemname.'_ignoreme', '', get_string('star', 'mod_surveypro'), $attributes);
             $mform->setType($this->itemname, PARAM_RAW);
 

--- a/field/checkbox/classes/plugin.class.php
+++ b/field/checkbox/classes/plugin.class.php
@@ -486,7 +486,9 @@ EOS;
         $labels = $this->item_get_content_array(SURVEYPRO_LABELS, 'options');
         $defaults = surveypro_multilinetext_to_array($this->defaultvalue);
 
-        $attributes = array('class' => 'indent-'.$this->indent, 'group' => 1);
+        $attributes = array();
+        $attributes['class'] = 'indent-'.$this->indent.' checkbox_check';
+        $attributes['group'] = 1;
 
         $elementgroup = array();
         $i = 0;
@@ -496,7 +498,7 @@ EOS;
             $elementgroup[] = $mform->createElement('mod_surveypro_advcheckbox', $uniqueid, '', $label, $attributes, array('0', '1'));
 
             if ($this->adjustment == SURVEYPRO_HORIZONTAL) {
-                unset($attributes['class']);
+                $attributes['class'] = 'checkbox_check';
             }
 
             if (!$searchform) {
@@ -527,7 +529,6 @@ EOS;
         }
 
         if (!$this->required) {
-            $attributes['group'] = 1;
             $attributes['id'] = $idprefix.'_noanswer';
             $options = array('0', '1');
             $elementgroup[] = $mform->createElement('mod_surveypro_advcheckbox', $this->itemname.'_noanswer', '', get_string('noanswer', 'surveypro'), $attributes, $options);

--- a/field/date/classes/plugin.class.php
+++ b/field/date/classes/plugin.class.php
@@ -513,10 +513,19 @@ EOS;
         // End of: element values.
 
         // Begin of: mform element.
+        $attributes = array();
         $elementgroup = array();
-        $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_day', '', $days, array('class' => 'indent-'.$this->indent, 'id' => $idprefix.'_day'));
-        $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_month', '', $months, array('id' => $idprefix.'_month'));
-        $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_year', '', $years, array('id' => $idprefix.'_year'));
+
+        $attributes['id'] = $idprefix.'_day';
+        $attributes['class'] = 'indent-'.$this->indent.' date_select';
+        $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_day', '', $days, $attributes);
+
+        $attributes['id'] = $idprefix.'_month';
+        $attributes['class'] = 'date_select';
+        $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_month', '', $months, $attributes);
+
+        $attributes['id'] = $idprefix.'_year';
+        $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_year', '', $years, $attributes);
 
         if ($this->required) {
             $mform->addGroup($elementgroup, $this->itemname.'_group', $elementlabel, ' ', false);
@@ -530,7 +539,8 @@ EOS;
                 $mform->_required[] = $starplace;
             }
         } else {
-            $attributes = array('id' => $idprefix.'_noanswer');
+            $attributes['id'] = $idprefix.'_noanswer';
+            $attributes['class'] = 'date_check';
             $elementgroup[] = $mform->createElement('mod_surveypro_checkbox', $this->itemname.'_noanswer', '', get_string('noanswer', 'mod_surveypro'), $attributes);
             $mform->addGroup($elementgroup, $this->itemname.'_group', $elementlabel, ' ', false);
             $mform->disabledIf($this->itemname.'_group', $this->itemname.'_noanswer', 'checked');

--- a/field/datetime/classes/plugin.class.php
+++ b/field/datetime/classes/plugin.class.php
@@ -572,12 +572,25 @@ EOS;
         // End of: element values.
 
         // Begin of: mform element.
+        $attributes = array();
         $elementgroup = array();
-        $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_day', '', $days, array('class' => 'indent-'.$this->indent, 'id' => $idprefix.'_day'));
-        $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_month', '', $months, array('id' => $idprefix.'_month'));
-        $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_year', '', $years, array('id' => $idprefix.'_year'));
-        $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_hour', '', $hours, array('id' => $idprefix.'_hour'));
-        $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_minute', '', $minutes, array('id' => $idprefix.'_minute'));
+
+        $attributes['id'] = $idprefix.'_day';
+        $attributes['class'] = 'indent-'.$this->indent.' datetime_select';
+        $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_day', '', $days, $attributes);
+
+        $attributes['id'] = $idprefix.'_month';
+        $attributes['class'] = 'datetime_select';
+        $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_month', '', $months, $attributes);
+
+        $attributes['id'] = $idprefix.'_year';
+        $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_year', '', $years, $attributes);
+
+        $attributes['id'] = $idprefix.'_hour';
+        $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_hour', '', $hours, $attributes);
+
+        $attributes['id'] = $idprefix.'_minute';
+        $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_minute', '', $minutes, $attributes);
 
         $separator = array(' ', ' ', ', ', ':');
         if ($this->required) {
@@ -592,7 +605,8 @@ EOS;
                 $mform->_required[] = $starplace;
             }
         } else {
-            $attributes = array('id' => $idprefix.'_noanswer');
+            $attributes['id'] = $idprefix.'_noanswer';
+            $attributes['class'] = 'datetime_check';
             $elementgroup[] = $mform->createElement('mod_surveypro_checkbox', $this->itemname.'_noanswer', '', get_string('noanswer', 'mod_surveypro'), $attributes);
             $separator[] = ' ';
             $mform->addGroup($elementgroup, $this->itemname.'_group', $elementlabel, $separator, false);

--- a/field/fileupload/classes/plugin.class.php
+++ b/field/fileupload/classes/plugin.class.php
@@ -297,12 +297,12 @@ EOS;
         $filetypes = array_map('trim', explode(',', $this->filetypes));
 
         $attributes = array();
+        $attributes['id'] = $idprefix;
+        $attributes['class'] = 'indent-'.$this->indent.' fileupload_filemanager'; // Does not work: MDL-28194.
         $attributes['maxbytes'] = $this->maxbytes;
         $attributes['accepted_types'] = $filetypes;
         $attributes['subdirs'] = false;
         $attributes['maxfiles'] = $this->maxfiles;
-        $attributes['id'] = $idprefix;
-        $attributes['class'] = 'indent-'.$this->indent; // Does not work: MDL-28194.
         $mform->addElement('mod_surveypro_filemanager', $fieldname, $elementlabel, null, $attributes);
 
         if ($this->required) {

--- a/field/integer/classes/plugin.class.php
+++ b/field/integer/classes/plugin.class.php
@@ -448,7 +448,10 @@ EOS;
         }
         // End of: element values
 
-        $mform->addElement('mod_surveypro_select', $this->itemname, $elementlabel, $integers, array('class' => 'indent-'.$this->indent, 'id' => $idprefix));
+        $attributes = array();
+        $attributes['id'] = $idprefix;
+        $attributes['class'] = 'indent-'.$this->indent.' integer_select';
+        $mform->addElement('mod_surveypro_select', $this->itemname, $elementlabel, $integers, $attributes);
 
         if (!$searchform) {
             if ($this->required) {

--- a/field/multiselect/classes/plugin.class.php
+++ b/field/multiselect/classes/plugin.class.php
@@ -457,7 +457,10 @@ EOS;
         $idprefix = 'id_surveypro_field_multiselect_'.$this->sortindex;
 
         $labels = $this->item_get_content_array(SURVEYPRO_LABELS, 'options');
-        $attributes = array('size' => $this->heightinrows, 'class' => 'indent-'.$this->indent, 'id' => $idprefix);
+        $attributes = array();
+        $attributes['id'] = $idprefix;
+        $attributes['class'] = 'indent-'.$this->indent.' multiselect_select';
+        $attributes['size'] = $this->heightinrows;
         if (!$searchform) {
             if ($this->required) {
                 $select = $mform->addElement('mod_surveypro_select', $this->itemname, $elementlabel, $labels, $attributes);
@@ -468,8 +471,9 @@ EOS;
                 $select->setMultiple(true);
                 $elementgroup[] = $select;
 
-                unset($attributes['size']);
                 $attributes['id'] = $idprefix.'_noanswer';
+                $attributes['class'] = 'multiselect_check';
+                unset($attributes['size']);
                 $elementgroup[] = $mform->createElement('mod_surveypro_checkbox', $this->itemname.'_noanswer', '', get_string('noanswer', 'mod_surveypro'), $attributes);
 
                 $mform->addGroup($elementgroup, $this->itemname.'_group', $elementlabel, '', false);
@@ -483,8 +487,10 @@ EOS;
             $select->setMultiple(true);
             $elementgroup[] = $select;
 
+            $attributes['class'] = 'multiselect_check';
+            unset($attributes['size']);
+
             if (!$this->required) {
-                unset($attributes['size']);
                 $attributes['id'] = $idprefix.'_noanswer';
                 $elementgroup[] = $mform->createElement('mod_surveypro_checkbox', $this->itemname.'_noanswer', '', get_string('noanswer', 'mod_surveypro'), $attributes);
             }

--- a/field/numeric/classes/plugin.class.php
+++ b/field/numeric/classes/plugin.class.php
@@ -381,7 +381,9 @@ EOS;
 
         $idprefix = 'id_surveypro_field_numeric_'.$this->sortindex;
 
-        $attributes = array('class' => 'indent-'.$this->indent, 'id' => $idprefix);
+        $attributes = array();
+        $attributes['id'] = $idprefix;
+        $attributes['class'] = 'indent-'.$this->indent.' numeric_text';
 
         // Cool for browsers supporting html 5.
         // $attributes['type'] = 'number';
@@ -405,9 +407,12 @@ EOS;
         } else {
             $elementgroup = array();
             $elementgroup[] = $mform->createElement('text', $this->itemname, '', $attributes);
-            $attributes = array('id' => $idprefix.'_ignoreme');
-            $elementgroup[] = $mform->createElement('mod_surveypro_checkbox', $this->itemname.'_ignoreme', '', get_string('star', 'mod_surveypro'), $attributes);
             $mform->setType($this->itemname, PARAM_RAW);
+
+            $attributes['id'] = $idprefix.'_ignoreme';
+            $attributes['class'] = 'numeric_text';
+            $elementgroup[] = $mform->createElement('mod_surveypro_checkbox', $this->itemname.'_ignoreme', '', get_string('star', 'mod_surveypro'), $attributes);
+
             $mform->addGroup($elementgroup, $this->itemname.'_group', $elementlabel, ' ', false);
             $mform->disabledIf($this->itemname.'_group', $this->itemname.'_ignoreme', 'checked');
             $mform->setDefault($this->itemname.'_ignoreme', '1');

--- a/field/radiobutton/classes/plugin.class.php
+++ b/field/radiobutton/classes/plugin.class.php
@@ -474,7 +474,9 @@ EOS;
 
         $idprefix = 'id_surveypro_field_radiobutton_'.$this->sortindex;
 
-        $attributes = array('class' => 'indent-'.$this->indent);
+        $attributes = array();
+        $attributes['class'] = 'indent-'.$this->indent.' radiobutton_radio';
+
         $elementgroup = array();
 
         // Begin of: mform element.
@@ -483,24 +485,24 @@ EOS;
                 $attributes['id'] = $idprefix.'_invite';
                 $elementgroup[] = $mform->createElement('mod_surveypro_radio', $this->itemname, '', get_string('choosedots'), SURVEYPRO_INVITEVALUE, $attributes);
                 if ($this->adjustment == SURVEYPRO_HORIZONTAL) {
-                    unset($attributes['class']);
+                    $attributes['class'] = 'radiobutton_radio';
                 }
             }
         } else {
             $attributes['id'] = $idprefix.'_ignoreme';
             $elementgroup[] = $mform->createElement('mod_surveypro_radio', $this->itemname, '', get_string('star', 'mod_surveypro'), SURVEYPRO_IGNOREMEVALUE, $attributes);
             if ($this->adjustment == SURVEYPRO_HORIZONTAL) {
-                unset($attributes['class']);
+                $attributes['class'] = 'radiobutton_radio';
             }
         }
 
         $labels = $this->item_get_content_array(SURVEYPRO_LABELS, 'options');
         $labelcount = count($labels);
         foreach ($labels as $k => $label) {
-            $attributes['id'] = $idprefix.'_'."$k";
+            $attributes['id'] = $idprefix.'_'.$k;
             $elementgroup[] = $mform->createElement('mod_surveypro_radio', $this->itemname, '', $label, "$k", $attributes);
             if ($this->adjustment == SURVEYPRO_HORIZONTAL) {
-                unset($attributes['class']);
+                $attributes['class'] = 'radiobutton_radio';
             }
         }
 

--- a/field/rate/classes/plugin.class.php
+++ b/field/rate/classes/plugin.class.php
@@ -376,15 +376,16 @@ EOS;
             }
         }
 
+        $attributes = array();
         if ($this->style == SURVEYPROFIELD_RATE_USERADIO) {
             foreach ($options as $row => $option) {
-                $attributes = array('class' => 'indent-'.$this->indent);
+                $attributes['class'] = 'indent-'.$this->indent.' rate_radio';
                 $uniquename = $this->itemname.'_'.$row;
                 $elementgroup = array();
                 foreach ($rates as $col => $rate) {
                     $attributes['id'] = $idprefix.'_'.$row.'_'.$col;
                     $elementgroup[] = $mform->createElement('mod_surveypro_radio', $uniquename, '', $rate, $col, $attributes);
-                    unset($attributes['class']);
+                    $attributes['class'] = 'rate_radio';
                 }
                 $mform->addGroup($elementgroup, $uniquename.'_group', $option, ' ', false);
 
@@ -395,18 +396,19 @@ EOS;
             }
         }
 
-        $attributes = array('class' => 'indent-'.$this->indent);
         if ($this->style == SURVEYPROFIELD_RATE_USESELECT) {
-            foreach ($options as $k => $option) {
-                $uniquename = $this->itemname.'_'.$k;
-                $attributes['id'] = $idprefix.'_'.$k;
+            $attributes['class'] = 'indent-'.$this->indent.' rate_select';
+            foreach ($options as $row => $option) {
+                $uniquename = $this->itemname.'_'.$row;
+                $attributes['id'] = $idprefix.'_'.$row;
                 $mform->addElement('mod_surveypro_select', $uniquename, $option, $rates, $attributes);
-                $this->item_add_color_unifier($mform, $k, $optioncount);
+                $this->item_add_color_unifier($mform, $row, $optioncount);
             }
         }
 
         if (!$this->required) { // This is the last if it exists
             $attributes['id'] = $idprefix.'_noanswer';
+            $attributes['class'] = 'indent-'.$this->indent.' rate_check';
             $mform->addElement('mod_surveypro_checkbox', $this->itemname.'_noanswer', '', get_string('noanswer', 'mod_surveypro'), $attributes);
         }
 
@@ -436,15 +438,15 @@ EOS;
 
         switch ($this->defaultoption) {
             case SURVEYPRO_CUSTOMDEFAULT:
-                foreach ($options as $k => $option) {
-                    $uniquename = $this->itemname.'_'.$k;
-                    $defaultindex = array_search($defaultvalues[$k], $rates);
+                foreach ($options as $row => $option) {
+                    $uniquename = $this->itemname.'_'.$row;
+                    $defaultindex = array_search($defaultvalues[$row], $rates);
                     $mform->setDefault($uniquename, "$defaultindex");
                 }
                 break;
             case SURVEYPRO_INVITEDEFAULT:
-                foreach ($options as $k => $option) {
-                    $uniquename = $this->itemname.'_'.$k;
+                foreach ($options as $row => $option) {
+                    $uniquename = $this->itemname.'_'.$row;
                     $mform->setDefault($uniquename, SURVEYPRO_INVITEVALUE);
                 }
                 break;
@@ -508,11 +510,11 @@ EOS;
             $uniquerates = array_unique($rates);
             $duplicaterates = array_diff_assoc($rates, $uniquerates);
 
-            foreach ($duplicaterates as $k => $unused) {
+            foreach ($duplicaterates as $row => $unused) {
                 if ($this->style == SURVEYPROFIELD_RATE_USERADIO) {
-                    $elementname = $this->itemname.'_'.$k.'_group';
+                    $elementname = $this->itemname.'_'.$row.'_group';
                 } else {
-                    $elementname = $this->itemname.'_'.$k;
+                    $elementname = $this->itemname.'_'.$row;
                 }
                 $errors[$elementname] = get_string('uerr_duplicaterate', 'surveyprofield_rate');
             }
@@ -619,8 +621,8 @@ EOS;
                 $labels = $this->item_get_content_array(SURVEYPRO_LABELS, 'options');
 
                 $rates = $this->item_get_content_array(SURVEYPRO_VALUES, 'rates');
-                foreach ($labels as $k => $label) {
-                    $index = $answers[$k];
+                foreach ($labels as $col => $label) {
+                    $index = $answers[$col];
                     $output[] = $label.SURVEYPROFIELD_RATE_VALUERATESEPARATOR.$rates[$index];
                 }
                 $return = implode(SURVEYPRO_OUTPUTMULTICONTENTSEPARATOR, $output);
@@ -631,8 +633,8 @@ EOS;
                 $labels = $this->item_get_content_array(SURVEYPRO_LABELS, 'options');
 
                 $rates = $this->item_get_content_array(SURVEYPRO_LABELS, 'rates');
-                foreach ($labels as $k => $label) {
-                    $index = $answers[$k];
+                foreach ($labels as $col => $label) {
+                    $index = $answers[$col];
                     $output[] = $label.SURVEYPROFIELD_RATE_VALUERATESEPARATOR.$rates[$index];
                 }
                 $return = implode(SURVEYPRO_OUTPUTMULTICONTENTSEPARATOR, $output);
@@ -660,14 +662,14 @@ EOS;
 
         $options = surveypro_multilinetext_to_array($this->options);
         if ($this->style == SURVEYPROFIELD_RATE_USERADIO) {
-            foreach ($options as $k => $option) {
-                $elementnames[] = $this->itemname.'_'.$k.'_group';
+            foreach ($options as $row => $option) {
+                $elementnames[] = $this->itemname.'_'.$row.'_group';
             }
         }
 
         if ($this->style == SURVEYPROFIELD_RATE_USESELECT) {
-            foreach ($options as $k => $option) {
-                $elementnames[] = $this->itemname.'_'.$k;
+            foreach ($options as $row => $option) {
+                $elementnames[] = $this->itemname.'_'.$row;
             }
         }
 

--- a/field/recurrence/classes/plugin.class.php
+++ b/field/recurrence/classes/plugin.class.php
@@ -477,9 +477,16 @@ EOS;
         // End of: element values
 
         // Begin of: mform element.
+        $attributes = array();
         $elementgroup = array();
-        $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_day', '', $days, array('class' => 'indent-'.$this->indent, 'id' => $idprefix.'_day'));
-        $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_month', '', $months, array('id' => $idprefix.'_month'));
+
+        $attributes['id'] = $idprefix.'_day';
+        $attributes['class'] = 'indent-'.$this->indent.' recurrence_select';
+        $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_day', '', $days, $attributes);
+
+        $attributes['id'] = $idprefix.'_month';
+        $attributes['class'] = 'recurrence_select';
+        $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_month', '', $months, $attributes);
 
         if ($this->required) {
             $mform->addGroup($elementgroup, $this->itemname.'_group', $elementlabel, ' ', false);
@@ -493,7 +500,8 @@ EOS;
                 $mform->_required[] = $starplace;
             }
         } else {
-            $attributes = array('id' => $idprefix.'_noanswer');
+            $attributes['id'] = $idprefix.'_noanswer';
+            $attributes['class'] = 'recurrence_check';
             $elementgroup[] = $mform->createElement('mod_surveypro_checkbox', $this->itemname.'_noanswer', '', get_string('noanswer', 'mod_surveypro'), $attributes);
             $mform->addGroup($elementgroup, $this->itemname.'_group', $elementlabel, ' ', false);
             $mform->disabledIf($this->itemname.'_group', $this->itemname.'_noanswer', 'checked');

--- a/field/select/classes/plugin.class.php
+++ b/field/select/classes/plugin.class.php
@@ -485,12 +485,18 @@ EOS;
         }
         // End of: element values
 
+        $attributes = array();
+        $attributes['id'] = $idprefix;
+        $attributes['class'] = 'indent-'.$this->indent.' select_select';
         if (!$this->labelother) {
-            $mform->addElement('mod_surveypro_select', $this->itemname, $elementlabel, $labels, array('class' => 'indent-'.$this->indent, 'id' => $idprefix));
+            $mform->addElement('mod_surveypro_select', $this->itemname, $elementlabel, $labels, $attributes);
         } else {
             $elementgroup = array();
-            $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname, '', $labels, array('class' => 'indent-'.$this->indent, 'id' => $idprefix));
-            $elementgroup[] = $mform->createElement('text', $this->itemname.'_text', '', array('id' => $idprefix.'_text'));
+            $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname, '', $labels, $attributes);
+
+            $attributes['id'] = $idprefix.'_text';
+            $attributes['class'] = 'select_select';
+            $elementgroup[] = $mform->createElement('text', $this->itemname.'_text', '', $attributes);
             $mform->setType($this->itemname.'_text', PARAM_RAW);
             $mform->disabledIf($this->itemname.'_text', $this->itemname, 'neq', 'other');
             $mform->addGroup($elementgroup, $this->itemname.'_group', $elementlabel, ' ', false);

--- a/field/shortdate/classes/plugin.class.php
+++ b/field/shortdate/classes/plugin.class.php
@@ -466,10 +466,15 @@ EOS;
         // End of: element values
 
         // Begin of: mform element.
+        $attributes = array();
         $elementgroup = array();
-        $attributes = array('id' => $idprefix.'_month', 'class' => 'indent-'.$this->indent);
+
+        $attributes['id'] = $idprefix.'_month';
+        $attributes['class'] = 'indent-'.$this->indent.' shortdate_select';
         $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_month', '', $months, $attributes);
-        $attributes = array('id' => $idprefix.'_year');
+
+        $attributes['id'] = $idprefix.'_year';
+        $attributes['class'] = 'shortdate_select';
         $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_year', '', $years, $attributes);
 
         if ($this->required) {
@@ -484,7 +489,8 @@ EOS;
                 $mform->_required[] = $starplace;
             }
         } else {
-            $attributes = array('id' => $idprefix.'_noanswer');
+            $attributes['id'] = $idprefix.'_noanswer';
+            $attributes['class'] = 'shortdate_check';
             $elementgroup[] = $mform->createElement('mod_surveypro_checkbox', $this->itemname.'_noanswer', '', get_string('noanswer', 'mod_surveypro'), $attributes);
             $mform->addGroup($elementgroup, $this->itemname.'_group', $elementlabel, ' ', false);
             $mform->disabledIf($this->itemname.'_group', $this->itemname.'_noanswer', 'checked');

--- a/field/textarea/classes/plugin.class.php
+++ b/field/textarea/classes/plugin.class.php
@@ -354,10 +354,10 @@ EOS;
         $idprefix = 'id_surveypro_field_textarea_'.$this->sortindex;
 
         $attributes = array();
-        $attributes['class'] = 'indent-'.$this->indent;
         $attributes['id'] = $idprefix;
         if (empty($this->useeditor)) {
             $fieldname = $this->itemname;
+            $attributes['class'] = 'indent-'.$this->indent.' textarea_textarea';
             $attributes['wrap'] = 'virtual';
             $attributes['rows'] = $this->arearows;
             $attributes['cols'] = $this->areacols;
@@ -365,6 +365,7 @@ EOS;
             $mform->setType($fieldname, PARAM_TEXT);
         } else {
             // $attributes['class'] and $attributes['id'] do not work: MDL_28194
+            $attributes['class'] = 'indent-'.$this->indent.' textarea_editor';
             $fieldname = $this->itemname.'_editor';
             $editoroptions = array('trusttext' => true, 'subdirs' => true, 'maxfiles' => EDITOR_UNLIMITED_FILES);
             $mform->addElement('mod_surveypro_editor', $fieldname, $elementlabel, $attributes, $editoroptions);

--- a/field/time/classes/plugin.class.php
+++ b/field/time/classes/plugin.class.php
@@ -479,9 +479,16 @@ EOS;
         // End of: element values
 
         // Begin of: mform element.
+        $attributes = array();
         $elementgroup = array();
-        $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_hour', '', $hours, array('class' => 'indent-'.$this->indent, 'id' => $idprefix.'_hour'));
-        $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_minute', '', $minutes, array('id' => $idprefix.'_minute'));
+
+        $attributes['id'] = $idprefix.'_hour';
+        $attributes['class'] = 'indent-'.$this->indent.' time_select';
+        $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_hour', '', $hours, $attributes);
+
+        $attributes['id'] = $idprefix.'_minute';
+        $attributes['class'] = 'time_select';
+        $elementgroup[] = $mform->createElement('mod_surveypro_select', $this->itemname.'_minute', '', $minutes, $attributes);
 
         $separator = array(':');
         if ($this->required) {
@@ -496,7 +503,8 @@ EOS;
                 $mform->_required[] = $starplace;
             }
         } else {
-            $attributes = array('id' => $idprefix.'_noanswer');
+            $attributes['id'] = $idprefix.'_noanswer';
+            $attributes['class'] = 'time_check';
             $elementgroup[] = $mform->createElement('mod_surveypro_checkbox', $this->itemname.'_noanswer', '', get_string('noanswer', 'mod_surveypro'), $attributes);
             $separator[] = ' ';
             $mform->addGroup($elementgroup, $this->itemname.'_group', $elementlabel, $separator, false);

--- a/form/outform/fill_form.php
+++ b/form/outform/fill_form.php
@@ -174,8 +174,8 @@ class mod_surveypro_outform extends moodleform {
                         $item->item_add_color_unifier($mform);
 
                         $itemname = $item->get_itemname().'_note';
-                        $option = array('class' => 'indent-'.$item->get_indent());
-                        $mform->addElement('mod_surveypro_static', $itemname, get_string('note', 'mod_surveypro'), $fullinfo, $option);
+                        $attributes = array('class' => 'indent-'.$item->get_indent().' label_static');
+                        $mform->addElement('mod_surveypro_static', $itemname, get_string('note', 'mod_surveypro'), $fullinfo, $attributes);
                     }
 
                     if (!$surveypro->newpageforchild) {

--- a/format/label/classes/plugin.class.php
+++ b/format/label/classes/plugin.class.php
@@ -267,7 +267,7 @@ EOS;
             // $content .= html_writer::start_tag('fieldset', array('class' => 'hidden'));
             // $content .= html_writer::start_tag('div', array('class' => 'centerpara'));
             $content .= html_writer::start_tag('div', array('class' => 'fitem'));
-            $content .= html_writer::start_tag('div', array('class' => 'fstatic fullwidth'));
+            $content .= html_writer::start_tag('div', array('class' => 'fstatic fullwidth label_static'));
             // $content .= html_writer::start_tag('div', array('class' => 'indent-'.$this->indent));
             $content .= $this->get_content();
             // $content .= html_writer::end_tag('div');
@@ -280,8 +280,9 @@ EOS;
             $labelsep = get_string('labelsep', 'langconfig'); // Separator usually is ': '.
             $elementnumber = $this->customnumber ? $this->customnumber.$labelsep : '';
             $elementlabel = $elementnumber.$this->leftlabel;
-            $option = array('class' => 'indent-'.$this->indent);
-            $mform->addElement('mod_surveypro_static', $this->itemname, $elementlabel, $this->get_content(), $option);
+            $attributes = array();
+            $attributes['class'] = 'indent-'.$this->indent.' label_static';
+            $mform->addElement('mod_surveypro_static', $this->itemname, $elementlabel, $this->get_content(), $attributes);
         }
     }
 

--- a/styles.css
+++ b/styles.css
@@ -392,34 +392,56 @@
 }
 /* End of: to correct vertical alignment in read only mode */
 
-/* vertical distance between select in rate is too much */
+/* vertical distance between top margin of a row and input elements is too small */
 #page-mod-surveypro-layout_preview .mform .fitem,
 #page-mod-surveypro-view_form .mform .fitem,
 #page-mod-surveypro-view_search .mform .fitem {
     padding-top:0.7em;
 }
-
-#page-mod-surveypro-layout_preview .mform div[id*=rate],
-#page-mod-surveypro-view_form .mform div[id*=rate],
-#page-mod-surveypro-view_search .mform div[id*=rate] {
-    padding-top:0;
-}
-/* End of: vertical distance between select in rate is too much */
+/* End of: vertical distance between top margin of a row and input elements is too small */
 
 /* make up to autofill input to let it look like a static text */
-#page-mod-surveypro-layout_preview .mform input[id*=autofill],
-#page-mod-surveypro-view_form .mform input[id*=autofill],
-#page-mod-surveypro-view_search .mform input[id*=autofill] {
-	background-color: Transparent;
-	border: 0 Transparent none;
-	box-shadow: none;
+#page-mod-surveypro-layout_preview .mform input.autofill_text,
+#page-mod-surveypro-view_form .mform input.autofill_text,
+#page-mod-surveypro-view_search .mform input.autofill_text {
+    background-color: transparent;
+    border: 0 transparent none;
+    box-shadow: none;
 }
 /* End: make up to autofill input to let it look like a static text */
 
-/* padding bottom for Noanswer checkbox of rate elements */
-#page-mod-surveypro-layout_preview .mform div[id*=noanswer],
-#page-mod-surveypro-view_form .mform div[id*=noanswer],
-#page-mod-surveypro-view_search .mform div[id*=noanswer] {
-    padding-bottom:0.7em;
+/* vertical distance between select in rate is too much */
+#page-mod-surveypro-layout_preview .mform select.rate_select,
+#page-mod-surveypro-view_form .mform select.rate_select,
+#page-mod-surveypro-view_search .mform select.rate_select {
+    margin-top:0.2em;
+    margin-bottom:0.2em;
 }
-/* End of: padding bottom for Noanswer checkbox of rate elements */
+/* End of: vertical distance between select in rate is too much */
+
+/* these are a div selector */
+/* padding top for div opening to rate elements */
+#page-mod-surveypro-layout_preview .mform div.rate_select,
+#page-mod-surveypro-view_form .mform div.rate_select,
+#page-mod-surveypro-view_search .mform div.rate_select {
+    padding-top:0;
+}
+/* End of: padding top for div opening to rate elements */
+
+/* padding bottom for noanswer checkbox in a dedicated row, like, for instence, in rate elements */
+#page-mod-surveypro-layout_preview .mform div.rate_check,
+#page-mod-surveypro-view_form .mform div.rate_check,
+#page-mod-surveypro-view_search .mform div.rate_check {
+    padding-top:0;
+    padding-bottom:0.5em;
+}
+/* End of: padding bottom for noanswer checkbox in a dedicated row, like, for instence, in rate elements */
+
+/* padding bottom for noanswer checkbox in a dedicated row, like, for instence, in rate elements */
+#page-mod-surveypro-layout_preview .mform div.fitem_fstatic,
+#page-mod-surveypro-view_form .mform div.fitem_fstatic,
+#page-mod-surveypro-view_search .mform div.fitem_fstatic {
+    padding-top:0;
+}
+/* End of: padding bottom for noanswer checkbox in a dedicated row, like, for instence, in rate elements */
+/* End of: these are a div selector */


### PR DESCRIPTION
With that addition I am able to apply a style to all the elements specifying plugin and item detail. For instance: date_select selects the three drop down menu with day, month and year or date_chack selects the noanswer checkbox of each date item.
This is specially useful for the autofill plugin that is changed in its aspect to look like a static text.