### PR TITLE
CONTRIB-6269 mod_surveypro: fixed failing behat test

### DIFF
--- a/tests/behat/overwrite_mastertemplate.feature
+++ b/tests/behat/overwrite_mastertemplate.feature
@@ -1,4 +1,4 @@
-@mod @mod_surveypro @aaa
+@mod @mod_surveypro
 Feature: verify the deletion of old items works as expected during master templates replacement
   In order to verify the overwrite of master templates
   As a teacher

--- a/tests/behat/preserve_autofillpersonaldata.feature
+++ b/tests/behat/preserve_autofillpersonaldata.feature
@@ -58,7 +58,6 @@ Feature: editing a submission, autofill userID is not overwritten
     And I expand all fieldsets
     And I set the following fields to these values:
       | Content             | Your first name |
-      | Indent              | 0               |
       | Question position   | left            |
       | Element number      | 2               |
       | id_element01_select | user first name |
@@ -70,7 +69,6 @@ Feature: editing a submission, autofill userID is not overwritten
     And I expand all fieldsets
     And I set the following fields to these values:
       | Content             | Your last name |
-      | Indent              | 0              |
       | Question position   | left           |
       | Element number      | 3              |
       | id_element01_select | user last name |
@@ -83,7 +81,6 @@ Feature: editing a submission, autofill userID is not overwritten
     And I set the following fields to these values:
       | Content           | Is this true? |
       | Required          | 1             |
-      | Indent            | 0             |
       | Question position | left          |
       | Element number    | 4             |
       | Element style     | dropdown menu |
@@ -117,10 +114,9 @@ Feature: editing a submission, autofill userID is not overwritten
 
     And I follow "Responses"
     And I follow "edit_submission_row_1"
-    Then I should see "4"
-    Then I should see "student1"
-    Then I should see "user1"
-    Then I should see "Yes"
+    Then the field "Your first name" matches value "student1"
+    Then the field "Your last name" matches value "user1"
+    Then the field "4: Is this true?" matches value "Yes"
 
     And I set the field "4: Is this true?" to "No"
     And I press "Submit"
@@ -134,10 +130,9 @@ Feature: editing a submission, autofill userID is not overwritten
 
     And I follow "Responses"
     And I follow "edit_submission_row_1"
-    Then I should see "4"
-    Then I should see "student1"
-    Then I should see "user1"
-    Then I should see "No"
+    Then the field "Your first name" matches value "student1"
+    Then the field "Your last name" matches value "user1"
+    Then the field "4: Is this true?" matches value "No"
 
     And I log out
 
@@ -147,10 +142,9 @@ Feature: editing a submission, autofill userID is not overwritten
     And I follow "Preserve autofill"
 
     And I follow "edit_submission_row_1"
-    Then I should see "4"
-    Then I should see "student1"
-    Then I should see "user1"
-    Then I should see "No"
+    Then the field "Your first name" matches value "student1"
+    Then the field "Your last name" matches value "user1"
+    Then the field "4: Is this true?" matches value "No"
     And I set the field "4: Is this true?" to "Yes"
     And I press "Submit"
 
@@ -163,9 +157,8 @@ Feature: editing a submission, autofill userID is not overwritten
 
     And I follow "Responses"
     And I follow "edit_submission_row_1"
-    Then I should see "4"
-    Then I should see "student1"
-    Then I should see "user1"
-    Then I should see "Yes"
+    Then the field "Your first name" matches value "student1"
+    Then the field "Your last name" matches value "user1"
+    Then the field "4: Is this true?" matches value "Yes"
 
     And I log out


### PR DESCRIPTION
Since the branch better_userform_mform_element the scenario: "test that editing a submission, autofill userID is not overwritten" no longer works fine because the autofill item element has been changed from static text to regular text input field.
This branch let work fine again that behat test.