### PR TITLE
CONTRIB-6286 mod_surveypro: added a feedback to utempalte deletion

### DIFF
--- a/classes/itemlist.class.php
+++ b/classes/itemlist.class.php
@@ -1238,6 +1238,7 @@ class mod_surveypro_itemlist {
                 die();
             }
         }
+
         if ($this->confirm == SURVEYPRO_CONFIRMED_NO) {
             $message = get_string('usercanceled', 'mod_surveypro');
             echo $OUTPUT->notification($message, 'notifymessage');
@@ -1334,10 +1335,12 @@ class mod_surveypro_itemlist {
             echo $OUTPUT->footer();
             die();
         }
+
         if ($this->confirm == SURVEYPRO_CONFIRMED_NO) {
             $message = get_string('usercanceled', 'mod_surveypro');
             echo $OUTPUT->notification($message, 'notifymessage');
         }
+
         if ($this->confirm == SURVEYPRO_ACTION_EXECUTED) {
             $a = new stdClass();
             $a->content = $this->actionfeedback->content;
@@ -1446,6 +1449,7 @@ class mod_surveypro_itemlist {
             echo $OUTPUT->footer();
             die();
         }
+
         if ($this->confirm == SURVEYPRO_ACTION_EXECUTED) {
             $message = get_string('feedback_dropmultilang', 'mod_surveypro');
             echo $OUTPUT->notification($message, 'notifysuccess');
@@ -1559,7 +1563,7 @@ class mod_surveypro_itemlist {
         }
     }
 
-    // MARK item make standard.
+    // MARK item make free.
 
     /**
      * Set the item as standard (free).
@@ -1628,6 +1632,7 @@ class mod_surveypro_itemlist {
                 die();
             }
         }
+
         if ($this->confirm == SURVEYPRO_CONFIRMED_NO) {
             $message = get_string('usercanceled', 'mod_surveypro');
             echo $OUTPUT->notification($message, 'notifymessage');
@@ -1757,10 +1762,12 @@ class mod_surveypro_itemlist {
             $message = get_string('confirm_deleteallitems', 'mod_surveypro');
             $this->bulk_action_ask($message);
         }
+
         if ($this->confirm == SURVEYPRO_CONFIRMED_NO) {
             $message = get_string('usercanceled', 'mod_surveypro');
             echo $OUTPUT->notification($message, 'notifymessage');
         }
+
         if ($this->confirm == SURVEYPRO_ACTION_EXECUTED) {
             $message = get_string('feedback_deleteallitems', 'mod_surveypro');
             echo $OUTPUT->notification($message, 'notifysuccess');
@@ -1806,10 +1813,12 @@ class mod_surveypro_itemlist {
             $message = get_string('confirm_deletevisibleitems', 'mod_surveypro');
             $this->bulk_action_ask($message);
         }
+
         if ($this->confirm == SURVEYPRO_CONFIRMED_NO) {
             $message = get_string('usercanceled', 'mod_surveypro');
             echo $OUTPUT->notification($message, 'notifymessage');
         }
+
         if ($this->confirm == SURVEYPRO_ACTION_EXECUTED) {
             $message = get_string('feedback_deletevisibleitems', 'mod_surveypro');
             echo $OUTPUT->notification($message, 'notifysuccess');
@@ -1855,10 +1864,12 @@ class mod_surveypro_itemlist {
             $message = get_string('confirm_deletehiddenitems', 'mod_surveypro');
             $this->bulk_action_ask($message);
         }
+
         if ($this->confirm == SURVEYPRO_CONFIRMED_NO) {
             $message = get_string('usercanceled', 'mod_surveypro');
             echo $OUTPUT->notification($message, 'notifymessage');
         }
+
         if ($this->confirm == SURVEYPRO_ACTION_EXECUTED) {
             $message = get_string('feedback_deletehiddenitems', 'mod_surveypro');
             echo $OUTPUT->notification($message, 'notifysuccess');

--- a/classes/utemplate.class.php
+++ b/classes/utemplate.class.php
@@ -989,9 +989,14 @@ class mod_surveypro_usertemplate extends mod_surveypro_templatebase {
 
             $fs = get_file_storage();
             $xmlfile = $fs->get_file_by_id($this->utemplateid);
+            $a = $xmlfile->get_filename();
             $xmlfile->delete();
 
             $this->trigger_event('usertemplate_deleted');
+
+            // Feedback.
+            $message = get_string('feedback_delete1utemplate', 'mod_surveypro', $a);
+            echo $OUTPUT->notification($message, 'notifymessage');
         }
 
         if ($this->confirm == SURVEYPRO_CONFIRMED_NO) {

--- a/lang/en/surveypro.php
+++ b/lang/en/surveypro.php
@@ -195,6 +195,7 @@ $string['extranoteinsearch_descr'] = 'Are user notes needed in the search form?'
 $string['extranoteinsearch'] = 'Extra note in search form';
 $string['feedback_delete1item'] = 'The \'{$a->pluginname}\' element: {$a->content} has been successfully deleted';
 $string['feedback_delete1response'] = 'User response has been successfully deleted';
+$string['feedback_delete1utemplate'] = 'Usertemplate "{$a}" was successfully deleted';
 $string['feedback_deleteallitems'] = 'All the elements were successfully deleted';
 $string['feedback_deleteallresponses'] = 'All the responses of this survey have been successfully deleted';
 $string['feedback_deletechainitems'] = 'The \'{$a->pluginname}\' element: {$a->content} and descending element(s) have been successfully deleted';


### PR DESCRIPTION
Almost each action in surveypro lies over two steps: 
1) ask for confirmation
2) feedback.

Usertemplate deletion is still missing the feedback when the action is confirmed.