### PR TITLE
NOBUG: Update travis so tests are performed against new 31_STABLE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ env:
   - MOODLE_BRANCH=master           DB=pgsql
   - MOODLE_BRANCH=master           DB=mysqli
   - MOODLE_BRANCH=MOODLE_30_STABLE DB=pgsql
-  - MOODLE_BRANCH=MOODLE_30_STABLE DB=mysqli
+  - MOODLE_BRANCH=MOODLE_31_STABLE DB=pgsql
+  - MOODLE_BRANCH=MOODLE_31_STABLE DB=mysqli
 # global:
 # This line determines which version of Moodle to test against.
 #  - MOODLE_BRANCH=MOODLE_30_STABLE


### PR DESCRIPTION
We do postgres and mysql tests both in lates stable (31) and master.
And only one of them in older stables (30)