### PR TITLE
CONTRIB-6271 mod_surveypro: moved filter alphabeth to the center

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -210,6 +210,10 @@
 /* End of: #manageitems, #sortitems, #managetemplates and #validaterelations tables*/
 
 /* Begin of: submissions table */
+#page-mod-surveypro-view .initialbar {
+    text-align: center;
+}
+
 #page-mod-surveypro-view table#submissions {
     width:100%;
 }


### PR DESCRIPTION
I hate to see the page load starting with the "Filtering alphabeth", then, just below, the "Table" and when the table is finally all displayed, the "Submission overview" appear in the middle.
I also hate to see the "Filtering alphabeth", that is part of the "Table", far from the table.

I would love to have:
"Submission overview"
"Filtering alphabeth"
"Table"
but this costs a big query to count users twice: one for the "Submission overview" and one for the "Table".

Maybe this high cost may be saved by moving the "Filtering alphabeth" far from the "Submission overview"... and this is what I did. (owful solution)