### PR TITLE
Mtemplate save improvements

### DIFF
--- a/classes/itembase.php
+++ b/classes/itembase.php
@@ -168,7 +168,7 @@ class mod_surveypro_itembase {
         global $DB;
 
         if (!$itemid) {
-            $message = 'Something was wrong at line '.__LINE__.' of file '.__FILE__.'! Can not load an item without its ID';
+            $message = 'Can not load an item without its ID';
             debugging($message, DEBUG_DEVELOPER);
         }
 

--- a/templatemaster/classes/class.php
+++ b/templatemaster/classes/class.php
@@ -15,9 +15,9 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Surveypro class to manage surveyprotemplate_00templateNamePlaceholder00 template
+ * Surveypro class to manage surveyprotemplate_templatemasternameamepleasedontguess template
  *
- * @package   surveyprotemplate_00templateNamePlaceholder00
+ * @package   surveyprotemplate_templatemasternameamepleasedontguess
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
@@ -25,13 +25,13 @@
 defined('MOODLE_INTERNAL') || die();
 
 /**
- * The class to manage surveyprotemplate_00templateNamePlaceholder00 template
+ * The class to manage surveyprotemplate_templatemasternameamepleasedontguess template
  *
- * @package   surveyprotemplate_00templateNamePlaceholder00
+ * @package   surveyprotemplate_templatemasternameamepleasedontguess
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class surveyprotemplate_00templateNamePlaceholder00 {
+class surveyprotemplate_templatemasternameamepleasedontguess_class {
 
     /**
      * Apply template settings.

--- a/templatemaster/lang/en/surveyprotemplate_pluginname.php
+++ b/templatemaster/lang/en/surveyprotemplate_pluginname.php
@@ -15,11 +15,11 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Strings for component 'surveyprotemplate_00templateNamePlaceholder00', language 'en'
+ * Strings for component 'surveyprotemplate_templatemasternameamepleasedontguess', language 'en'
  *
- * @package   surveyprotemplate_00templateNamePlaceholder00
+ * @package   surveyprotemplate_templatemasternameamepleasedontguess
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$string['pluginname'] = '00templateNamePlaceholder00';
+$string['pluginname'] = 'templatemasternameamepleasedontguess';

--- a/templatemaster/template.xml
+++ b/templatemaster/template.xml
@@ -15,9 +15,9 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Defines the version of surveypro surveyproTemplate_00templateNamePlaceholder00 subplugin
+ * Defines the version of surveypro surveyproTemplate_templatemasternameamepleasedontguess subplugin
  *
- * @package   surveyprotemplate_00templateNamePlaceholder00
+ * @package   surveyprotemplate_templatemasternameamepleasedontguess
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */

--- a/templatemaster/version.php
+++ b/templatemaster/version.php
@@ -15,16 +15,16 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Defines the version of surveypro surveyproTemplate_00templateNamePlaceholder00 subplugin
+ * Defines the version of surveypro surveyproTemplate_templatemasternameamepleasedontguess subplugin
  *
- * @package   surveyprotemplate_00templateNamePlaceholder00
+ * @package   surveyprotemplate_templatemasternameamepleasedontguess
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2014111000;
+$plugin->version = 1965100401;
 $plugin->release = '1.0';
-$plugin->requires = 2013111800; // Requires this Moodle version.
-$plugin->component = 'surveyprotemplate_00templateNamePlaceholder00'; // Full name of the plugin (used for diagnostics).
+$plugin->requires = 1965100401; // Requires this Moodle version.
+$plugin->component = 'surveyprotemplate_templatemasternameamepleasedontguess'; // Full name of the plugin (used for diagnostics).


### PR DESCRIPTION
In this patch I tried to fix these issues:
- master template still accepts numbers in the name
- the name of its class is wrong in <<mastertemplatename>>/classes/class.php
- there is no test about the correctness of the module "templatemaster" folder
- the temp folder, where the zip file is created, has not an extra security clean so, if the master template process crashes, the undeleted temporary folder will cause a new crash each time a new mastertemplate is asked with the same name.