### PR TITLE
CONTRIB-6398 mod_surveypro: fixed bad frequency report

### DIFF
--- a/classes/itembase.php
+++ b/classes/itembase.php
@@ -1520,6 +1520,9 @@ class mod_surveypro_itembase {
         if ($content == SURVEYPRO_NOANSWERVALUE) { // Answer was "no answer".
             return get_string('answerisnoanswer', 'mod_surveypro');
         }
+        if ($content == SURVEYPRO_ANSWERNOTINDBVALUE) { // Item was disabled. (Used by frequenct report).
+            return get_string('notanswereditem', 'mod_surveypro');
+        }
         if ($content === null) { // Item was disabled.
             return get_string('notanswereditem', 'mod_surveypro');
         }

--- a/field/age/classes/field.php
+++ b/field/age/classes/field.php
@@ -716,6 +716,9 @@ EOS;
         if ($content == SURVEYPRO_NOANSWERVALUE) { // Answer was "no answer".
             return get_string('answerisnoanswer', 'mod_surveypro');
         }
+        if ($content == SURVEYPRO_ANSWERNOTINDBVALUE) { // Item was disabled. (Used by frequenct report).
+            return get_string('notanswereditem', 'mod_surveypro');
+        }
         if ($content === null) { // Item was disabled.
             return get_string('notanswereditem', 'mod_surveypro');
         }

--- a/field/boolean/classes/field.php
+++ b/field/boolean/classes/field.php
@@ -724,6 +724,9 @@ EOS;
         if ($content == SURVEYPRO_NOANSWERVALUE) { // Answer was "no answer".
             return get_string('answerisnoanswer', 'mod_surveypro');
         }
+        if ($content == SURVEYPRO_ANSWERNOTINDBVALUE) { // Item was disabled. (Used by frequenct report).
+            return get_string('notanswereditem', 'mod_surveypro');
+        }
         if ($content === null) { // Item was disabled.
             return get_string('notanswereditem', 'mod_surveypro');
         }

--- a/field/character/classes/field.php
+++ b/field/character/classes/field.php
@@ -616,8 +616,8 @@ EOS;
         // Content.
         $content = trim($answer->content);
         // SURVEYPRO_NOANSWERVALUE does not exist here.
-        if ($content == SURVEYPRO_NOANSWERVALUE) { // Answer was "no answer".
-            return get_string('answerisnoanswer', 'mod_surveypro');
+        if ($content == SURVEYPRO_ANSWERNOTINDBVALUE) { // Item was disabled. (Used by frequenct report).
+            return get_string('notanswereditem', 'mod_surveypro');
         }
         if ($content === null) { // Item was disabled.
             return get_string('notanswereditem', 'mod_surveypro');

--- a/field/checkbox/classes/field.php
+++ b/field/checkbox/classes/field.php
@@ -861,8 +861,11 @@ EOS;
     public function userform_db_to_export($answer, $format='') {
         // Content.
         $content = $answer->content;
-        if ($content === SURVEYPRO_NOANSWERVALUE) { // Answer was "no answer".
+        if ($content == SURVEYPRO_NOANSWERVALUE) { // Answer was "no answer".
             return get_string('answerisnoanswer', 'mod_surveypro');
+        }
+        if ($content == SURVEYPRO_ANSWERNOTINDBVALUE) { // Item was disabled. (Used by frequenct report).
+            return get_string('notanswereditem', 'mod_surveypro');
         }
         if ($content === null) { // Item was disabled.
             return get_string('notanswereditem', 'mod_surveypro');

--- a/field/date/classes/field.php
+++ b/field/date/classes/field.php
@@ -769,6 +769,9 @@ EOS;
         if ($content == SURVEYPRO_NOANSWERVALUE) { // Answer was "no answer".
             return get_string('answerisnoanswer', 'mod_surveypro');
         }
+        if ($content == SURVEYPRO_ANSWERNOTINDBVALUE) { // Item was disabled. (Used by frequenct report).
+            return get_string('notanswereditem', 'mod_surveypro');
+        }
         if ($content === null) { // Item was disabled.
             return get_string('notanswereditem', 'mod_surveypro');
         }

--- a/field/datetime/classes/field.php
+++ b/field/datetime/classes/field.php
@@ -856,6 +856,9 @@ EOS;
         if ($content == SURVEYPRO_NOANSWERVALUE) { // Answer was "no answer".
             return get_string('answerisnoanswer', 'mod_surveypro');
         }
+        if ($content == SURVEYPRO_ANSWERNOTINDBVALUE) { // Item was disabled. (Used by frequenct report).
+            return get_string('notanswereditem', 'mod_surveypro');
+        }
         if ($content === null) { // Item was disabled.
             return get_string('notanswereditem', 'mod_surveypro');
         }

--- a/field/fileupload/classes/field.php
+++ b/field/fileupload/classes/field.php
@@ -420,6 +420,10 @@ EOS;
      * @return string - the string for the export file
      */
     public function userform_db_to_export($answer, $format='') {
+        if ($content == SURVEYPRO_ANSWERNOTINDBVALUE) { // Item was disabled. (Used by frequenct report).
+            return get_string('notanswereditem', 'mod_surveypro');
+        }
+
         // SURVEYPRO_NOANSWERVALUE does not exist here.
         $context = context_module::instance($this->cm->id);
 

--- a/field/integer/classes/field.php
+++ b/field/integer/classes/field.php
@@ -683,6 +683,9 @@ EOS;
         if ($content == SURVEYPRO_NOANSWERVALUE) { // Answer was "no answer".
             return get_string('answerisnoanswer', 'mod_surveypro');
         }
+        if ($content == SURVEYPRO_ANSWERNOTINDBVALUE) { // Item was disabled. (Used by frequenct report).
+            return get_string('notanswereditem', 'mod_surveypro');
+        }
         if ($content === null) { // Item was disabled.
             return get_string('notanswereditem', 'mod_surveypro');
         }

--- a/field/multiselect/classes/field.php
+++ b/field/multiselect/classes/field.php
@@ -753,6 +753,9 @@ EOS;
         // Content.
         $content = $answer->content;
         // SURVEYPRO_NOANSWERVALUE does not exist here
+        if ($content == SURVEYPRO_ANSWERNOTINDBVALUE) { // Item was disabled. (Used by frequenct report).
+            return get_string('notanswereditem', 'mod_surveypro');
+        }
         if ($content === null) { // Item was disabled.
             return get_string('notanswereditem', 'mod_surveypro');
         }

--- a/field/numeric/classes/field.php
+++ b/field/numeric/classes/field.php
@@ -628,6 +628,9 @@ EOS;
         if ($content == SURVEYPRO_NOANSWERVALUE) { // Answer was "no answer".
             return get_string('answerisnoanswer', 'mod_surveypro');
         }
+        if ($content == SURVEYPRO_ANSWERNOTINDBVALUE) { // Item was disabled. (Used by frequenct report).
+            return get_string('notanswereditem', 'mod_surveypro');
+        }
         if (strlen($content) == 0) { // Item was disabled.
             return get_string('notanswereditem', 'mod_surveypro');
         }

--- a/field/radiobutton/classes/field.php
+++ b/field/radiobutton/classes/field.php
@@ -796,6 +796,9 @@ EOS;
         if ($content == SURVEYPRO_NOANSWERVALUE) { // Answer was "no answer".
             return get_string('answerisnoanswer', 'mod_surveypro');
         }
+        if ($content == SURVEYPRO_ANSWERNOTINDBVALUE) { // Item was disabled. (Used by frequenct report).
+            return get_string('notanswereditem', 'mod_surveypro');
+        }
         if ($content === null) { // Item was disabled.
             return get_string('notanswereditem', 'mod_surveypro');
         }

--- a/field/rate/classes/field.php
+++ b/field/rate/classes/field.php
@@ -616,6 +616,9 @@ EOS;
         if ($content == SURVEYPRO_NOANSWERVALUE) { // Answer was "no answer".
             return get_string('answerisnoanswer', 'mod_surveypro');
         }
+        if ($content == SURVEYPRO_ANSWERNOTINDBVALUE) { // Item was disabled. (Used by frequenct report).
+            return get_string('notanswereditem', 'mod_surveypro');
+        }
         if ($content === null) { // Item was disabled.
             return get_string('notanswereditem', 'mod_surveypro');
         }

--- a/field/recurrence/classes/field.php
+++ b/field/recurrence/classes/field.php
@@ -732,6 +732,9 @@ EOS;
         if ($content == SURVEYPRO_NOANSWERVALUE) { // Answer was "no answer".
             return get_string('answerisnoanswer', 'mod_surveypro');
         }
+        if ($content == SURVEYPRO_ANSWERNOTINDBVALUE) { // Item was disabled. (Used by frequenct report).
+            return get_string('notanswereditem', 'mod_surveypro');
+        }
         if ($content === null) { // Item was disabled.
             return get_string('notanswereditem', 'mod_surveypro');
         }

--- a/field/select/classes/field.php
+++ b/field/select/classes/field.php
@@ -747,6 +747,9 @@ EOS;
         if ($content == SURVEYPRO_NOANSWERVALUE) { // Answer was "no answer".
             return get_string('answerisnoanswer', 'mod_surveypro');
         }
+        if ($content == SURVEYPRO_ANSWERNOTINDBVALUE) { // Item was disabled. (Used by frequenct report).
+            return get_string('notanswereditem', 'mod_surveypro');
+        }
         if ($content === null) { // Item was disabled.
             return get_string('notanswereditem', 'mod_surveypro');
         }

--- a/field/shortdate/classes/field.php
+++ b/field/shortdate/classes/field.php
@@ -709,6 +709,9 @@ EOS;
         if ($content == SURVEYPRO_NOANSWERVALUE) { // Answer was "no answer".
             return get_string('answerisnoanswer', 'mod_surveypro');
         }
+        if ($content == SURVEYPRO_ANSWERNOTINDBVALUE) { // Item was disabled. (Used by frequenct report).
+            return get_string('notanswereditem', 'mod_surveypro');
+        }
         if ($content === null) { // Item was disabled.
             return get_string('notanswereditem', 'mod_surveypro');
         }

--- a/field/time/classes/field.php
+++ b/field/time/classes/field.php
@@ -754,6 +754,9 @@ EOS;
         if ($content == SURVEYPRO_NOANSWERVALUE) { // Answer was "no answer".
             return get_string('answerisnoanswer', 'mod_surveypro');
         }
+        if ($content == SURVEYPRO_ANSWERNOTINDBVALUE) { // Item was disabled. (Used by frequenct report).
+            return get_string('notanswereditem', 'mod_surveypro');
+        }
         if ($content === null) { // Item was disabled.
             return get_string('notanswereditem', 'mod_surveypro');
         }

--- a/report/frequency/graph.php
+++ b/report/frequency/graph.php
@@ -29,7 +29,6 @@ require_once($CFG->dirroot.'/mod/surveypro/report/frequency/lib.php');
 
 $id = required_param('id', PARAM_INT); // Course Module ID.
 $itemid = required_param('itemid', PARAM_INT); // Item ID.
-$submissionscount = required_param('submissionscount', PARAM_INT); // Submissions count.
 // $group = optional_param('group', 0, PARAM_INT); // Group ID.
 
 $cm = get_coursemodule_from_id('surveypro', $id, 0, false, MUST_EXIST);
@@ -53,17 +52,11 @@ $sql = 'SELECT content, count(id) as absolute
         ORDER BY content';
 $answers = $DB->get_recordset_sql($sql, $whereparams);
 
-$counted = 0;
 $content = array();
 $absolute = array();
 foreach ($answers as $answer) {
     $content[] = $item->userform_db_to_export($answer);
     $absolute[] = $answer->absolute;
-    $counted += $answer->absolute;
-}
-if ($counted < $submissionscount) {
-    $content[] = get_string('answernotpresent', 'surveyproreport_frequency');
-    $absolute[] = ($submissionscount - $counted);
 }
 
 $answers->close();

--- a/report/frequency/lang/en/surveyproreport_frequency.php
+++ b/report/frequency/lang/en/surveyproreport_frequency.php
@@ -23,7 +23,6 @@
  */
 
 $string['absolute'] = 'absolute';
-$string['answernotpresent'] = 'missing';
 $string['content'] = 'answer';
 $string['itemid_help'] = 'Choose the survey question to calculate its distribution';
 $string['itemid'] = 'Survey question';

--- a/report/frequency/view.php
+++ b/report/frequency/view.php
@@ -46,7 +46,6 @@ require_capability('mod/surveypro:accessreports', $context);
 
 // Calculations.
 $utilityman = new mod_surveypro_utility($cm, $surveypro);
-$hassubmissions = $utilityman->has_submissions();
 $reportman = new surveyproreport_frequency_report($cm, $context, $surveypro);
 $reportman->setup_outputtable();
 
@@ -78,7 +77,6 @@ $reportman->nosubmissions_stop();
 // Begin of: prepare params for the form.
 $formparams = new stdClass();
 $formparams->surveypro = $surveypro;
-$formparams->answercount = $hassubmissions;
 $mform = new mod_surveypro_chooseitemform($formurl, $formparams);
 // End of: prepare params for the form.
 
@@ -88,13 +86,12 @@ $mform->display();
 
 // Begin of: manage form submission.
 if ($fromform = $mform->get_data()) {
-    $reportman->fetch_data($fromform->itemid, $hassubmissions);
+    $reportman->fetch_data($fromform->itemid);
 
     $paramurl = array();
     $paramurl['id'] = $cm->id;
     $paramurl['group'] = 0;
     $paramurl['itemid'] = $fromform->itemid;
-    $paramurl['submissionscount'] = $hassubmissions;
     $url = new moodle_url('/mod/surveypro/report/frequency/graph.php', $paramurl);
     // To troubleshoot graph, open a new window in the broser and directly call
     // http://localhost/head/mod/surveypro/report/frequency/graph.php?id=xx&group=0&itemid=yyy&submissionscount=1


### PR DESCRIPTION
In the frequency report there was a misunderstanding between the count of submissions and the count of answers to the item id=xxx. Of course they may be different and this was leading to sum of percentages different from 1.

Second problem was that the string in the first column of the report table was not correct because the value "SURVEYPRO_ANSWERNOTINDBVALUE" was not managed in the public method userform_db_to_export($answer, $format='') of each field class.