### PR TITLE
CONTRIB-6406 mod_surveypro: fixed wrong list of filenames

### DIFF
--- a/classes/mastertemplate.php
+++ b/classes/mastertemplate.php
@@ -240,7 +240,7 @@ class mod_surveypro_mastertemplate extends mod_surveypro_templatebase {
         $filenames = array(
             'template.xml',
             'version.php',
-            'classes/class.php',
+            'classes/template.php',
             'lang/en/surveyprotemplate_'.$pluginname.'.php',
             'pix/icon.png',
             'pix/icon.svg'


### PR DESCRIPTION
At master template save time
the temporary folder can not be deleted because it is still not empty.
This was due to wrong list of provided filenames.