### PR TITLE
NOBUG mod_surveypro: added explanation of use

### DIFF
--- a/classes/view_form.php
+++ b/classes/view_form.php
@@ -711,8 +711,8 @@ class mod_surveypro_view_form extends mod_surveypro_formbase {
         $requireditems = array();
         foreach ($pluginlist as $plugin) {
             $classname = 'surveypro'.SURVEYPRO_TYPEFIELD.'_'.$plugin.'_'.SURVEYPRO_TYPEFIELD;
-            $itemcanbemandatory = $classname::item_uses_mandatory_dbfield();
-            if ($itemcanbemandatory) {
+            $canbemandatory = $classname::item_uses_mandatory_dbfield();
+            if ($canbemandatory) {
                 $sql = 'SELECT i.id, i.parentid, i.parentvalue, i.reserved
                         FROM {surveypro_item} i
                           JOIN {surveypro'.SURVEYPRO_TYPEFIELD.'_'.$plugin.'} p ON i.id = p.itemid

--- a/field/checkbox/classes/field.php
+++ b/field/checkbox/classes/field.php
@@ -70,6 +70,27 @@ class surveyprofield_checkbox_field extends mod_surveypro_itembase {
 
     /**
      * @var bool 0 => optional item; 1 => mandatory item;
+     *
+     * Take in mind that "required" (for checkbox item) means only: "The 'No answer' checkbox is not displayed".
+     * Each checkbox element is intrinsically required.
+     * There is noy for a student to jump a standard checkbox element.
+     *
+     * Example: "What do you take for breakfast?" milk, bread, jam.
+     * If the user jumps this element HE/SHE IS STATING THAT HE/SHE DOES NOT TAKE milk AND NOT bread AND NOT jam.
+     *
+     * If the editing teacher choose to allow the student to jump this question, he HAS TO leave unchecked the "required" propery.
+     * In that way the element will be equipped with an additional exclusive "No answer" checkbox.
+     * This last checkbox privides to the student the possibility to say "I don't tell you what I take for breakfast!"
+     *
+     * Note that a checkbox can have $minimumrequired irrespectively of being required or no.
+     * Alias: a checkbox element can be not $required and have, at the same time, $minimumrequired > 0.
+     * This is perfectly valid.
+     *
+     * Example: "What do you take for breakfast?" milk, bread, jam.
+     * With: $required = 0 and $minimumrequired = 2
+     *
+     * This means that the student is allowed to select the exclusive "No answer" checkbox and run away BUT
+     * IF he/she decides to provide an answer THEN he/she has to select at least 2 checkboxes.
      */
     protected $required;
 

--- a/field/checkbox/db/upgrade.php
+++ b/field/checkbox/db/upgrade.php
@@ -106,7 +106,7 @@ function xmldb_surveyprofield_checkbox_upgrade($oldversion) {
         $table = new xmldb_table('surveyprofield_checkbox');
         $field = new xmldb_field('required', XMLDB_TYPE_INTEGER, '2', null, XMLDB_NOTNULL, null, '2', 'extranote');
 
-        // Conditionally launch add field noanswerdefault.
+        // Conditionally launch add field required.
         if (!$dbman->field_exists($table, $field)) {
             $dbman->add_field($table, $field);
         }


### PR DESCRIPTION
Added explanation about the difference between $required and $minimumrequired and their compatibility for checkboxes elements.
This is needed because at first glace $minimumrequired greater than 0 may appear inappropriate for not required element.
The trick is in the semantic of the checkbox. In a word: students can never jump a checkbox element even if they leave the element untouched.
The added explanation describe exactly this.