### PR TITLE
NOBUG mod_surveypro: asked for friendly format to answers

### DIFF
--- a/report/frequency/classes/report.php
+++ b/report/frequency/classes/report.php
@@ -153,7 +153,7 @@ class surveyproreport_frequency_report extends mod_surveypro_reportbase {
             $itemvalue = new stdClass();
             $itemvalue->id = $answer->id;
             $itemvalue->content = $answer->content;
-            $tablerow[] = $item->userform_db_to_export($itemvalue);
+            $tablerow[] = $item->userform_db_to_export($itemvalue, SURVEYPRO_FIRENDLYFORMAT);
 
             // Absolute.
             $tablerow[] = $answer->absolute;


### PR DESCRIPTION
in the frequency report 
the distribution of answers has to display the friendly name of the answers.
For instance:
to the radio button element "Which protocol do you use to code diagnoses" with answers "DSM IV-TR", "ICD-9", "ICD-10"
I have to get a frequency report displaying:

DSM IV-TR.....3
ICD-9..............6
ICD-10............8

and not

0...............3
1...............6
2...............8
