### PR TITLE
NOBUG mod_surveypro: $string['hideallitems'] defined twice

### DIFF
--- a/lang/en/surveypro.php
+++ b/lang/en/surveypro.php
@@ -225,7 +225,6 @@ $string['hassubmissions_alert'] = 'This survey has already been answered at leas
 $string['hidden_help'] = 'Use this option to hide the element. Hided elements will not be available to anyone. You can consider these elements as not part of the survey.';
 $string['hidden'] = 'Hidden element. Unhide it to personalize.';
 $string['hideallitems'] = 'Hide all elements';
-$string['hideallitems'] = 'hide all item';
 $string['hidefield'] = 'Visible element. Chilck to hide.';
 $string['hideinstructions_help'] = 'Use this checkbox to show/hide filling instruction for this element.';
 $string['hideinstructions'] = 'Hide filling instruction';


### PR DESCRIPTION
removed the second definition of $string['hideallitems']