### PR TITLE
CONTRIB-6449 mod_surveypro: denied sort by customnumber

### DIFF
--- a/classes/itemlist.php
+++ b/classes/itemlist.php
@@ -668,6 +668,7 @@ class mod_surveypro_itemlist {
 
         $table->sortable(true, 'sortindex', 'ASC'); // Sorted by sortindex by default.
         $table->no_sorting('content');
+        $table->no_sorting('customnumber');
         $table->no_sorting('parentitem');
         $table->no_sorting('parentconstraints');
         $table->no_sorting('status');


### PR DESCRIPTION
Sorting elements by custom number in relation table leads to a mysql error.
SELECT id as itemid, plugin, type FROM head_surveypro_item WHERE surveyproid = ? ORDER BY customnumber ASC, sortindex DESC
[array (
0 => '152',
)]

Error code: dmlreadexception
Stack trace:

line 474 of /lib/dml/moodle_database.php: dml_read_exception thrown
line 1027 of /lib/dml/mysqli_native_moodle_database.php: call to moodle_database->query_end()
line 1250 of /lib/dml/moodle_database.php: call to mysqli_native_moodle_database->get_recordset_sql()
line 1198 of /lib/dml/moodle_database.php: call to moodle_database->get_recordset_select()
line 705 of /mod/surveypro/classes/itemlist.php: call to moodle_database->get_recordset()
line 101 of /mod/surveypro/layout_validation.php: call to mod_surveypro_itemlist->display_relations_table()