### PR TITLE
NOBUG mod_surveypro: added correct $error definition

### DIFF
--- a/field/textarea/form/itemsetup_form.php
+++ b/field/textarea/form/itemsetup_form.php
@@ -108,6 +108,7 @@ class mod_surveypro_itemsetupform extends mod_surveypro_itembaseform {
         // Useless: $surveypro = $this->_customdata->surveypro;.
 
         $errors = parent::validation($data, $files);
+
         if (strlen($data['maxlength'])) {
             $isinteger = (bool)(strval(intval($data['maxlength'])) == strval($data['maxlength']));
             if (!$isinteger) {

--- a/form/items/itembase_form.php
+++ b/form/items/itembase_form.php
@@ -344,7 +344,7 @@ class mod_surveypro_itembaseform extends moodleform {
         // Useless: $item = $this->_customdata->item;.
         // Useless: $surveypro = $this->_customdata->surveypro;.
 
-        $errors = array();
+        $errors = parent::validation($data, $files);
 
         // Editing teacher can not set "noanswer" as default option if the item is mandatory.
         if ( isset($data['defaultvalue_check']) && isset($data['required']) ) {

--- a/form/outform/fill_form.php
+++ b/form/outform/fill_form.php
@@ -276,9 +276,9 @@ class mod_surveypro_outform extends moodleform {
         }
 
         $errors = parent::validation($data, $files);
-        $warnings = array();
 
         // Validate an item only if is enabled, alias: only if its content matches the parent-child constrain
+        $warnings = array();
         $olditemid = 0;
         foreach ($data as $elementname => $content) {
             if ($matches = mod_surveypro_utility::get_item_parts($elementname)) {

--- a/form/outform/search_form.php
+++ b/form/outform/search_form.php
@@ -134,7 +134,7 @@ class mod_surveypro_searchform extends moodleform {
         $surveypro = $this->_customdata->surveypro;
         // Useless: $canaccessreserveditems = $this->_customdata->canaccessreserveditems;.
 
-        $errors = array();
+        $errors = parent::validation($data, $files);
 
         $olditemid = 0;
         foreach ($data as $elementname => $unused) {

--- a/report/frequency/form/item_form.php
+++ b/report/frequency/form/item_form.php
@@ -96,7 +96,7 @@ class mod_surveypro_chooseitemform extends moodleform {
         // Get _customdata.
         // Useless: $surveypro = $this->_customdata->surveypro;.
 
-        $errors = array();
+        $errors = parent::validation($data, $files);
 
         if (!$data['itemid']) {
             $errors['itemid'] = get_string('pleasechooseavalue', 'surveyproreport_frequency');


### PR DESCRIPTION
I had no evidence at all of an error but I think the correct way to proceed is using
`$errors = parent::validation($data, $files);`