### PR TITLE
CONTRIB-6466 mod_surveypro: new test for numbers using different formats

### DIFF
--- a/classes/submission.php
+++ b/classes/submission.php
@@ -839,6 +839,63 @@ class mod_surveypro_submission {
     }
 
     /**
+     * Actually display the thanks page.
+     *
+     * @return void
+     */
+    public function show_thanks_page($responsestatus, $formview) {
+        global $OUTPUT;
+
+        if ($responsestatus == SURVEYPRO_MISSINGMANDATORY) {
+            $a = get_string('statusinprogress', 'mod_surveypro');
+            $message = get_string('missingmandatory', 'mod_surveypro', $a);
+            echo $OUTPUT->notification($message, 'notifyproblem');
+        }
+
+        if ($responsestatus == SURVEYPRO_MISSINGVALIDATION) {
+            $a = get_string('statusinprogress', 'mod_surveypro');
+            $message = get_string('missingvalidation', 'mod_surveypro', $a);
+            echo $OUTPUT->notification($message, 'notifyproblem');
+        }
+
+        if ($formview == SURVEYPRO_EDITRESPONSE) {
+            $message = get_string('basic_editthanks', 'mod_surveypro');
+        } else {
+            if (!empty($this->surveypro->thankshtml)) {
+                $htmlbody = $this->surveypro->thankshtml;
+                $component = 'mod_surveypro';
+                $filearea = SURVEYPRO_THANKSHTMLFILEAREA;
+                $message = file_rewrite_pluginfile_urls($htmlbody, 'pluginfile.php', $this->context->id, $component, $filearea, $this->surveypro->id);
+            } else {
+                $message = get_string('basic_submitthanks', 'mod_surveypro');
+            }
+        }
+
+        $utilityman = new mod_surveypro_utility($this->cm, $this->surveypro);
+        $cansubmitmore = $utilityman->can_submit_more();
+
+        $paramurlbase = array('id' => $this->cm->id);
+        if ($cansubmitmore) { // If the user is allowed to submit one more response.
+            $paramurl = $paramurlbase + array('view' => SURVEYPRO_NEWRESPONSE);
+            $buttonurl = new moodle_url('/mod/surveypro/view_form.php', $paramurl);
+            $onemore = new single_button($buttonurl, get_string('addnewsubmission', 'mod_surveypro'));
+
+            $buttonurl = new moodle_url('/mod/surveypro/view.php', $paramurlbase);
+            $gotolist = new single_button($buttonurl, get_string('gotolist', 'mod_surveypro'));
+
+            echo $OUTPUT->box_start('generalbox centerpara', 'notice');
+            echo html_writer::tag('p', $message);
+            echo html_writer::tag('div', $OUTPUT->render($onemore).$OUTPUT->render($gotolist), array('class' => 'buttons'));
+            echo $OUTPUT->box_end();
+        } else {
+            echo $OUTPUT->box($message, 'notice centerpara');
+            $buttonurl = new moodle_url('/mod/surveypro/view.php', $paramurlbase);
+            $buttonlabel = get_string('gotolist', 'mod_surveypro');
+            echo $OUTPUT->box($OUTPUT->single_button($buttonurl, $buttonlabel, 'get'), 'generalbox centerpara');
+        }
+    }
+
+    /**
      * User interaction for single submission duplication.
      *
      * If the action is missing confirmation: ask.

--- a/field/numeric/tests/behat/multiformat.feature
+++ b/field/numeric/tests/behat/multiformat.feature
@@ -1,0 +1,56 @@
+@mod @mod_surveypro @surveyprofield @surveyprofield_numeric @current
+Feature: verify the input with different number format
+  In order to verify numbers are correctly handled in different languages // Why this feature is useful
+  As student1                                                             // It can be 'an admin', 'a teacher', 'a student', 'a guest', 'a user', 'a tests writer' and 'a developer'
+  I submit a numeric field                                                // The feature we want
+
+  Background:
+    Given remote langimport tests are enabled
+    And the following "courses" exist:
+      | fullname                  | shortname | category | groupmode |
+      | Multiformat numeric input | MF Number | 0        | 0         |
+    And the following "users" exist:
+      | username | firstname | lastname | email                |
+      | student1 | Student1  | user1    | student1@nowhere.net |
+    And the following "course enrolments" exist:
+      | user     | course    | role           |
+      | student1 | MF Number | student        |
+    And the following "activities" exist:
+      | activity  | name                           | intro                          | course    | idnumber   |
+      | surveypro | Test multiformat numeric input | Test multiformat numeric input | MF Number | surveypro1 |
+    And surveypro "Test multiformat numeric input" contains the following items:
+      | type   | plugin  |
+      | field  | numeric |
+
+  @javascript
+  Scenario: submit the numeric field using two different formats
+    And I log in as "admin"
+    And I navigate to "Language packs" node in "Site administration > Language"
+    And I set the field "menupack" to "Italiano"
+    And I press "Install selected language pack(s)"
+    Then I should see "Language pack 'it' was successfully installed"
+    And I log out
+
+    # Force English for UI.
+    And I follow "English" in the language menu
+    And I log in as "student1"
+    And I am on site homepage
+    And I follow "Multiformat numeric input"
+    And I follow "Test multiformat numeric input"
+    And I press "New response"
+    And I set the field "Write the best approximation of π you can remember" to "3,14"
+    And I press "Submit"
+    Then I should see "Provided value is not a number"
+
+    And I set the field "Write the best approximation of π you can remember" to "3.14"
+    And I press "Submit"
+
+    And I follow "Italiano" in the language menu
+    And I press "Nuova risposta"
+    And I set the field "Write the best approximation of π you can remember" to "3.14"
+    And I press "Invia"
+    Then I should see "Provided value is not a number"
+
+    And I set the field "Write the best approximation of π you can remember" to "3,14"
+    And I press "Invia"
+

--- a/view.php
+++ b/view.php
@@ -40,6 +40,12 @@ if (!empty($id)) {
 
 require_course_login($course, true, $cm);
 
+// A response was submitted.
+$justsubmitted = optional_param('justsubmitted', 0, PARAM_INT);
+$formview = optional_param('formview', 0, PARAM_INT);
+$responsestatus = optional_param('responsestatus', 0, PARAM_INT);
+
+// The list is managed.
 $submissionid = optional_param('submissionid', 0, PARAM_INT);
 $action = optional_param('act', SURVEYPRO_NOACTION, PARAM_INT);
 $view = optional_param('view', SURVEYPRO_NOVIEW, PARAM_INT);
@@ -74,11 +80,15 @@ echo $OUTPUT->header();
 
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABSUBMISSIONS, SURVEYPRO_SUBMISSION_MANAGE);
 
-$submissionman->actions_feedback(); // Action feedback after PAGE.
+if (!empty($justsubmitted)) {
+    $submissionman->show_thanks_page($responsestatus, $formview);
+} else {
+    $submissionman->actions_feedback(); // Action feedback after PAGE.
 
-$submissionman->show_action_buttons();
-$submissionman->display_submissions_table();
-$submissionman->trigger_event(); // Event: all_submissions_viewed.
+    $submissionman->show_action_buttons();
+    $submissionman->display_submissions_table();
+    $submissionman->trigger_event(); // Event: all_submissions_viewed.
+}
 
 // Finish the page.
 echo $OUTPUT->footer();

--- a/view_form.php
+++ b/view_form.php
@@ -123,6 +123,21 @@ if ($userformman->formdata = $outform->get_data()) {
         $redirecturl = new moodle_url('/mod/surveypro/view_form.php', $paramurl);
         redirect($redirecturl); // Redirect to the first non empty page.
     }
+
+    // If none redirect you, reload THE RIGHT page WITHOUT $paramurl['view'].
+    // This is necessary otherwise if the user switches language using the corresponding menu
+    // just after a new response is submitted
+    // the browser redirects to http://localhost/head_behat/mod/surveypro/view_form.php?s=xxx&view=1&lang=it
+    // and not               to http://localhost/head_behat/mod/surveypro/view.php?s=xxx&lang=it
+    // alias it goes to the page to get one more response
+    // instead of remaining in the view submissions page.
+    $paramurl = array();
+    $paramurl['s'] = $surveypro->id;
+    $paramurl['responsestatus'] = $userformman->get_responsestatus();
+    $paramurl['justsubmitted'] = 1;
+    $paramurl['formview'] = $userformman->get_view(); // What was I viewing in the form?
+    $redirecturl = new moodle_url('/mod/surveypro/view.php', $paramurl);
+    redirect($redirecturl); // Redirect to the first non empty page.
 }
 // End of: manage form submission.
 
@@ -144,7 +159,6 @@ new mod_surveypro_tabs($cm, $context, $surveypro, $userformman->get_tabtab(), $u
 
 $userformman->noitem_stopexecution();
 $userformman->nomoresubmissions_stopexecution();
-$userformman->manage_thanks_page();
 $userformman->warning_submission_copy();
 $userformman->display_page_x_of_y();
 


### PR DESCRIPTION
In the frame of this patch I found an undiscovered issue.
To submits a surveypro, students are redirected to the view_form page.
The view_form page verifies the submission, saves it and much more.
IF a submissions was really performed (no pause, no cancel, no previous page button was pressed) the thanks page is displayed, buttons to continue are displayed AND THE EXECUTION IS STOPPED.
This is very bad because if in that page the student switches the lang using the corresponding menu, he/she is redirected to the view_form page that is the one to submit one more response and not to the thanks page were he/she actually is.
