### PR TITLE
CONTRIB-6476 mod_surveypro: improved submissions selection

### DIFF
--- a/report/attachments/uploads.php
+++ b/report/attachments/uploads.php
@@ -58,6 +58,7 @@ if (count($parts) == 2) {
 // Calculations.
 $context = context_module::instance($cm->id);
 $canaccessreserveditems = has_capability('mod/surveypro:accessreserveditems', $context, null, true);
+$canviewhiddenactivities = has_capability('moodle/course:viewhiddenactivities', $context);
 $uploadsformman = new surveyproreport_attachments_form($cm, $context, $surveypro);
 $uploadsformman->prevent_direct_user_input();
 $uploadsformman->set_userid($userid);
@@ -76,6 +77,7 @@ $formparams->itemid = $itemid;
 $formparams->userid = $userid;
 $formparams->submissionid = $submissionid;
 $formparams->canaccessreserveditems = $canaccessreserveditems;
+$formparams->canviewhiddenactivities = $canviewhiddenactivities;
 // End of: prepare params for the form.
 
 $filterform = new surveyproreport_filterform($formurl, $formparams, 'post', '', array('id' => 'userentry'));

--- a/report/delayedusers/classes/report.php
+++ b/report/delayedusers/classes/report.php
@@ -81,29 +81,52 @@ class surveyproreport_delayedusers_report extends mod_surveypro_reportbase {
     }
 
     /**
-     * Fetch_data
+     * Fetch_data.
+     *
+     * This is the idea supporting the code.
+     *
+     * Teachers is the role of users usually accessing reports.
+     * They are "teachers" so they care about "students" and nothing more.
+     * If, at import time, some records go under the admin ownership
+     * the teacher is not supposed to see them because admin is not a student.
+     * In this case, if the teacher wants to see submissions owned by admin, HE HAS TO ENROLL ADMIN with some role.
+     *
+     * Different is the story for the admin.
+     * If an admin wants to make a report, he will see EACH RESPONSE SUBMITTED
+     * without care to the role of the owner of the submission.
+     *
+     * @return void
      */
     public function fetch_data() {
         global $DB, $COURSE, $OUTPUT;
 
+        $canviewhiddenactivities = has_capability('moodle/course:viewhiddenactivities', $this->context);
+
         $coursecontext = context_course::instance($COURSE->id);
         $roles = get_roles_used_in_context($coursecontext);
         if (!$role = array_keys($roles)) {
-            // Return nothing.
-            return;
+            if (!$canviewhiddenactivities) {
+                // Return nothing.
+                return;
+            }
         }
+
+        $whereparams = array();
+        $whereparams['surveyproid'] = $this->surveypro->id;
         $sql = 'SELECT DISTINCT '.user_picture::fields('u').'
                 FROM {user} u
-                  JOIN (SELECT id, userid
-                        FROM {role_assignments}
-                        WHERE contextid = '.$coursecontext->id.'
-                          AND roleid IN ('.implode(',', $role).')) ra ON u.id = ra.userid
-                  LEFT JOIN (SELECT id, userid
-                             FROM {surveypro_submission}
-                             WHERE surveyproid = :surveyproid
-                             GROUP BY userid) s ON s.userid = u.id
-                WHERE ISNULL(s.id)';
-        $whereparams = array('surveyproid' => $this->surveypro->id);
+                    LEFT JOIN (SELECT id, userid
+                               FROM {surveypro_submission}
+                               WHERE surveyproid = :surveyproid
+                               GROUP BY userid) s ON s.userid = u.id';
+        if (!$canviewhiddenactivities) {
+            $sql .= ' JOIN (SELECT id, userid
+                            FROM {role_assignments}
+                            WHERE contextid = :contextid
+                                AND roleid IN ('.implode(',', $role).')) ra ON u.id = ra.userid';
+            $whereparams['contextid'] = $coursecontext->id;
+        }
+        $sql .= ' WHERE ISNULL(s.id)';
 
         list($where, $filterparams) = $this->outputtable->get_sql_where();
         if ($where) {

--- a/report/frequency/form/item_form.php
+++ b/report/frequency/form/item_form.php
@@ -96,6 +96,8 @@ class mod_surveypro_chooseitemform extends moodleform {
         // Get _customdata.
         // Useless: $surveypro = $this->_customdata->surveypro;.
 
+        // TODO: why it does not show the message in the form even when $data['itemid'] == 0?
+
         $errors = parent::validation($data, $files);
 
         if (!$data['itemid']) {

--- a/report/frequency/view.php
+++ b/report/frequency/view.php
@@ -55,6 +55,12 @@ $paramurl = array('id' => $cm->id, 'rname' => 'frequency');
 $formurl = new moodle_url('/mod/surveypro/report/frequency/view.php', $paramurl);
 // End of: define $mform return url.
 
+// Begin of: prepare params for the form.
+$formparams = new stdClass();
+$formparams->surveypro = $surveypro;
+$mform = new mod_surveypro_chooseitemform($formurl, $formparams);
+// End of: prepare params for the form.
+
 // Output starts here.
 $url = new moodle_url('/mod/surveypro/report/frequency/view.php', array('s' => $surveypro->id));
 $PAGE->set_url($url);
@@ -75,13 +81,8 @@ $reportman->stop_if_textareas_only();
 $reportman->nosubmissions_stop();
 // End of: stop here if no submissions are available.
 
-// Begin of: prepare params for the form.
-$formparams = new stdClass();
-$formparams->surveypro = $surveypro;
-$mform = new mod_surveypro_chooseitemform($formurl, $formparams);
-// End of: prepare params for the form.
-
 // Begin of: display the form.
+$mform->set_data(array('itemid' => $itemid));
 $mform->display();
 // End of: display the form.
 


### PR DESCRIPTION
Background.

Let's understand: submission === response.

At responses import time (from "moodle instance 1" to "moodle instance 2"),
the ownership of responses is assigned to the user with id == submission->userid.
It may happen that a submission has a userid not existing in "moodle instance 2".
In this case the ownership of the response is assigned to the user that is performing the import.
This user is not forced to be enrolled in the course so, at the end, it may happen that a submission in "moodle instance 2" is assigned to a not enrolled user.
This is the background.

The issue:
Usually the teacher don't want to see submissions from user not enrolled.
At the same time the admin WANTS to see its submissions even if he is not enrolled in the course.
So... which submission has to be selected by queries?

The agreed answer is this:

     * Teachers is the role of users usually accessing reports.
     * They are "teachers" so they care about "students" and nothing more.
     * If, at import time, some records go under the admin ownership
     * the teacher is not supposed to see them because admin is not a student.
     * In this case, if the teacher wants to see submissions owned by admin, HE HAS TO ENROLL ADMIN with some role.
     *
     * Different is the story for the admin.
     * If an admin wants to make a report, he will see EACH RESPONSE SUBMITTED
     * without care to the role of the owner of the submission.

This issue adds this feature to the module.