### PR TITLE
CONTRIB-6482 mod_surveypro: replaced direct IN in sql

### DIFF
--- a/classes/view_form.php
+++ b/classes/view_form.php
@@ -809,14 +809,18 @@ class mod_surveypro_view_form extends mod_surveypro_formbase {
         }
 
         $pages = range($this->get_formpage() + 1, $this->firstpageright - 1);
+        list($insql, $whereparams) = $DB->get_in_or_equal($pages, SQL_PARAMS_NAMED, 'pages');
+        $whereparams['surveyproid'] = $this->surveypro->id;
         $where = 'surveyproid = :surveyproid
-                AND formpage IN ('.implode(',', $pages).')';
-        $itemlistid = $DB->get_records_select('surveypro_item', $where, array('surveyproid' => $this->surveypro->id), 'id', 'id');
+                AND formpage '.$insql;
+        $itemlistid = $DB->get_records_select('surveypro_item', $where, $whereparams, 'id', 'id');
         $itemlistid = array_keys($itemlistid);
 
+        list($insql, $whereparams) = $DB->get_in_or_equal($itemlistid, SQL_PARAMS_NAMED, 'itemid');
+        $whereparams['submissionid'] = $this->formdata->submissionid;
         $where = 'submissionid = :submissionid
-            AND itemid IN ('.implode(',', $itemlistid).')';
-        $DB->delete_records_select('surveypro_answer', $where, array('submissionid' => $this->formdata->submissionid));
+            AND itemid '.$insql;
+        $DB->delete_records_select('surveypro_answer', $where, $whereparams);
     }
 
     /**

--- a/lib.php
+++ b/lib.php
@@ -442,8 +442,10 @@ function surveypro_delete_instance($id) {
 
             if ($deletelist = $DB->get_records('surveypro_item', $whereparams, 'id', 'id')) {
                 $deletelist = array_keys($deletelist);
-                $select = 'itemid IN ('.implode(',', $deletelist).')';
-                $DB->delete_records_select($tablename, $select);
+                list($insql, $whereparams) = $DB->get_in_or_equal($deletelist, SQL_PARAMS_NAMED, 'delete');
+                $select = 'itemid '.$insql;
+
+                $DB->delete_records_select($tablename, $select, $whereparams);
             }
         }
     }


### PR DESCRIPTION
There are still some occurrences of 
IN ('.implode(',', $xxx).')'
in the code that should be replaced by appropriate code.

I am not fixing the code into reports because I will fix them when I will add the group filter.