### PR TITLE
CONTRIB-6492 mod_surveypro:changed logic search

### DIFF
--- a/classes/reportbase.php
+++ b/classes/reportbase.php
@@ -224,15 +224,22 @@ class mod_surveypro_reportbase {
 
     /**
      * get_middle_sql
+     *
+     * @param bool $actualrelation the kind of relation I need in the query
+     * @return array($sql, $whereparams);
      */
-    public function get_middle_sql() {
+    public function get_middle_sql($actualrelation=true) {
         global $COURSE;
 
         $coursecontext = context_course::instance($COURSE->id);
         $canviewhiddenactivities = has_capability('moodle/course:viewhiddenactivities', $coursecontext);
 
         $whereparams = array();
-        $whereparams['surveyproid'] = $this->surveypro->id;
+        if ($actualrelation) {
+            $whereparams['surveyproid'] = $this->surveypro->id;
+        } else {
+            $whereparams['surveyproid'] = null;
+        }
 
         list($enrolsql, $eparams) = get_enrolled_sql($coursecontext);
 
@@ -244,6 +251,8 @@ class mod_surveypro_reportbase {
                     $whereparams['eu.id'] = null;
                     break;
                 case 0: // Each user with submissions.
+                    // JOIN $enrolsql is needed to take guest out!
+                    $sql .= ' JOIN ('.$enrolsql.') eu ON eu.id = u.id';
                     break;
                 default: // Each user of group xx with submissions.
                     $sql .= ' JOIN {groups_members} gm ON gm.userid = u.id';

--- a/report/delayedusers/classes/report.php
+++ b/report/delayedusers/classes/report.php
@@ -127,15 +127,21 @@ class surveyproreport_delayedusers_report extends mod_surveypro_reportbase {
      * @return array($sql, $whereparams);
      */
     public function get_submissions_sql() {
+        $whereparams = array();
         $submissiontable = 'SELECT userid, surveyproid
                             FROM {surveypro_submission}
-                            GROUP BY userid';
+                            WHERE surveyproid = :subsurveyproid
+                            GROUP BY userid, surveyproid';
+        $whereparams['subsurveyproid'] = $this->surveypro->id;
+
         $sql = 'SELECT '.user_picture::fields('u').', s.surveyproid
                 FROM {user} u
-                JOIN ('.$submissiontable.') s ON s.userid = u.id';
+                LEFT JOIN ('.$submissiontable.') s ON s.userid = u.id';
 
-        list($middlesql, $whereparams) = $this->get_middle_sql();
+        list($middlesql, $middleparams) = $this->get_middle_sql(false);
         $sql .= $middlesql;
+        $whereparams = array_merge($whereparams, $middleparams);
+        unset($whereparams['surveyproid']);
 
         if ($this->outputtable->get_sql_sort()) {
             $sql .= ' ORDER BY '.$this->outputtable->get_sql_sort();

--- a/report/delayedusers/view.php
+++ b/report/delayedusers/view.php
@@ -58,7 +58,20 @@ if ($showjumper) {
 
     $formparams = new stdClass();
     $formparams->canaccessallgroups = $canaccessallgroups;
-    $formparams->addnotinanygroup = $reportman->add_notinanygroup();
+    // Bloody tricky trap!
+    // ALWAYS set $formparams->addnotinanygroup to false, here!
+    // Don't set it to $reportman->add_notinanygroup();!
+
+    // It is a logical fail. You can not ask for users...
+    // "not in any group" (alias: "not enrolled") && "still not submitting"
+    // because guest user will ALWAYS be counted.
+    // If a user is "not enrolled", of course he still didn't submit.
+
+    // The "not in any group" item, here, IS A NONSENSE
+    // it is needed when users...
+    // ACTUALLY HAVE submissions EVEN IF they are not enrolled
+    // but in this report I look for users WITHOUT submissions.
+    $formparams->addnotinanygroup = false;
     $formparams->jumpercontent = $jumpercontent;
     $groupfilterform = new mod_surveypro_groupfilterform($formurl, $formparams);
 }


### PR DESCRIPTION
Currently, for courses divided into groups, the delayed user report allows to select:
- users from all groups
- users from a single group
- users non enrolled.

This last option IS A LOGICAL ERROR.
You can not ask for users...
"not in any group" (alias: "not enrolled") && "still not submitting" (delayed)
because guest user will ALWAYS be counted.
If a user is "not enrolled", of course he still didn't submit.

The "not in any group" item, in the "delayed user" report, IS A NONSENSE
it is needed when users...
ACTUALLY HAVE submissions EVEN IF they are not enrolled
but in this report only users WITHOUT submission are searched.
