### PR TITLE
CONTRIB-6493 mod_surveypro: changed navigation in lib.php

### DIFF
--- a/report/colles/classes/report.php
+++ b/report/colles/classes/report.php
@@ -182,19 +182,41 @@ class surveyproreport_colles_report extends mod_surveypro_reportbase {
      * Get child reports.
      *
      * @param bool $canaccessreports
-     * @return mixed array if child reports are available, void otherwise
+     * @return $childreports
      */
     public function has_childreports($canaccessreports) {
-        if ($canaccessreports) {
-            $childreports = array();
-            $childreports['summary'] = array('type' => 'summary');
-            $childreports['scales'] = array('type' => 'scales');
-            $childreports['questions'] = array('type' => 'questions');
-
-            return $childreports;
-        } else {
+        if (!$canaccessreports) {
             return false;
         }
+
+        $questionreports = array();
+        $questionreports['fieldset_content_01'] = array('type' => 'questions', 'area' => 0);
+        $questionreports['fieldset_content_02'] = array('type' => 'questions', 'area' => 1);
+        $questionreports['fieldset_content_03'] = array('type' => 'questions', 'area' => 2);
+        $questionreports['fieldset_content_04'] = array('type' => 'questions', 'area' => 3);
+        $questionreports['fieldset_content_05'] = array('type' => 'questions', 'area' => 4);
+        $questionreports['fieldset_content_06'] = array('type' => 'questions', 'area' => 5);
+
+        $childreports = array();
+        $childreports['summary'] = array('type' => 'summary');
+        $childreports['scales'] = array('type' => 'scales');
+        $childreports['areas'] = $questionreports;
+
+        // To uncomment the next code to get examples of nested navigation into admin > report block,
+        // you have to add strings corresponding to keys to $this->surveypro->template lang file.
+        // $subfourtharray = array();
+        // $subfourtharray['4.3.1'] = array('type' => 'fourth', 'foo' => 3, 'bar' => 1);
+        // $subfourtharray['4.3.2'] = array('type' => 'fourth', 'foo' => 3, 'bar' => 2);
+        // $subfourtharray['4.3.3'] = array('type' => 'fourth', 'foo' => 3, 'bar' => 3);
+
+        // $fourtharray = array();
+        // $fourtharray['4.1'] = array('type' => 'fourth', 'foo' => 1);
+        // $fourtharray['4.2'] = array('type' => 'fourth', 'foo' => 2);
+        // $fourtharray['4.3'] = $subfourtharray;
+
+        // $childreports['fourth'] = $fourtharray;
+
+        return $childreports;
     }
 
     /**

--- a/template/collesactual/lang/en/surveyprotemplate_collesactual.php
+++ b/template/collesactual/lang/en/surveyprotemplate_collesactual.php
@@ -23,6 +23,9 @@
  */
 
 $string['pluginname'] = 'COLLES (Actual)';
+$string['summary'] = 'Summary';
+$string['scales'] = 'Scales';
+$string['areas'] = 'Questions';
 
 $string['useritem'] = 'Style of the choice elements';
 $string['useritem_desc'] = 'This option let you choose the style of the elemets for the choices of the survey. "Radio buttons" is the standard, "Drop down menu" is better for not huge monitors.<br />Changes will take effect with new surveypro';

--- a/template/collesactual/lang/it/surveyprotemplate_collesactual.php
+++ b/template/collesactual/lang/it/surveyprotemplate_collesactual.php
@@ -23,6 +23,9 @@
  */
 
 $string['pluginname'] = 'COLLES (Actual)';
+$string['summary'] = 'Riepilogo';
+$string['scales'] = 'Valutazioni';
+$string['areas'] = 'Aree';
 
 $string['useritem'] = 'Tipo di selettore';
 $string['useritem_desc'] = 'Questa opzione consente di scegliere il tipo di selettore per rispondere al sondaggio. "Bottoni radio" è lo standard, "Menu a tendina" è consigliato per i monitor di modeste dimensioni.<br />Le modifiche avranno effetto sui prossimi nuovi somdaggi.';
@@ -50,7 +53,7 @@ $string['radiobutton_content_04'] = '<p>quello che imparo è importante per la m
 $string['radiobutton_content_05'] = '<p>imparo come migliorare la mia pratica professionale.</p>';
 $string['radiobutton_content_06'] = '<p>quello che imparo si collega bene con la mia pratica professionale.</p>';
 
-$string['fieldset_content_02'] = 'Reflective thinking';
+$string['fieldset_content_02'] = 'Senso critico';
 
 // $string['label_content_02'] = '<p>In questa unità online...</p>';
 

--- a/template/collesactual/tests/behat/graphs.feature
+++ b/template/collesactual/tests/behat/graphs.feature
@@ -78,11 +78,26 @@ Feature: apply a COLLES (actual) mastertemplate to test graphs
     And I follow "To test COLLES graphs"
     And I follow "Run COLLES report"
 
-    And I navigate to "summary" node in "Surveypro administration > Report > Colles report"
+    And I navigate to "Summary" node in "Surveypro administration > Report > Colles report"
     Then I should not see "Summary report"
 
-    And I navigate to "scales" node in "Surveypro administration > Report > Colles report"
+    And I navigate to "Scales" node in "Surveypro administration > Report > Colles report"
     Then I should not see "Scales report"
 
-    And I navigate to "questions" node in "Surveypro administration > Report > Colles report"
+    And I navigate to "Relevance" node in "Surveypro administration > Report > Colles report > Questions"
+    Then I should not see "Questions report"
+
+    And I navigate to "Reflective thinking" node in "Surveypro administration > Report > Colles report > Questions"
+    Then I should not see "Questions report"
+
+    And I navigate to "Interactivity" node in "Surveypro administration > Report > Colles report > Questions"
+    Then I should not see "Questions report"
+
+    And I navigate to "Tutor support" node in "Surveypro administration > Report > Colles report > Questions"
+    Then I should not see "Questions report"
+
+    And I navigate to "Peer support" node in "Surveypro administration > Report > Colles report > Questions"
+    Then I should not see "Questions report"
+
+    And I navigate to "Interpretation" node in "Surveypro administration > Report > Colles report > Questions"
     Then I should not see "Questions report"

--- a/template/collesactualpreferred/lang/en/surveyprotemplate_collesactualpreferred.php
+++ b/template/collesactualpreferred/lang/en/surveyprotemplate_collesactualpreferred.php
@@ -23,6 +23,9 @@
  */
 
 $string['pluginname'] = 'COLLES (Preferred and Actual)';
+$string['summary'] = 'Summary';
+$string['scales'] = 'Scales';
+$string['areas'] = 'Questions';
 
 $string['useritem'] = 'Style of the choice elements';
 $string['useritem_desc'] = 'This option let you choose the style of the elemets for the choices of the survey. "Radio buttons" is the standard, "Drop down menu" is better for not huge monitors.<br />Changes will take effect with new surveypro';

--- a/template/collesactualpreferred/lang/it/surveyprotemplate_collesactualpreferred.php
+++ b/template/collesactualpreferred/lang/it/surveyprotemplate_collesactualpreferred.php
@@ -23,6 +23,9 @@
  */
 
 $string['pluginname'] = 'COLLES (Ideale e Reale)';
+$string['summary'] = 'Riepilogo';
+$string['scales'] = 'Valutazioni';
+$string['areas'] = 'Aree';
 
 $string['useritem'] = 'Tipo di selettore';
 $string['useritem_desc'] = 'Questa opzione consente di scegliere il tipo di selettore per rispondere al sondaggio. "Bottoni radio" è lo standard, "Menu a tendina" è consigliato per i monitor di modeste dimensioni.<br />Le modifiche avranno effetto sui prossimi nuovi somdaggi.';

--- a/template/collesactualpreferred/tests/behat/graphs.feature
+++ b/template/collesactualpreferred/tests/behat/graphs.feature
@@ -108,11 +108,26 @@ Feature: apply a COLLES (actual and preferred) mastertemplate to test graphs
     And I follow "To test COLLES graphs"
     And I follow "Run COLLES report"
 
-    And I navigate to "summary" node in "Surveypro administration > Report > Colles report"
+    And I navigate to "Summary" node in "Surveypro administration > Report > Colles report"
     Then I should not see "Summary report"
 
-    And I navigate to "scales" node in "Surveypro administration > Report > Colles report"
+    And I navigate to "Scales" node in "Surveypro administration > Report > Colles report"
     Then I should not see "Scales report"
 
-    And I navigate to "questions" node in "Surveypro administration > Report > Colles report"
+    And I navigate to "Relevance" node in "Surveypro administration > Report > Colles report > Questions"
+    Then I should not see "Questions report"
+
+    And I navigate to "Reflective thinking" node in "Surveypro administration > Report > Colles report > Questions"
+    Then I should not see "Questions report"
+
+    And I navigate to "Interactivity" node in "Surveypro administration > Report > Colles report > Questions"
+    Then I should not see "Questions report"
+
+    And I navigate to "Tutor support" node in "Surveypro administration > Report > Colles report > Questions"
+    Then I should not see "Questions report"
+
+    And I navigate to "Peer support" node in "Surveypro administration > Report > Colles report > Questions"
+    Then I should not see "Questions report"
+
+    And I navigate to "Interpretation" node in "Surveypro administration > Report > Colles report > Questions"
     Then I should not see "Questions report"

--- a/template/collespreferred/lang/en/surveyprotemplate_collespreferred.php
+++ b/template/collespreferred/lang/en/surveyprotemplate_collespreferred.php
@@ -23,6 +23,9 @@
  */
 
 $string['pluginname'] = 'COLLES (Preferred)';
+$string['summary'] = 'Summary';
+$string['scales'] = 'Scales';
+$string['areas'] = 'Questions';
 
 $string['useritem'] = 'Style of the choice elements';
 $string['useritem_desc'] = 'This option let you choose the style of the elemets for the choices of the survey. "Radio buttons" is the standard, "Drop down menu" is better for not huge monitors.<br />Changes will take effect with new surveypro';

--- a/template/collespreferred/lang/it/surveyprotemplate_collespreferred.php
+++ b/template/collespreferred/lang/it/surveyprotemplate_collespreferred.php
@@ -23,6 +23,9 @@
  */
 
 $string['pluginname'] = 'COLLES (Ideale)';
+$string['summary'] = 'Riepilogo';
+$string['scales'] = 'Valutazioni';
+$string['areas'] = 'Aree';
 
 $string['useritem'] = 'Tipo di selettore';
 $string['useritem_desc'] = 'Questa opzione consente di scegliere il tipo di selettore per rispondere al sondaggio. "Bottoni radio" è lo standard, "Menu a tendina" è consigliato per i monitor di modeste dimensioni.<br />Le modifiche avranno effetto sui prossimi nuovi somdaggi.';
@@ -50,7 +53,7 @@ $string['radiobutton_content_04'] = '<p>quello che imparo è importante per la m
 $string['radiobutton_content_05'] = '<p>imparo come migliorare la mia pratica professionale.</p>';
 $string['radiobutton_content_06'] = '<p>quello che imparo si collega bene con la mia pratica professionale.</p>';
 
-$string['fieldset_content_02'] = 'Reflective thinking';
+$string['fieldset_content_02'] = 'Senso critico';
 
 // $string['label_content_02'] = '<p>In questa unità online...</p>';
 

--- a/template/collespreferred/tests/behat/graphs.feature
+++ b/template/collespreferred/tests/behat/graphs.feature
@@ -78,11 +78,26 @@ Feature: apply a COLLES (preferred) mastertemplate to test graphs
     And I follow "To test COLLES graphs"
     And I follow "Run COLLES report"
 
-    And I navigate to "summary" node in "Surveypro administration > Report > Colles report"
+    And I navigate to "Summary" node in "Surveypro administration > Report > Colles report"
     Then I should not see "Summary report"
 
-    And I navigate to "scales" node in "Surveypro administration > Report > Colles report"
+    And I navigate to "Scales" node in "Surveypro administration > Report > Colles report"
     Then I should not see "Scales report"
 
-    And I navigate to "questions" node in "Surveypro administration > Report > Colles report"
+    And I navigate to "Relevance" node in "Surveypro administration > Report > Colles report > Questions"
+    Then I should not see "Questions report"
+
+    And I navigate to "Reflective thinking" node in "Surveypro administration > Report > Colles report > Questions"
+    Then I should not see "Questions report"
+
+    And I navigate to "Interactivity" node in "Surveypro administration > Report > Colles report > Questions"
+    Then I should not see "Questions report"
+
+    And I navigate to "Tutor support" node in "Surveypro administration > Report > Colles report > Questions"
+    Then I should not see "Questions report"
+
+    And I navigate to "Peer support" node in "Surveypro administration > Report > Colles report > Questions"
+    Then I should not see "Questions report"
+
+    And I navigate to "Interpretation" node in "Surveypro administration > Report > Colles report > Questions"
     Then I should not see "Questions report"


### PR DESCRIPTION
Colles report is divided into three sections: Summary, Scales and Questions.
The first section consists into a single graphic.
It is called by Administration > Surveypro administration > Report > Colles report > summary.
Clicking on the graphic the report changes to Scales section.
This section is a 6 graphs page, one per each Scale: Relevance, Reflective Thinking...
Clicking again on the graphs the report moves to Questions section. This section has 4 graphs per each Scale.
Currently this third section is unique and is build with 6x4 graphs but should be divided into 6 sections of 4 graphs only with corresponding items in the Administration > Surveypro administration > Report > Colles report