### PR TITLE
CONTRIB-6520 mod_surveypro: bad use of parent userform_db_to_export

### DIFF
--- a/classes/itembase.php
+++ b/classes/itembase.php
@@ -1535,6 +1535,27 @@ class mod_surveypro_itembase {
     }
 
     /**
+     * Manage standard content used by all items.
+     *
+     * @param string $content
+     * @return string - the string for the export file
+     */
+    public static function userform_standardcontent_to_string($content) {
+        $quickresponse = null;
+
+        // The content of the provided answer.
+        if ($content == SURVEYPRO_NOANSWERVALUE) { // Answer was "no answer".
+            $quickresponse = get_string('answerisnoanswer', 'mod_surveypro');
+        } else if ($content == SURVEYPRO_ANSWERNOTINDBVALUE) { // Item was disabled. (used by frequency report).
+            $quickresponse = get_string('notanswereditem', 'mod_surveypro');
+        } else if ($content === null) { // Item was disabled.
+            $quickresponse = get_string('notanswereditem', 'mod_surveypro');
+        }
+
+        return $quickresponse;
+    }
+
+    /**
      * Starting from the info stored into $answer, this function returns the corresponding content for the export file.
      *
      * @param object $answer
@@ -1542,18 +1563,25 @@ class mod_surveypro_itembase {
      * @return string - the string for the export file
      */
     public function userform_db_to_export($answer, $format='') {
-        $response = null;
-
         // The content of the provided answer.
-        $content = trim($answer->content);
-        if ($content == SURVEYPRO_NOANSWERVALUE) { // Answer was "no answer".
-            $response = get_string('answerisnoanswer', 'mod_surveypro');
-        } else if ($content == SURVEYPRO_ANSWERNOTINDBVALUE) { // Item was disabled. (Used by frequenct report).
-            $response = get_string('notanswereditem', 'mod_surveypro');
-        } else if ($content === null) { // Item was disabled.
-            $response = get_string('notanswereditem', 'mod_surveypro');
+        $content = $answer->content;
+
+        $quickresponse = self::userform_standardcontent_to_string($content);
+        if ($quickresponse !== null) { // Parent method provided the response.
+            return $quickresponse;
         }
 
-        return $response;
+        // Output.
+        if (strlen($content)) {
+            $return = $content;
+        } else {
+            if ($format == SURVEYPRO_FRIENDLYFORMAT) {
+                $return = get_string('emptyanswer', 'mod_surveypro');
+            } else {
+                $return = '';
+            }
+        }
+
+        return $return;
     }
 }

--- a/classes/submission.php
+++ b/classes/submission.php
@@ -116,7 +116,6 @@ class mod_surveypro_submission {
 
         $this->prevent_direct_user_input($confirm);
         $this->submission_to_pdf();
-
     }
 
     // MARK set.
@@ -1451,8 +1450,8 @@ class mod_surveypro_submission {
                 $html = str_replace('@@col2@@', $content, $html);
 
                 // Third column.
-                if (isset($userdatarecord[$item->get_itemid()])) {
-                    $content = $item->userform_db_to_export($userdatarecord[$item->get_itemid()], SURVEYPRO_FRIENDLYFORMAT);
+                if (isset($userdatarecord[$itemseed->id])) {
+                    $content = $item->userform_db_to_export($userdatarecord[$itemseed->id], SURVEYPRO_FRIENDLYFORMAT);
                     if ($item->get_plugin() != 'textarea') { // Content does not come from an html editor.
                         $content = htmlspecialchars($content, ENT_NOQUOTES, 'UTF-8');
                         $content = str_replace(SURVEYPRO_OUTPUTMULTICONTENTSEPARATOR, '<br />', $content);

--- a/classes/view_form.php
+++ b/classes/view_form.php
@@ -597,9 +597,14 @@ class mod_surveypro_view_form extends mod_surveypro_formbase {
         $this->save_surveypro_submission();
         // End of: let's start by saving one record in surveypro_submission.
 
+        // Generate $itemhelperinfo.
         $itemhelperinfo = array();
         foreach ($this->formdata as $elementname => $content) {
-            if (!$matches = mod_surveypro_utility::get_item_parts($elementname)) {
+            if ($matches = mod_surveypro_utility::get_item_parts($elementname)) {
+                if ($matches['prefix'] == SURVEYPRO_DONTSAVEMEPREFIX) {
+                    continue; // To next foreach.
+                }
+            } else {
                 // Button or something not relevant.
                 if ($elementname == 's') {
                     $surveyproid = $content;
@@ -609,10 +614,6 @@ class mod_surveypro_view_form extends mod_surveypro_formbase {
                 // - nextbutton
                 // and some more.
                 continue; // To next foreach.
-            } else {
-                if ($matches['prefix'] == SURVEYPRO_DONTSAVEMEPREFIX) {
-                    continue; // To next foreach.
-                }
             }
 
             $itemid = $matches['itemid'];

--- a/field/age/classes/field.php
+++ b/field/age/classes/field.php
@@ -717,13 +717,13 @@ EOS;
      * @return string - the string for the export file
      */
     public function userform_db_to_export($answer, $format='') {
-        $quickresponse = parent::userform_db_to_export($answer, $format);
+        // The content of the provided answer.
+        $content = $answer->content;
+
+        $quickresponse = self::userform_standardcontent_to_string($content);
         if ($quickresponse !== null) { // Parent method provided the response.
             return $quickresponse;
         }
-
-        // The content of the provided answer.
-        $content = $answer->content;
 
         // Output.
         $agearray = self::item_split_unix_time($content);

--- a/field/boolean/classes/field.php
+++ b/field/boolean/classes/field.php
@@ -719,13 +719,13 @@ EOS;
      * @return string - the string for the export file
      */
     public function userform_db_to_export($answer, $format='') {
-        $quickresponse = parent::userform_db_to_export($answer, $format);
+        // The content of the provided answer.
+        $content = $answer->content;
+
+        $quickresponse = self::userform_standardcontent_to_string($content);
         if ($quickresponse !== null) { // Parent method provided the response.
             return $quickresponse;
         }
-
-        // The content of the provided answer.
-        $content = $answer->content;
 
         // Format.
         if ($format == SURVEYPRO_FRIENDLYFORMAT) {

--- a/field/character/classes/field.php
+++ b/field/character/classes/field.php
@@ -642,36 +642,6 @@ EOS;
     }
 
     /**
-     * Starting from the info stored into $answer, this function returns the corresponding content for the export file.
-     *
-     * @param object $answer
-     * @param string $format
-     * @return string - the string for the export file
-     */
-    public function userform_db_to_export($answer, $format='') {
-        $quickresponse = parent::userform_db_to_export($answer, $format);
-        if ($quickresponse !== null) { // Parent method provided the response.
-            return $quickresponse;
-        }
-
-        // The content of the provided answer.
-        $content = $answer->content;
-
-        // Output.
-        if (strlen($content)) {
-            $return = $content;
-        } else {
-            if ($format == SURVEYPRO_FRIENDLYFORMAT) {
-                $return = get_string('emptyanswer', 'mod_surveypro');
-            } else {
-                $return = '';
-            }
-        }
-
-        return $return;
-    }
-
-    /**
      * Returns an array with the names of the mform element added using $mform->addElement or $mform->addGroup.
      *
      * @return array

--- a/field/checkbox/classes/field.php
+++ b/field/checkbox/classes/field.php
@@ -879,13 +879,13 @@ EOS;
      * @return string - the string for the export file
      */
     public function userform_db_to_export($answer, $format='') {
-        $quickresponse = parent::userform_db_to_export($answer, $format);
+        // The content of the provided answer.
+        $content = $answer->content;
+
+        $quickresponse = self::userform_standardcontent_to_string($content);
         if ($quickresponse !== null) { // Parent method provided the response.
             return $quickresponse;
         }
-
-        // The content of the provided answer.
-        $content = $answer->content;
 
         // Format.
         if ($format == SURVEYPRO_FRIENDLYFORMAT) {

--- a/field/date/classes/field.php
+++ b/field/date/classes/field.php
@@ -773,13 +773,13 @@ EOS;
      * @return string - the string for the export file
      */
     public function userform_db_to_export($answer, $format='') {
-        $quickresponse = parent::userform_db_to_export($answer, $format);
+        // The content of the provided answer.
+        $content = $answer->content;
+
+        $quickresponse = self::userform_standardcontent_to_string($content);
         if ($quickresponse !== null) { // Parent method provided the response.
             return $quickresponse;
         }
-
-        // The content of the provided answer.
-        $content = $answer->content;
 
         // Format.
         if ($format == SURVEYPRO_FRIENDLYFORMAT) {

--- a/field/datetime/classes/field.php
+++ b/field/datetime/classes/field.php
@@ -883,13 +883,13 @@ EOS;
      * @return string - the string for the export file
      */
     public function userform_db_to_export($answer, $format='') {
-        $quickresponse = parent::userform_db_to_export($answer, $format);
+        // The content of the provided answer.
+        $content = $answer->content;
+
+        $quickresponse = self::userform_standardcontent_to_string($content);
         if ($quickresponse !== null) { // Parent method provided the response.
             return $quickresponse;
         }
-
-        // The content of the provided answer.
-        $content = $answer->content;
 
         // Format.
         if ($format == SURVEYPRO_FRIENDLYFORMAT) {

--- a/field/multiselect/classes/field.php
+++ b/field/multiselect/classes/field.php
@@ -750,13 +750,13 @@ EOS;
      * @return string - the string for the export file
      */
     public function userform_db_to_export($answer, $format='') {
-        $quickresponse = parent::userform_db_to_export($answer, $format);
+        // The content of the provided answer.
+        $content = $answer->content;
+
+        $quickresponse = self::userform_standardcontent_to_string($content);
         if ($quickresponse !== null) { // Parent method provided the response.
             return $quickresponse;
         }
-
-        // The content of the provided answer.
-        $content = $answer->content;
 
         // Format.
         if ($format == SURVEYPRO_FRIENDLYFORMAT) {

--- a/field/radiobutton/classes/field.php
+++ b/field/radiobutton/classes/field.php
@@ -791,13 +791,13 @@ EOS;
      * @return string - the string for the export file
      */
     public function userform_db_to_export($answer, $format='') {
-        $quickresponse = parent::userform_db_to_export($answer, $format);
+        // The content of the provided answer.
+        $content = $answer->content;
+
+        $quickresponse = self::userform_standardcontent_to_string($content);
         if ($quickresponse !== null) { // Parent method provided the response.
             return $quickresponse;
         }
-
-        // The content of the provided answer.
-        $content = $answer->content;
 
         // Format.
         if ($format == SURVEYPRO_FRIENDLYFORMAT) {

--- a/field/rate/classes/field.php
+++ b/field/rate/classes/field.php
@@ -611,13 +611,13 @@ EOS;
      * @return string - the string for the export file
      */
     public function userform_db_to_export($answer, $format='') {
-        $quickresponse = parent::userform_db_to_export($answer, $format);
+        // The content of the provided answer.
+        $content = $answer->content;
+
+        $quickresponse = self::userform_standardcontent_to_string($content);
         if ($quickresponse !== null) { // Parent method provided the response.
             return $quickresponse;
         }
-
-        // The content of the provided answer.
-        $content = $answer->content;
 
         // Format.
         if ($format == SURVEYPRO_FRIENDLYFORMAT) {

--- a/field/recurrence/classes/field.php
+++ b/field/recurrence/classes/field.php
@@ -731,13 +731,13 @@ EOS;
      * @return string - the string for the export file
      */
     public function userform_db_to_export($answer, $format='') {
-        $quickresponse = parent::userform_db_to_export($answer, $format);
+        // The content of the provided answer.
+        $content = $answer->content;
+
+        $quickresponse = self::userform_standardcontent_to_string($content);
         if ($quickresponse !== null) { // Parent method provided the response.
             return $quickresponse;
         }
-
-        // The content of the provided answer.
-        $content = $answer->content;
 
         // Format.
         if ($format == SURVEYPRO_FRIENDLYFORMAT) {

--- a/field/select/classes/field.php
+++ b/field/select/classes/field.php
@@ -742,13 +742,13 @@ EOS;
      * @return string - the string for the export file
      */
     public function userform_db_to_export($answer, $format='') {
-        $quickresponse = parent::userform_db_to_export($answer, $format);
+        // The content of the provided answer.
+        $content = $answer->content;
+
+        $quickresponse = self::userform_standardcontent_to_string($content);
         if ($quickresponse !== null) { // Parent method provided the response.
             return $quickresponse;
         }
-
-        // The content of the provided answer.
-        $content = $answer->content;
 
         // Format.
         if ($format == SURVEYPRO_FRIENDLYFORMAT) {

--- a/field/shortdate/classes/field.php
+++ b/field/shortdate/classes/field.php
@@ -698,13 +698,13 @@ EOS;
      * @return string - the string for the export file
      */
     public function userform_db_to_export($answer, $format='') {
-        $quickresponse = parent::userform_db_to_export($answer, $format);
+        // The content of the provided answer.
+        $content = $answer->content;
+
+        $quickresponse = self::userform_standardcontent_to_string($content);
         if ($quickresponse !== null) { // Parent method provided the response.
             return $quickresponse;
         }
-
-        // The content of the provided answer.
-        $content = $answer->content;
 
         // Format.
         if ($format == SURVEYPRO_FRIENDLYFORMAT) {

--- a/field/time/classes/field.php
+++ b/field/time/classes/field.php
@@ -743,13 +743,13 @@ EOS;
      * @return string - the string for the export file
      */
     public function userform_db_to_export($answer, $format='') {
-        $quickresponse = parent::userform_db_to_export($answer, $format);
+        // The content of the provided answer.
+        $content = $answer->content;
+
+        $quickresponse = self::userform_standardcontent_to_string($content);
         if ($quickresponse !== null) { // Parent method provided the response.
             return $quickresponse;
         }
-
-        // The content of the provided answer.
-        $content = $answer->content;
 
         // Format.
         if ($format == SURVEYPRO_FRIENDLYFORMAT) {


### PR DESCRIPTION
In the output to PDF of a response the numeric answers were dropped.
This was due to a bad use of the userform_db_to_export parent method.
It was not returning a self-consistent value so...
1) it worked fine for all the child classes calling it AND THEN refining the final output
2) it worked very bad for child classes not having that method at all.