### PR TITLE
NOBUG mod_surveypro: leave add_item always on top

### DIFF
--- a/lang/en/surveypro.php
+++ b/lang/en/surveypro.php
@@ -83,7 +83,6 @@ $string['badchildparentvalue'] = 'Malformed condition: "{$a}".<br />It might nev
 $string['badtablenamefound'] = 'Parse error reading xml. "{$a}" has been found as table name and, most probably, is invalid.';
 $string['basic_editthanks'] = 'Thank you. Your response has been successfully modified!';
 $string['basic_submitthanks'] = 'Thank you. Your response has been successfully submitted!';
-$string['beginfromscratch'] = 'To create a new survey you can apply a master template to get the survey all at once<br />or add elements one by one to create the survey that best suits your needs.';
 $string['branching'] = 'Branching';
 $string['canneversubmit'] = 'You are not allowed to submit a response';
 $string['cannotsubmittooearly'] = 'The survey is still not open. You have to wait until {$a}';
@@ -483,6 +482,7 @@ $string['verbose'] = 'Verbose (for human reading)';
 $string['versionmismatch'] = 'Version mismatch for {$a->plugin} {$a->type} plugin. Template uses version: {$a->currentversion} while your surveypro plugin uses version {$a->versiondisk}';
 $string['visiblesonly_help'] = 'Include in this template only visibles elements.';
 $string['visiblesonly'] = 'Visibles elements only';
+$string['welcome_emptysurvey'] = 'To create a new survey you can add elements one by one to build the survey that best suits your needs<br />or apply a master template to get a standard survey all at once.';
 $string['welcome_dataexport'] = 'Use this page to export responses of this survey. <br />
 A statistic software format is available such as a more human readable one. Export content depends on the "{$a}" choosen for each element (whether available).';
 $string['welcome_dataimport'] = 'Use this page to import responses into this survey. <br />

--- a/layout_items.php
+++ b/layout_items.php
@@ -95,9 +95,7 @@ $basecondition = $basecondition && empty($surveypro->template);
 $basecondition = $basecondition && (!$hassubmissions || $riskyediting);
 
 // Master template form.
-$mtemplatecondition = true;
-$mtemplatecondition = $mtemplatecondition && (!$itemcount);
-if ($mtemplatecondition) {
+if (!$itemcount) { // The surveypro is empty.
     require_once($CFG->dirroot.'/mod/surveypro/form/mtemplates/apply_form.php');
 
     $mtemplateman = new mod_surveypro_mastertemplate($cm, $context, $surveypro);
@@ -163,12 +161,10 @@ if ($hassubmissions) {
 $itemlistman->actions_feedback();
 $itemlistman->display_item_editing_feedback();
 
-if ($mtemplatecondition) {
-    // Display mtemplate form.
-    $message = get_string('beginfromscratch', 'mod_surveypro');
+if (!$itemcount) {
+    // Display welcome message.
+    $message = get_string('welcome_emptysurvey', 'mod_surveypro');
     echo $OUTPUT->notification($message, 'notifymessage');
-
-    $mtemplateform->display();
 }
 
 if ($newitemcondition) {
@@ -179,6 +175,11 @@ if ($newitemcondition) {
 if ($bulkactioncondition) {
     // Display bulkaction form.
     $bulkactionform->display();
+}
+
+if (!$itemcount) {
+    // Display mtemplate form.
+    $mtemplateform->display();
 }
 
 $itemlistman->display_items_table();

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_surveypro'; // Full name of the plugin (used for diagnostics).
 $plugin->maturity = MATURITY_ALPHA; // MATURITY_RC.
-$plugin->version = 2016070801; // The current module version (Date: YYYYMMDDXX).
+$plugin->version = 2016091501; // The current module version (Date: YYYYMMDDXX).
 $plugin->release = '1.0'; // The current release.
 $plugin->requires = 2015111600; // Requires this Moodle version.
 $plugin->cron = 3600; // Period for cron to check this module (in seconds).


### PR DESCRIPTION
I simply received the request to always leave the add_item drop down menu on top of the page because currently...
- if the survey has no item: the add_item drop down is displayed in second position (the first one is for the master template drop down menu)
- once the survey is no longer empty: the add_item drop down is displayed in first position (the second position is for bulk action drop down menu).
People is complaining this is misleading.