### PR TITLE
CONTRIB-6533 surveypro: changed drop_jumped_saved_data

### DIFF
--- a/classes/view_form.php
+++ b/classes/view_form.php
@@ -809,8 +809,12 @@ class mod_surveypro_view_form extends mod_surveypro_formbase {
         if ($this->firstpageright == ($this->get_formpage() + 1)) {
             return;
         }
+        if ($this->firstpageright == SURVEYPRO_RIGHT_OVERFLOW) {
+            $pages = range($this->get_formpage() + 1, $this->get_maxassignedpage());
+        } else {
+            $pages = range($this->get_formpage() + 1, $this->firstpageright - 1);
+        }
 
-        $pages = range($this->get_formpage() + 1, $this->firstpageright - 1);
         list($insql, $whereparams) = $DB->get_in_or_equal($pages, SQL_PARAMS_NAMED, 'pages');
         $whereparams['surveyproid'] = $this->surveypro->id;
         $where = 'surveyproid = :surveyproid


### PR DESCRIPTION
This is a nasty rare issue occurring ONLY when last pages of the survey are not going to be displayed because they only hold child elements that are not supposed to appear because of the answer that their parents received.