### PR TITLE
CONTRIB-6534 mod_surveypro: added verified = 1

### DIFF
--- a/classes/submission.php
+++ b/classes/submission.php
@@ -1335,7 +1335,7 @@ class mod_surveypro_submission {
 
         $submission = $DB->get_record('surveypro_submission', array('id' => $this->submissionid));
         $user = $DB->get_record('user', array('id' => $submission->userid));
-        $where = array('submissionid' => $this->submissionid);
+        $where = array('submissionid' => $this->submissionid, 'verified' => 1);
         $userdatarecord = $DB->get_records('surveypro_answer', $where, '', 'itemid, id, content');
 
         $canaccessreserveditems = has_capability('mod/surveypro:accessreserveditems', $this->context, $user->id, true);


### PR DESCRIPTION
Super hidden issue occurring only to people not having enough sex!

Fill a surveypro lying over more than a page.
Fill each element and, when you are at the last page DO NOT SUBMIT
but
return back to the first page selecting `<< previous page` as much time as needed (please, make sex instead).
When you reach the first page select the "Responses" TAB.
Your response is shown as "In progress" in the page (of course, nobody submitted it) and...
if you ask for the PDF you get something that is different from what the export to CSV returns.

The reason is this.
In order to save what the user entered in the form, the save process is performed even when `<< previous` or `pause` buttons are pressed.
When people use the `pause` button they want to save the record EVEN IF THEIR ANSWERS ARE NOT VALID (i.e. they don't satisfy specific requirements, they are too long or out from a range or whatever). People says: "My time is over. I have to push `pause` without care to what I entered. Tomorrow I will give it some more attention."
When people use the `<< previous` button it is because they are not sure about what they entered in the previous pages but they don't want to loose what they entered in the last page.
Because of those reasons, answers to the elements of the pages in which the user returned back to previous page are still saved BUT MARKED AS NOT VERIFIED.

Well, if the students (not making sex) rewind the survey up to the first page HE CHANGES TO NOT VERIFIED answers that were marked as verified when they were firstly provided.

At the moment, the PDF uses ALL the answers while the export to CSV uses only VERIFIED answers.
Please make sex!