### PR TITLE
CONTRIB-6538 mod_surveypro: changed empty to !strlen

### DIFF
--- a/classes/itembase.php
+++ b/classes/itembase.php
@@ -282,7 +282,7 @@ class mod_surveypro_itembase {
         // so I can not save labels to parentvalue as they may change.
         // Because of this, even if the user writes, for instance, "bread\nmilk" to parentvalue
         // I have to encode it to key(bread);key(milk).
-        if (isset($record->parentid) && $record->parentid) {
+        if (!empty($record->parentid)) {
             $parentitem = surveypro_get_item($this->cm, $this->surveypro, $record->parentid);
             $record->parentvalue = $parentitem->parent_encode_child_parentcontent($record->parentcontent);
             unset($record->parentcontent);

--- a/form/items/itembase_form.php
+++ b/form/items/itembase_form.php
@@ -352,19 +352,19 @@ class mod_surveypro_itembaseform extends moodleform {
             $errors['defaultvalue_group'] = get_string('ierr_notalloweddefault', 'mod_surveypro', $a);
         }
 
-        if (empty($data['parentid']) && empty($data['parentcontent'])) {
+        if ( empty($data['parentid']) && (!strlen($data['parentcontent'])) ) {
             // Stop validation here.
             return $errors;
         }
 
         // You choosed a parentid but you are missing the parentcontent.
-        if (empty($data['parentid']) && (strlen($data['parentcontent']) > 0)) { // $data['parentcontent'] can be = '0'.
+        if ( empty($data['parentid']) && (strlen($data['parentcontent'])) ) { // $data['parentcontent'] can be = '0'.
             $a = get_string('parentcontent', 'mod_surveypro');
             $errors['parentid'] = get_string('ierr_missingparentid', 'mod_surveypro', $a);
         }
 
         // You did not choose a parent item but you entered an answer.
-        if ( !empty($data['parentid']) && (strlen($data['parentcontent']) == 0) ) { // $data['parentcontent'] can be = '0'.
+        if ( !empty($data['parentid']) && (!strlen($data['parentcontent'])) ) { // $data['parentcontent'] can be = '0'.
             $a = get_string('parentid', 'mod_surveypro');
             $errors['parentcontent'] = get_string('ierr_missingparentcontent', 'mod_surveypro', $a);
         }

--- a/locallib.php
+++ b/locallib.php
@@ -94,7 +94,7 @@ function surveypro_multilinetext_to_array($textareacontent) {
     // Use preg_replace (and not str_replace) because of eventual multiple instances of "\n\n".
     $textareacontent = preg_replace('~\n\n+~', "\n", $textareacontent);
 
-    if (empty($textareacontent)) {
+    if (!strlen($textareacontent)) {
         return array();
     }
 


### PR DESCRIPTION
First: create a branched surveypro with
boolean1 and
boolean2 where boolean2 is conditioned by answer to boolean1 == 1

The condition is well respected at fill time.

Second: create a branched surveypro with
boolean1 and
boolean2 where boolean2 is conditioned by answer to boolean1 == 0

The condition is not respected at fill time.

I fixed this by changing 
    if (empty($textareacontent)) {
to
    if (!strlen($textareacontent)) {
