### PR TITLE
CONTRIB-6546 surveypro: rewritten userform_child_item_allowed_dynamic

### DIFF
--- a/field/boolean/classes/field.php
+++ b/field/boolean/classes/field.php
@@ -611,41 +611,14 @@ EOS;
      * @return array
      */
     public function userform_get_parent_disabilitation_info($childparentvalue) {
-        $disabilitationinfo = array();
-
         $parentvalues = explode(SURVEYPRO_DBMULTICONTENTSEPARATOR, $childparentvalue); // 1;1;0;.
 
-        $indexsubset = array();
-        $labelsubset = array();
-        $key = array_search('>', $parentvalues);
-        if ($key !== false) {
-            $indexsubset = array_slice($parentvalues, 0, $key);
-            $labelsubset = array_slice($parentvalues, $key + 1);
-        } else {
-            $indexsubset = $parentvalues;
-        }
-
-        if ($indexsubset) {
-            // Only garbage after the first index, but user wrote it.
-            foreach ($indexsubset as $index) {
-                $mformelementinfo = new stdClass();
-                $mformelementinfo->parentname = $this->itemname;
-                $mformelementinfo->operator = 'neq';
-                $mformelementinfo->content = $index;
-                $disabilitationinfo[] = $mformelementinfo;
-            }
-        }
-
-        // Only garbage but user wrote it.
-        if ($labelsubset) {
-            foreach ($labelsubset as $label) {
-                $mformelementinfo = new stdClass();
-                $mformelementinfo->parentname = $this->itemname;
-                $mformelementinfo->operator = 'neq';
-                $mformelementinfo->content = $label;
-                $disabilitationinfo[] = $mformelementinfo;
-            }
-        }
+        $disabilitationinfo = array();
+        $mformelementinfo = new stdClass();
+        $mformelementinfo->parentname = $this->itemname;
+        $mformelementinfo->operator = 'neq';
+        $mformelementinfo->content = $parentvalues[0];
+        $disabilitationinfo[] = $mformelementinfo;
 
         return $disabilitationinfo;
     }

--- a/field/boolean/classes/field.php
+++ b/field/boolean/classes/field.php
@@ -665,7 +665,6 @@ EOS;
      * @return boolean: true: if the item is welcome; false: if the item must be dropped out
      */
     public function userform_child_item_allowed_dynamic($childparentvalue, $data) {
-        // In $data I can ONLY find $this->itemname.
         return ($data[$this->itemname] == $childparentvalue);
     }
 

--- a/field/integer/classes/field.php
+++ b/field/integer/classes/field.php
@@ -627,7 +627,6 @@ EOS;
      * @return boolean: true: if the item is welcome; false: if the item must be dropped out
      */
     public function userform_child_item_allowed_dynamic($childparentvalue, $data) {
-        // In $data I can ONLY find $this->itemname.
         return ($data[$this->itemname] == $childparentvalue);
     }
 

--- a/field/integer/classes/field.php
+++ b/field/integer/classes/field.php
@@ -573,41 +573,14 @@ EOS;
      * @return array
      */
     public function userform_get_parent_disabilitation_info($childparentvalue) {
-        $disabilitationinfo = array();
-
         $parentvalues = explode(SURVEYPRO_DBMULTICONTENTSEPARATOR, $childparentvalue); // 1;1;0;.
 
-        $indexsubset = array();
-        $labelsubset = array();
-        $key = array_search('>', $parentvalues);
-        if ($key !== false) {
-            $indexsubset = array_slice($parentvalues, 0, $key);
-            $labelsubset = array_slice($parentvalues, $key + 1);
-        } else {
-            $indexsubset = $parentvalues;
-        }
-
-        if ($indexsubset) {
-            // Only garbage after the first index, but user wrote it.
-            foreach ($indexsubset as $k => $index) {
-                $mformelementinfo = new stdClass();
-                $mformelementinfo->parentname = $this->itemname;
-                $mformelementinfo->operator = 'neq';
-                $mformelementinfo->content = $index;
-                $disabilitationinfo[] = $mformelementinfo;
-            }
-        }
-
-        if ($labelsubset) {
-            // Only garbage, but user wrote it.
-            foreach ($labelsubset as $k => $label) {
-                $mformelementinfo = new stdClass();
-                $mformelementinfo->parentname = $this->itemname;
-                $mformelementinfo->operator = 'neq';
-                $mformelementinfo->content = $label;
-                $disabilitationinfo[] = $mformelementinfo;
-            }
-        }
+        $disabilitationinfo = array();
+        $mformelementinfo = new stdClass();
+        $mformelementinfo->parentname = $this->itemname;
+        $mformelementinfo->operator = 'neq';
+        $mformelementinfo->content = $parentvalues[0];
+        $disabilitationinfo[] = $mformelementinfo;
 
         return $disabilitationinfo;
     }

--- a/field/multiselect/classes/field.php
+++ b/field/multiselect/classes/field.php
@@ -653,20 +653,23 @@ EOS;
      * @return boolean: true: if the item is welcome; false: if the item must be dropped out
      */
     public function userform_child_item_allowed_dynamic($childparentvalue, $data) {
-        // In $data I can ONLY find $this->itemname.
-
         // I need to verify (checkbox per checkbox) if they hold the same value the user entered.
         $labels = $this->item_get_content_array(SURVEYPRO_LABELS, 'options');
         $parentvalues = explode(SURVEYPRO_DBMULTICONTENTSEPARATOR, $childparentvalue); // 2;3.
 
-        $status = true;
-        foreach ($labels as $k => $unused) {
-            $key = array_search($k, $parentvalues);
-            if ($key !== false) {
-                $status = $status && (isset($data[$this->itemname.'_'.$k]));
+        if (isset($data[$this->itemname])) {
+            if (count(array_diff($data[$this->itemname], $parentvalues))) {
+                $status = false;
             } else {
-                $status = $status && (!isset($data[$this->itemname.'_'.$k]));
+                $status = true;
             }
+        } else {
+            // If $data[$this->itemname] is not set
+            // this means that either:
+            // 1. User answered "No answer".
+            // 2. User submitted the multiselect without selecting any item.
+            // In both cases, $status = false.
+            $status = false;
         }
 
         return $status;

--- a/field/radiobutton/classes/field.php
+++ b/field/radiobutton/classes/field.php
@@ -643,53 +643,24 @@ EOS;
 
         $parentvalues = explode(SURVEYPRO_DBMULTICONTENTSEPARATOR, $childparentvalue); // 1;1;0;.
 
-        $indexsubset = array();
-        $labelsubset = array();
-        $key = array_search('>', $parentvalues);
-        if ($key !== false) {
-            $indexsubset = array_slice($parentvalues, 0, $key);
-            $labelsubset = array_slice($parentvalues, $key + 1);
+        if ($parentvalues[0] == '>') {
+            $mformelementinfo = new stdClass();
+            $mformelementinfo->parentname = $this->itemname;
+            $mformelementinfo->operator = 'neq';
+            $mformelementinfo->content = 'other';
+            $disabilitationinfo[] = $mformelementinfo;
+
+            $mformelementinfo = new stdClass();
+            $mformelementinfo->parentname = $this->itemname.'_text';
+            $mformelementinfo->operator = 'neq';
+            $mformelementinfo->content = $parentvalues[1];
+            $disabilitationinfo[] = $mformelementinfo;
         } else {
-            $indexsubset = $parentvalues;
-        }
-
-        if ($indexsubset) {
-            // Only garbage after the first index, but user wrote it.
-            foreach ($indexsubset as $k => $index) {
-                $mformelementinfo = new stdClass();
-                $mformelementinfo->parentname = $this->itemname;
-                $mformelementinfo->operator = 'neq';
-                $mformelementinfo->content = $index;
-                $disabilitationinfo[] = $mformelementinfo;
-            }
-        }
-
-        if ($labelsubset) {
-            foreach ($labelsubset as $k => $label) {
-                // Only garbage after the first label, but user wrote it.
-                if (!empty($this->labelother)) {
-                    $mformelementinfo = new stdClass();
-                    $mformelementinfo->parentname = $this->itemname;
-                    $mformelementinfo->operator = 'neq';
-                    $mformelementinfo->content = 'other';
-                    $disabilitationinfo[] = $mformelementinfo;
-
-                    $mformelementinfo = new stdClass();
-                    $mformelementinfo->parentname = $this->itemname.'_text';
-                    $mformelementinfo->operator = 'neq';
-                    $mformelementinfo->content = $label;
-                    $disabilitationinfo[] = $mformelementinfo;
-                }
-            }
-        } else {
-            // Even if no labels were provided
-            // I have to add one more $disabilitationinfo if $this->other is not empty.
-            if (!empty($this->labelother)) {
-                $mformelementinfo = new stdClass();
-                $mformelementinfo->parentname = $this->itemname.'_other';
-                $mformelementinfo->content = 'checked';
-                $disabilitationinfo[] = $mformelementinfo;
-            }
+            $mformelementinfo = new stdClass();
+            $mformelementinfo->parentname = $this->itemname;
+            $mformelementinfo->operator = 'neq';
+            $mformelementinfo->content = $parentvalues[0];
+            $disabilitationinfo[] = $mformelementinfo;
         }
 
         return $disabilitationinfo;

--- a/field/radiobutton/classes/field.php
+++ b/field/radiobutton/classes/field.php
@@ -710,16 +710,19 @@ EOS;
      * @return boolean: true: if the item is welcome; false: if the item must be dropped out
      */
     public function userform_child_item_allowed_dynamic($childparentvalue, $data) {
-        // In $data I can ONLY find $this->itemname, $this->itemname.'_text'.
+        $parentvalues = explode(SURVEYPRO_DBMULTICONTENTSEPARATOR, $childparentvalue); // For instance: shark.
 
-        // I need to verify (checkbox per checkbox) if they hold the same value the user entered.
-        $labels = $this->item_get_content_array(SURVEYPRO_LABELS, 'options');
-
-        if ( ($this->labelother) && ($data[$this->itemname] == count($labels)) ) {
-            return ($data[$this->itemname.'_text'] == $childparentvalue);
+        // This is a radio button element. Only one answer is allowed.
+        if ($parentvalues[0] == '>' ) {
+            // The expected answer is a custom text.
+            $status = ($data[$this->itemname] == 'other');
+            $status = $status && ($data[$this->itemname.'_text'] == $parentvalues[1]);
         } else {
-            return ($data[$this->itemname] == $childparentvalue);
+            // $childparentvalue === $parentvalues[0] of course!
+            $status = ($data[$this->itemname] == $childparentvalue);
         }
+
+        return $status;
     }
 
     /**
@@ -745,6 +748,7 @@ EOS;
                     $olduseranswer->content = $answer['mainelement'];
                     break;
             }
+
             return;
         }
 

--- a/field/select/classes/field.php
+++ b/field/select/classes/field.php
@@ -662,17 +662,18 @@ EOS;
      * @return boolean: true: if the item is welcome; false: if the item must be dropped out
      */
     public function userform_child_item_allowed_dynamic($childparentvalue, $data) {
-        // In $data I can ONLY find $this->itemname, $this->itemname.'_text'.
+        $parentvalues = explode(SURVEYPRO_DBMULTICONTENTSEPARATOR, $childparentvalue); // For instance: shark.
 
-        // I need to verify (checkbox per checkbox) if they hold the same value the user entered.
-        $labels = $this->item_get_content_array(SURVEYPRO_LABELS, 'options');
-        // $parentvalues = explode(SURVEYPRO_DBMULTICONTENTSEPARATOR, $childparentvalue); // 2 OR shark.
-
-        if ( ($this->labelother) && ($data[$this->itemname] == count($labels)) ) {
-            return ($data[$this->itemname.'_text'] == $childparentvalue);
+        if ($parentvalues[0] == '>' ) {
+            // The expected answer is a custom text.
+            $status = ($data[$this->itemname] == 'other');
+            $status = $status && ($data[$this->itemname.'_text'] == $parentvalues[1]);
         } else {
-            return ($data[$this->itemname] == $childparentvalue);
+            // $childparentvalue === $parentvalues[0] of course!
+            $status = ($data[$this->itemname] == $childparentvalue);
         }
+
+        return $status;
     }
 
     /**

--- a/field/select/classes/field.php
+++ b/field/select/classes/field.php
@@ -595,53 +595,25 @@ EOS;
 
         $parentvalues = explode(SURVEYPRO_DBMULTICONTENTSEPARATOR, $childparentvalue); // 1;1;0;.
 
-        $indexsubset = array();
-        $labelsubset = array();
-        $key = array_search('>', $parentvalues);
-        if ($key !== false) {
-            $indexsubset = array_slice($parentvalues, 0, $key);
-            $labelsubset = array_slice($parentvalues, $key + 1);
+        if ($parentvalues[0] == '>') {
+            // The condition was set to a custom text.
+            $mformelementinfo = new stdClass();
+            $mformelementinfo->parentname = $this->itemname;
+            $mformelementinfo->operator = 'neq';
+            $mformelementinfo->content = 'other';
+            $disabilitationinfo[] = $mformelementinfo;
+
+            $mformelementinfo = new stdClass();
+            $mformelementinfo->parentname = $this->itemname.'_text';
+            $mformelementinfo->operator = 'neq';
+            $mformelementinfo->content = $parentvalues[1];
+            $disabilitationinfo[] = $mformelementinfo;
         } else {
-            $indexsubset = $parentvalues;
-        }
-
-        if ($indexsubset) {
-            // Only garbage after the first index, but user wrote it.
-            foreach ($indexsubset as $k => $index) {
-                $mformelementinfo = new stdClass();
-                $mformelementinfo->parentname = $this->itemname;
-                $mformelementinfo->operator = 'neq';
-                $mformelementinfo->content = $index;
-                $disabilitationinfo[] = $mformelementinfo;
-            }
-        }
-
-        if ($labelsubset) {
-            foreach ($labelsubset as $k => $unused) {
-                // Only garbage after the first label, but user wrote it.
-                if (!empty($this->labelother)) {
-                    $mformelementinfo = new stdClass();
-                    $mformelementinfo->parentname = $this->itemname;
-                    $mformelementinfo->operator = 'neq';
-                    $mformelementinfo->content = 'other';
-                    $disabilitationinfo[] = $mformelementinfo;
-
-                    $mformelementinfo = new stdClass();
-                    $mformelementinfo->parentname = $this->itemname.'_text';
-                    $mformelementinfo->operator = 'neq';
-                    $mformelementinfo->content = $childparentvalue;
-                    $disabilitationinfo[] = $mformelementinfo;
-                }
-            }
-        } else {
-            // Even if no labels were provided
-            // I have to add one more $disabilitationinfo if $this->other is not empty.
-            if (!empty($this->labelother)) {
-                $mformelementinfo = new stdClass();
-                $mformelementinfo->parentname = $this->itemname.'_other';
-                $mformelementinfo->content = 'checked';
-                $disabilitationinfo[] = $mformelementinfo;
-            }
+            $mformelementinfo = new stdClass();
+            $mformelementinfo->parentname = $this->itemname;
+            $mformelementinfo->operator = 'neq';
+            $mformelementinfo->content = $parentvalues[0];
+            $disabilitationinfo[] = $mformelementinfo;
         }
 
         return $disabilitationinfo;


### PR DESCRIPTION
Deep problem!
Almost all the 6 userform_child_item_allowed_dynamic methods are bad!
Luckily the methods used by boolean and integer (that are the most commonly used) work fine but the problem is still very relevant because those methods are responsible for the evaluation of the input provided by the user.

This is the story.
Parent and child in the same page.
Provide the parent with the answer allowing the child.
The child becomes enabled.
Provide an answer to the child.
Return to parent and change your answer.

At submit time mform submits the answer for the child too!! GRRRR
So, the method userform_child_item_allowed_dynamic verify if the submission was expected and, if needed, it drops it.