### PR TITLE
CONTRIB-6548 surveypro: userform_get_parent_disabilitation_info cleanup

### DIFF
--- a/field/boolean/classes/field.php
+++ b/field/boolean/classes/field.php
@@ -611,41 +611,14 @@ EOS;
      * @return array
      */
     public function userform_get_parent_disabilitation_info($childparentvalue) {
-        $disabilitationinfo = array();
-
         $parentvalues = explode(SURVEYPRO_DBMULTICONTENTSEPARATOR, $childparentvalue); // 1;1;0;.
 
-        $indexsubset = array();
-        $labelsubset = array();
-        $key = array_search('>', $parentvalues);
-        if ($key !== false) {
-            $indexsubset = array_slice($parentvalues, 0, $key);
-            $labelsubset = array_slice($parentvalues, $key + 1);
-        } else {
-            $indexsubset = $parentvalues;
-        }
-
-        if ($indexsubset) {
-            // Only garbage after the first index, but user wrote it.
-            foreach ($indexsubset as $index) {
-                $mformelementinfo = new stdClass();
-                $mformelementinfo->parentname = $this->itemname;
-                $mformelementinfo->operator = 'neq';
-                $mformelementinfo->content = $index;
-                $disabilitationinfo[] = $mformelementinfo;
-            }
-        }
-
-        // Only garbage but user wrote it.
-        if ($labelsubset) {
-            foreach ($labelsubset as $label) {
-                $mformelementinfo = new stdClass();
-                $mformelementinfo->parentname = $this->itemname;
-                $mformelementinfo->operator = 'neq';
-                $mformelementinfo->content = $label;
-                $disabilitationinfo[] = $mformelementinfo;
-            }
-        }
+        $disabilitationinfo = array();
+        $mformelementinfo = new stdClass();
+        $mformelementinfo->parentname = $this->itemname;
+        $mformelementinfo->operator = 'neq';
+        $mformelementinfo->content = $parentvalues[0];
+        $disabilitationinfo[] = $mformelementinfo;
 
         return $disabilitationinfo;
     }

--- a/field/integer/classes/field.php
+++ b/field/integer/classes/field.php
@@ -573,41 +573,14 @@ EOS;
      * @return array
      */
     public function userform_get_parent_disabilitation_info($childparentvalue) {
-        $disabilitationinfo = array();
-
         $parentvalues = explode(SURVEYPRO_DBMULTICONTENTSEPARATOR, $childparentvalue); // 1;1;0;.
 
-        $indexsubset = array();
-        $labelsubset = array();
-        $key = array_search('>', $parentvalues);
-        if ($key !== false) {
-            $indexsubset = array_slice($parentvalues, 0, $key);
-            $labelsubset = array_slice($parentvalues, $key + 1);
-        } else {
-            $indexsubset = $parentvalues;
-        }
-
-        if ($indexsubset) {
-            // Only garbage after the first index, but user wrote it.
-            foreach ($indexsubset as $k => $index) {
-                $mformelementinfo = new stdClass();
-                $mformelementinfo->parentname = $this->itemname;
-                $mformelementinfo->operator = 'neq';
-                $mformelementinfo->content = $index;
-                $disabilitationinfo[] = $mformelementinfo;
-            }
-        }
-
-        if ($labelsubset) {
-            // Only garbage, but user wrote it.
-            foreach ($labelsubset as $k => $label) {
-                $mformelementinfo = new stdClass();
-                $mformelementinfo->parentname = $this->itemname;
-                $mformelementinfo->operator = 'neq';
-                $mformelementinfo->content = $label;
-                $disabilitationinfo[] = $mformelementinfo;
-            }
-        }
+        $disabilitationinfo = array();
+        $mformelementinfo = new stdClass();
+        $mformelementinfo->parentname = $this->itemname;
+        $mformelementinfo->operator = 'neq';
+        $mformelementinfo->content = $parentvalues[0];
+        $disabilitationinfo[] = $mformelementinfo;
 
         return $disabilitationinfo;
     }

--- a/field/radiobutton/classes/field.php
+++ b/field/radiobutton/classes/field.php
@@ -643,53 +643,24 @@ EOS;
 
         $parentvalues = explode(SURVEYPRO_DBMULTICONTENTSEPARATOR, $childparentvalue); // 1;1;0;.
 
-        $indexsubset = array();
-        $labelsubset = array();
-        $key = array_search('>', $parentvalues);
-        if ($key !== false) {
-            $indexsubset = array_slice($parentvalues, 0, $key);
-            $labelsubset = array_slice($parentvalues, $key + 1);
+        if ($parentvalues[0] == '>') {
+            $mformelementinfo = new stdClass();
+            $mformelementinfo->parentname = $this->itemname;
+            $mformelementinfo->operator = 'neq';
+            $mformelementinfo->content = 'other';
+            $disabilitationinfo[] = $mformelementinfo;
+
+            $mformelementinfo = new stdClass();
+            $mformelementinfo->parentname = $this->itemname.'_text';
+            $mformelementinfo->operator = 'neq';
+            $mformelementinfo->content = $parentvalues[1];
+            $disabilitationinfo[] = $mformelementinfo;
         } else {
-            $indexsubset = $parentvalues;
-        }
-
-        if ($indexsubset) {
-            // Only garbage after the first index, but user wrote it.
-            foreach ($indexsubset as $k => $index) {
-                $mformelementinfo = new stdClass();
-                $mformelementinfo->parentname = $this->itemname;
-                $mformelementinfo->operator = 'neq';
-                $mformelementinfo->content = $index;
-                $disabilitationinfo[] = $mformelementinfo;
-            }
-        }
-
-        if ($labelsubset) {
-            foreach ($labelsubset as $k => $label) {
-                // Only garbage after the first label, but user wrote it.
-                if (!empty($this->labelother)) {
-                    $mformelementinfo = new stdClass();
-                    $mformelementinfo->parentname = $this->itemname;
-                    $mformelementinfo->operator = 'neq';
-                    $mformelementinfo->content = 'other';
-                    $disabilitationinfo[] = $mformelementinfo;
-
-                    $mformelementinfo = new stdClass();
-                    $mformelementinfo->parentname = $this->itemname.'_text';
-                    $mformelementinfo->operator = 'neq';
-                    $mformelementinfo->content = $label;
-                    $disabilitationinfo[] = $mformelementinfo;
-                }
-            }
-        } else {
-            // Even if no labels were provided
-            // I have to add one more $disabilitationinfo if $this->other is not empty.
-            if (!empty($this->labelother)) {
-                $mformelementinfo = new stdClass();
-                $mformelementinfo->parentname = $this->itemname.'_other';
-                $mformelementinfo->content = 'checked';
-                $disabilitationinfo[] = $mformelementinfo;
-            }
+            $mformelementinfo = new stdClass();
+            $mformelementinfo->parentname = $this->itemname;
+            $mformelementinfo->operator = 'neq';
+            $mformelementinfo->content = $parentvalues[0];
+            $disabilitationinfo[] = $mformelementinfo;
         }
 
         return $disabilitationinfo;

--- a/field/select/classes/field.php
+++ b/field/select/classes/field.php
@@ -595,53 +595,25 @@ EOS;
 
         $parentvalues = explode(SURVEYPRO_DBMULTICONTENTSEPARATOR, $childparentvalue); // 1;1;0;.
 
-        $indexsubset = array();
-        $labelsubset = array();
-        $key = array_search('>', $parentvalues);
-        if ($key !== false) {
-            $indexsubset = array_slice($parentvalues, 0, $key);
-            $labelsubset = array_slice($parentvalues, $key + 1);
+        if ($parentvalues[0] == '>') {
+            // The condition was set to a custom text.
+            $mformelementinfo = new stdClass();
+            $mformelementinfo->parentname = $this->itemname;
+            $mformelementinfo->operator = 'neq';
+            $mformelementinfo->content = 'other';
+            $disabilitationinfo[] = $mformelementinfo;
+
+            $mformelementinfo = new stdClass();
+            $mformelementinfo->parentname = $this->itemname.'_text';
+            $mformelementinfo->operator = 'neq';
+            $mformelementinfo->content = $parentvalues[1];
+            $disabilitationinfo[] = $mformelementinfo;
         } else {
-            $indexsubset = $parentvalues;
-        }
-
-        if ($indexsubset) {
-            // Only garbage after the first index, but user wrote it.
-            foreach ($indexsubset as $k => $index) {
-                $mformelementinfo = new stdClass();
-                $mformelementinfo->parentname = $this->itemname;
-                $mformelementinfo->operator = 'neq';
-                $mformelementinfo->content = $index;
-                $disabilitationinfo[] = $mformelementinfo;
-            }
-        }
-
-        if ($labelsubset) {
-            foreach ($labelsubset as $k => $unused) {
-                // Only garbage after the first label, but user wrote it.
-                if (!empty($this->labelother)) {
-                    $mformelementinfo = new stdClass();
-                    $mformelementinfo->parentname = $this->itemname;
-                    $mformelementinfo->operator = 'neq';
-                    $mformelementinfo->content = 'other';
-                    $disabilitationinfo[] = $mformelementinfo;
-
-                    $mformelementinfo = new stdClass();
-                    $mformelementinfo->parentname = $this->itemname.'_text';
-                    $mformelementinfo->operator = 'neq';
-                    $mformelementinfo->content = $childparentvalue;
-                    $disabilitationinfo[] = $mformelementinfo;
-                }
-            }
-        } else {
-            // Even if no labels were provided
-            // I have to add one more $disabilitationinfo if $this->other is not empty.
-            if (!empty($this->labelother)) {
-                $mformelementinfo = new stdClass();
-                $mformelementinfo->parentname = $this->itemname.'_other';
-                $mformelementinfo->content = 'checked';
-                $disabilitationinfo[] = $mformelementinfo;
-            }
+            $mformelementinfo = new stdClass();
+            $mformelementinfo->parentname = $this->itemname;
+            $mformelementinfo->operator = 'neq';
+            $mformelementinfo->content = $parentvalues[0];
+            $disabilitationinfo[] = $mformelementinfo;
         }
 
         return $disabilitationinfo;


### PR DESCRIPTION
The method used userform_get_parent_disabilitation_info
used to write the js disabilitation commands for children
is usually too complex without any apparent reason.
The code need cleanup.