### PR TITLE
CONTRIB-6550 mod_surveypro: enforced condition in can_submit_more

### DIFF
--- a/classes/utility.php
+++ b/classes/utility.php
@@ -830,17 +830,17 @@ class mod_surveypro_utility {
             $userid = $USER->id;
         }
 
-        if (empty($this->surveypro->maxentries)) {
-            return true;
-        } else {
-            if (has_capability('mod/surveypro:ignoremaxentries', $this->context, null, true)) {
-                return true;
+        $cansubmitmore = has_capability('mod/surveypro:submit', $this->context, null, true);
+        if ($cansubmitmore) {
+            if (!empty($this->surveypro->maxentries)) {
+                if (!has_capability('mod/surveypro:ignoremaxentries', $this->context, null, true)) {
+                    $usersubmissions = $this->has_submissions(true, SURVEYPRO_STATUSALL, $userid);
+                    $cansubmitmore = ($usersubmissions < $this->surveypro->maxentries);
+                }
             }
-
-            $usersubmissions = $this->has_submissions(true, SURVEYPRO_STATUSALL, $userid);
-
-            return ($usersubmissions < $this->surveypro->maxentries);
         }
+
+        return $cansubmitmore;
     }
 
     /**


### PR DESCRIPTION
Create a dummy surveypro (1 element is enough).
Log in as a student.
Fill the survey and submit it.
Log out

Log in as a teacher.
Edit the student response.
Submit it.
After submission EVEN IF THE TEACHER IS NOT ALLOWED TO RESPOND, the "Add one more response" button appear.
By clicking it, an error rise up. 