### PR TITLE
CONTRIB-6556 mod_surveypro: replaced `empty` with `!strlen`

### DIFF
--- a/classes/view_export.php
+++ b/classes/view_export.php
@@ -503,7 +503,7 @@ class mod_surveypro_view_export {
      */
     public function decode_content($richsubmission) {
         $content = $richsubmission->content;
-        if (empty($content)) {
+        if (!strlen($content)) {
             $return = '';
         } else {
             $itemid = $richsubmission->itemid;


### PR DESCRIPTION
as usual, empty includes answers == 0 and this is not correct!