### PR TITLE
NOBUG mod_surveypro: isset  instead of strlen

### DIFF
--- a/classes/view_export.php
+++ b/classes/view_export.php
@@ -502,8 +502,7 @@ class mod_surveypro_view_export {
      * @return void
      */
     public function decode_content($richsubmission) {
-        $content = $richsubmission->content;
-        if (!strlen($content)) {
+        if (!isset($richsubmission->content)) { // Because it is NULL.
             $return = '';
         } else {
             $itemid = $richsubmission->itemid;


### PR DESCRIPTION
looking at the database I found that I already prepared the db to store NULL when no input is provided and always something when something is provided. Because of this and because of your suggestion in https://github.com/kordan/moodle-mod_surveypro/pull/258#issuecomment-250435061 I made this change. I am going to replace all the other occurrences of !strlen in next PR.