### PR TITLE
CONTRIB-6576 surveypro: simplified integer userform_save_preprocessing

### DIFF
--- a/field/integer/classes/field.php
+++ b/field/integer/classes/field.php
@@ -614,11 +614,7 @@ EOS;
      * @return void
      */
     public function userform_save_preprocessing($answer, &$olduseranswer, $searchform) {
-        if ($answer['mainelement'] == SURVEYPRO_INVITEVALUE) {
-            $olduseranswer->content = null;
-        } else {
-            $olduseranswer->content = $answer['mainelement'];
-        }
+        $olduseranswer->content = $answer['mainelement'];
     }
 
     /**


### PR DESCRIPTION
it is not possible to arrive in integer userform_save_preprocessing having 
if ($answer['mainelement'] == SURVEYPRO_INVITEVALUE) {
because the submission of this value is not allowed.
Because of this, that method may be simplified.