### PR TITLE
CONTRIB-6577 surveypro: simplified boolean userform_save_preprocessing

### DIFF
--- a/field/boolean/classes/field.php
+++ b/field/boolean/classes/field.php
@@ -655,11 +655,7 @@ EOS;
         if (isset($answer['noanswer'])) {
             $olduseranswer->content = SURVEYPRO_NOANSWERVALUE;
         } else {
-            if ($answer['mainelement'] == SURVEYPRO_INVITEVALUE) {
-                $olduseranswer->content = null;
-            } else {
-                $olduseranswer->content = $answer['mainelement'];
-            }
+            $olduseranswer->content = $answer['mainelement'];
         }
     }
 


### PR DESCRIPTION
it is not possible to arrive in boolean userform_save_preprocessing having 
if ($answer['mainelement'] == SURVEYPRO_INVITEVALUE) {
because the submission of this value is not allowed.
Because of this, that method may be simplified.