### PR TITLE
CONTRIB-6578mod_surveypro: fixed numeric save_preprocessing

### DIFF
--- a/field/numeric/classes/field.php
+++ b/field/numeric/classes/field.php
@@ -548,8 +548,8 @@ EOS;
         }
 
         $content = trim($answer['mainelement']);
-        if (strlen($content) == 0) {
-            $olduseranswer->content = null;
+        if (!strlen($content)) {
+            $olduseranswer->content = '';
         } else {
             $content = $this->item_get_correct_number($content);
             $olduseranswer->content = round($content, $this->decimals);


### PR DESCRIPTION
numeric must save empty string and not null when empty strings are submitted