### PR TITLE
CONTRIB-6585 modsurveypro: added one color_unifier call

### DIFF
--- a/field/rate/classes/field.php
+++ b/field/rate/classes/field.php
@@ -425,6 +425,7 @@ EOS;
         }
 
         if (!$this->required) { // This is the last if it exists.
+            $this->item_add_color_unifier($mform);
             $noanswerstr = get_string('noanswer', 'mod_surveypro');
             $attributes['id'] = $idprefix.'_noanswer';
             $attributes['class'] = 'indent-'.$this->indent.' rate_check';


### PR DESCRIPTION
Each item in surveypro has a unique background colour.
Colours are alternated in the out form.
Rate item is supposed to have a unique background colour too.
If a rate item is not mandatory, the "No answer" checkbox uses a wrong background.