### PR TITLE
CONTRIB-6571 mod_surveypro: utility cleanup

### DIFF
--- a/classes/itemlist.php
+++ b/classes/itemlist.php
@@ -1403,7 +1403,7 @@ class mod_surveypro_itemlist {
                 $childitems = array_keys($childitems);
                 $nodes = implode(', ', $childitems);
                 $message .= get_string('confirm_deletechainitems', 'mod_surveypro', $nodes);
-                $labelyes = get_string('concontinue');
+                $labelyes = get_string('continue');
             } else {
                 $labelyes = get_string('yes');
             }

--- a/lib.php
+++ b/lib.php
@@ -650,7 +650,7 @@ function surveypro_cron() {
 function surveypro_get_participants($surveyproid) {
     global $DB;
 
-    $sql = 'SELECT DISTINCT s.userid as id, s.userid as id
+    $sql = 'SELECT DISTINCT s.userid as id
             FROM {surveypro_submission} s
             WHERE s.surveyproid = :surveyproid';
     return $DB->get_records_sql($sql, array('surveyproid' => $surveyproid));


### PR DESCRIPTION
Once a submission is deleted, if the course completion is requested, involved users must be selected but this selection must be performed before the submission deletion.
The same is true for item deletion.
