### PR TITLE
CONTRIB-6588 mod_surveypro: correct contentformat at save time

### DIFF
--- a/classes/itembase.php
+++ b/classes/itembase.php
@@ -1318,15 +1318,6 @@ class mod_surveypro_itembase {
         return $this->itemeditingfeedback;
     }
 
-    /**
-     * Returns the content format that has to be saved in surveypro_answer
-     *
-     * @return $return
-     */
-    public function get_answer_contentformat() {
-        return null;
-    }
-
     // MARK set.
 
     /**

--- a/classes/view_form.php
+++ b/classes/view_form.php
@@ -645,7 +645,7 @@ class mod_surveypro_view_form extends mod_surveypro_formbase {
                 $useranswer->submissionid = $iteminfo->submissionid;
                 $useranswer->itemid = $iteminfo->itemid;
                 $useranswer->content = SURVEYPRO_DUMMYCONTENT;
-                $useranswer->contentformat = null;
+                // $useranswer->contentformat = null; // Useless, as null is the default.
 
                 $useranswer->id = $DB->insert_record('surveypro_answer', $useranswer);
             }

--- a/classes/view_import.php
+++ b/classes/view_import.php
@@ -320,7 +320,6 @@ class mod_surveypro_view_import {
             } else {
                 $info->semantic = $item->get_contentformat();
             }
-            $info->answer_contentformat = $item->get_answer_contentformat();
             $itemhelperinfo[$col] = $info;
 
             // Itemoption.
@@ -906,7 +905,6 @@ class mod_surveypro_view_import {
                 $record->itemid = $columntoitemid[$col];
                 $record->content = $value;
                 $record->verified = 1;
-                $record->contentformat = $itemhelperinfo[$col]->answer_contentformat;
                 if ($debug) {
                     echo 'I am at the line '.__LINE__.' of the file '.__FILE__.'<br />';
                     echo 'I am going to save to surveypro_answer:<br />';

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="mod/surveypro/db" VERSION="20130930" COMMENT="XMLDB file for Moodle mod/surveypro"
+<XMLDB PATH="mod/surveypro/db" VERSION="20161017" COMMENT="XMLDB file for Moodle mod/surveypro"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
@@ -79,7 +79,7 @@
         <FIELD NAME="itemid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="verified" TYPE="int" LENGTH="4" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
         <FIELD NAME="content" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="contentformat" TYPE="int" LENGTH="4" NOTNULL="false" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="contentformat" TYPE="int" LENGTH="4" NOTNULL="false" SEQUENCE="false"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -157,10 +157,31 @@ function xmldb_surveypro_upgrade($oldversion) {
     }
 
     if ($oldversion < 2016100601) {
-        $DB->delete_records('surveypro_answer', array('content' => '@@_ANINDB_@@'));
+        $where = $DB->sql_compare_text('content').' = :content';
+        $DB->delete_records_select('surveypro_answer', $where, array('content' => '@@_ANINDB_@@'));
 
         // Surveypro savepoint reached.
         upgrade_mod_savepoint(true, 2016100601, 'surveypro');
+    }
+
+    if ($oldversion < 2016101700) {
+
+        // Changing the default of field contentformat on table surveypro_answer to null.
+        $table = new xmldb_table('surveypro_answer');
+        $field = new xmldb_field('content', XMLDB_TYPE_TEXT, null, null, null, null, null, 'verified');
+
+        // Launch change of default for field contentformat.
+        $dbman->change_field_default($table, $field);
+
+        // Changing the default of field contentformat on table surveypro_answer to drop it.
+        $table = new xmldb_table('surveypro_answer');
+        $field = new xmldb_field('contentformat', XMLDB_TYPE_INTEGER, '4', null, null, null, null, 'content');
+
+        // Launch change of default for field contentformat.
+        $dbman->change_field_default($table, $field);
+
+        // Surveypro savepoint reached.
+        upgrade_mod_savepoint(true, 2016101700, 'surveypro');
     }
 
     return true;

--- a/field/age/classes/field.php
+++ b/field/age/classes/field.php
@@ -656,7 +656,8 @@ EOS;
     /**
      * Starting from the info set by the user in the form
      * this method calculates what to save in the db
-     * or what to return for the search form
+     * or what to return for the search form.
+     * I don't set $olduseranswer->contentformat in order to accept the default db value.
      *
      * @param array $answer
      * @param object $olduseranswer

--- a/field/autofill/classes/field.php
+++ b/field/autofill/classes/field.php
@@ -466,7 +466,8 @@ EOS;
     /**
      * Starting from the info set by the user in the form
      * this method calculates what to save in the db
-     * or what to return for the search form
+     * or what to return for the search form.
+     * I don't set $olduseranswer->contentformat in order to accept the default db value.
      *
      * @param array $answer
      * @param object $olduseranswer

--- a/field/boolean/classes/field.php
+++ b/field/boolean/classes/field.php
@@ -644,7 +644,8 @@ EOS;
     /**
      * Starting from the info set by the user in the form
      * this method calculates what to save in the db
-     * or what to return for the search form
+     * or what to return for the search form.
+     * I don't set $olduseranswer->contentformat in order to accept the default db value.
      *
      * @param array $answer
      * @param object $olduseranswer

--- a/field/character/classes/field.php
+++ b/field/character/classes/field.php
@@ -595,7 +595,8 @@ EOS;
     /**
      * Starting from the info set by the user in the form
      * this method calculates what to save in the db
-     * or what to return for the search form
+     * or what to return for the search form.
+     * I don't set $olduseranswer->contentformat in order to accept the default db value.
      *
      * @param array $answer
      * @param object $olduseranswer

--- a/field/checkbox/classes/field.php
+++ b/field/checkbox/classes/field.php
@@ -827,7 +827,8 @@ EOS;
     /**
      * Starting from the info set by the user in the form
      * this method calculates what to save in the db
-     * or what to return for the search form
+     * or what to return for the search form.
+     * I don't set $olduseranswer->contentformat in order to accept the default db value.
      *
      * @param array $answer
      * @param object $olduseranswer

--- a/field/date/classes/field.php
+++ b/field/date/classes/field.php
@@ -705,7 +705,8 @@ EOS;
     /**
      * Starting from the info set by the user in the form
      * this method calculates what to save in the db
-     * or what to return for the search form
+     * or what to return for the search form.
+     * I don't set $olduseranswer->contentformat in order to accept the default db value.
      *
      * @param array $answer
      * @param object $olduseranswer

--- a/field/datetime/classes/field.php
+++ b/field/datetime/classes/field.php
@@ -809,7 +809,8 @@ EOS;
     /**
      * Starting from the info set by the user in the form
      * this method calculates what to save in the db
-     * or what to return for the search form
+     * or what to return for the search form.
+     * I don't set $olduseranswer->contentformat in order to accept the default db value.
      *
      * @param array $answer
      * @param object $olduseranswer

--- a/field/fileupload/classes/field.php
+++ b/field/fileupload/classes/field.php
@@ -359,7 +359,8 @@ EOS;
     /**
      * Starting from the info set by the user in the form
      * this method calculates what to save in the db
-     * or what to return for the search form
+     * or what to return for the search form.
+     * I don't set $olduseranswer->contentformat in order to accept the default db value.
      *
      * @param array $answer
      * @param object $olduseranswer

--- a/field/integer/classes/field.php
+++ b/field/integer/classes/field.php
@@ -606,7 +606,8 @@ EOS;
     /**
      * Starting from the info set by the user in the form
      * this method calculates what to save in the db
-     * or what to return for the search form
+     * or what to return for the search form.
+     * I don't set $olduseranswer->contentformat in order to accept the default db value.
      *
      * @param array $answer
      * @param object $olduseranswer

--- a/field/multiselect/classes/field.php
+++ b/field/multiselect/classes/field.php
@@ -698,7 +698,8 @@ EOS;
     /**
      * Starting from the info set by the user in the form
      * this method calculates what to save in the db
-     * or what to return for the search form
+     * or what to return for the search form.
+     * I don't set $olduseranswer->contentformat in order to accept the default db value.
      *
      * @param array $answer
      * @param object $olduseranswer

--- a/field/numeric/classes/field.php
+++ b/field/numeric/classes/field.php
@@ -534,7 +534,8 @@ EOS;
     /**
      * Starting from the info set by the user in the form
      * this method calculates what to save in the db
-     * or what to return for the search form
+     * or what to return for the search form.
+     * I don't set $olduseranswer->contentformat in order to accept the default db value.
      *
      * @param array $answer
      * @param object $olduseranswer

--- a/field/radiobutton/classes/field.php
+++ b/field/radiobutton/classes/field.php
@@ -699,7 +699,8 @@ EOS;
     /**
      * Starting from the info set by the user in the form
      * this method calculates what to save in the db
-     * or what to return for the search form
+     * or what to return for the search form.
+     * I don't set $olduseranswer->contentformat in order to accept the default db value.
      *
      * @param array $answer
      * @param object $olduseranswer

--- a/field/rate/classes/field.php
+++ b/field/rate/classes/field.php
@@ -556,7 +556,8 @@ EOS;
     /**
      * Starting from the info set by the user in the form
      * this method calculates what to save in the db
-     * or what to return for the search form
+     * or what to return for the search form.
+     * I don't set $olduseranswer->contentformat in order to accept the default db value.
      *
      * @param array $answer
      * @param object $olduseranswer

--- a/field/recurrence/classes/field.php
+++ b/field/recurrence/classes/field.php
@@ -670,7 +670,8 @@ EOS;
     /**
      * Starting from the info set by the user in the form
      * this method calculates what to save in the db
-     * or what to return for the search form
+     * or what to return for the search form.
+     * I don't set $olduseranswer->contentformat in order to accept the default db value.
      *
      * @param array $answer
      * @param object $olduseranswer

--- a/field/select/classes/field.php
+++ b/field/select/classes/field.php
@@ -651,7 +651,8 @@ EOS;
     /**
      * Starting from the info set by the user in the form
      * this method calculates what to save in the db
-     * or what to return for the search form
+     * or what to return for the search form.
+     * I don't set $olduseranswer->contentformat in order to accept the default db value.
      *
      * @param array $answer
      * @param object $olduseranswer

--- a/field/shortdate/classes/field.php
+++ b/field/shortdate/classes/field.php
@@ -637,7 +637,8 @@ EOS;
     /**
      * Starting from the info set by the user in the form
      * this method calculates what to save in the db
-     * or what to return for the search form
+     * or what to return for the search form.
+     * I don't set $olduseranswer->contentformat in order to accept the default db value.
      *
      * @param array $answer
      * @param object $olduseranswer

--- a/field/textarea/classes/field.php
+++ b/field/textarea/classes/field.php
@@ -345,21 +345,6 @@ EOS;
         return $this->useeditor;
     }
 
-    /**
-     * Returns the content format that has to be saved in surveypro_answer
-     *
-     * @return $return
-     */
-    public function get_answer_contentformat() {
-        if (empty($this->useeditor)) {
-            $return = 0;
-        } else {
-            $return = 1;
-        }
-
-        return $return;
-    }
-
     // MARK response.
 
     /**
@@ -525,7 +510,8 @@ EOS;
     /**
      * Starting from the info set by the user in the form
      * this method calculates what to save in the db
-     * or what to return for the search form
+     * or what to return for the search form.
+     * Here I set $olduseranswer->contentformat as needed.
      *
      * @param array $answer
      * @param object $olduseranswer
@@ -541,7 +527,7 @@ EOS;
             $olduseranswer = file_postupdate_standard_editor($olduseranswer, $this->itemname, $editoroptions, $context,
                     'mod_surveypro', SURVEYPROFIELD_TEXTAREA_FILEAREA, $olduseranswer->id);
             $olduseranswer->content = $olduseranswer->{$this->itemname};
-            $olduseranswer->contentformat = FORMAT_HTML;
+            $olduseranswer->contentformat = $answer['editor']['format'];
         } else {
             $olduseranswer->content = empty($this->trimonsave) ? $answer['mainelement'] : trim($answer['mainelement']);
         }

--- a/field/textarea/db/install.xml
+++ b/field/textarea/db/install.xml
@@ -17,7 +17,7 @@
         <FIELD NAME="position"         TYPE="int"  LENGTH="4"      NOTNULL="true"  UNSIGNED="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="extranote"        TYPE="char" LENGTH="255"    NOTNULL="false"                             SEQUENCE="false"/>
         <FIELD NAME="required"         TYPE="int"  LENGTH="4"      NOTNULL="false"                             SEQUENCE="false"/>
-        <FIELD NAME="trimonsave"       TYPE="int"  LENGTH="4"     NOTNULL="false"                             SEQUENCE="false"/>
+        <FIELD NAME="trimonsave"       TYPE="int"  LENGTH="4"      NOTNULL="false"                             SEQUENCE="false"/>
         <FIELD NAME="hideinstructions" TYPE="int"  LENGTH="4"      NOTNULL="false"                             SEQUENCE="false"/>
         <FIELD NAME="variable"         TYPE="char" LENGTH="64"     NOTNULL="false"                             SEQUENCE="false"/>
         <FIELD NAME="indent"           TYPE="int"  LENGTH="4"      NOTNULL="false"                             SEQUENCE="false"/>

--- a/field/time/classes/field.php
+++ b/field/time/classes/field.php
@@ -682,7 +682,8 @@ EOS;
     /**
      * Starting from the info set by the user in the form
      * this method calculates what to save in the db
-     * or what to return for the search form
+     * or what to return for the search form.
+     * I don't set $olduseranswer->contentformat in order to accept the default db value.
      *
      * @param array $answer
      * @param object $olduseranswer

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_surveypro'; // Full name of the plugin (used for diagnostics).
 $plugin->maturity = MATURITY_ALPHA; // MATURITY_RC.
-$plugin->version = 2016100601; // The current module version (Date: YYYYMMDDXX).
+$plugin->version = 2016101700; // The current module version (Date: YYYYMMDDXX).
 $plugin->release = '1.0'; // The current release.
 $plugin->requires = 2015111600; // Requires this Moodle version.
 $plugin->cron = 3600; // Period for cron to check this module (in seconds).


### PR DESCRIPTION
Here the answer content format is finally taken from the editor and no longer set to FORMAT_HTML per default.
If this branch is correct, now it is matter of better manage the export and the import to csv as, currently, with the export->import precess, the answer contentformat is missed.
