### PR TITLE
NOBUG mod_surveypro: does this rise up an error in php7?

### DIFF
--- a/tests/behat/multiselect_default7.feature
+++ b/tests/behat/multiselect_default7.feature
@@ -1,0 +1,20 @@
+@mod @mod_surveypro @javascript @_bug_phantomjs
+Feature: Forms with a multi select field dependency
+  In order to test multi select field dependency
+  As an admin
+  I need forms field which depends on multiple select options
+
+  Scenario: Field should be enabled only when all select options are selected
+    # Get to the fixture page.
+    Given the following "courses" exist:
+      | fullname | shortname | format |
+      | Course 1 | C1        | topics |
+    And the following "activities" exist:
+      | activity   | name | intro                                                                                       | course | idnumber |
+      | label      | L1   | <a href="../mod/surveypro/tests/fixtures/multiselect_default7.php">Multiselect_default7</a> | C1     | label1   |
+    And I log in as "admin"
+    And I am on site homepage
+    And I follow "Course 1"
+    When I follow "Multiselect_default7"
+# And I pause scenario execution
+    Then the "Enter your name" "field" should be disabled

--- a/tests/fixtures/multiselect_default7.php
+++ b/tests/fixtures/multiselect_default7.php
@@ -1,0 +1,68 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Fixture for Behat test for testing multiple select dependencies.
+ *
+ * @package core_form
+ * @copyright 2016 Rajesh Taneja <rajesh@moodle.com>
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require(__DIR__ . '/../../../../config.php');
+require_once($CFG->libdir . '/formslib.php');
+
+// Behat test fixture only.
+defined('BEHAT_SITE_RUNNING') || die('Only available on Behat test server');
+
+/**
+ * Form for testing multiple select dependencies.
+ *
+ * @package core_form
+ * @copyright 2016 Rajesh Taneja <rajesh@moodle.com>
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class test_form extends moodleform {
+
+    /**
+     * Form definition.
+     */
+    public function definition() {
+
+        $mform = $this->_form;
+
+        $labels = array('North', 'Est', 'South', 'West');
+        $select = $mform->addElement('select', 'mselect_name', 'Choose one or more directions', $labels);
+        $select->setMultiple(true);
+
+        $mform->addElement('text', 'text_name', 'Enter your name');
+        $mform->setType('text_name', PARAM_RAW);
+
+        $mform->disabledIf('text_name', 'mselect_name[]', 'neq', array(0, 3));
+
+        $this->add_action_buttons($cancel = true, $submitlabel = null);
+    }
+}
+
+$PAGE->set_context(context_system::instance());
+$PAGE->set_url('/lib/form/tests/fixtures/multiselect_default.php');
+$PAGE->set_title('multiselect_default');
+
+$mform = new test_form(new moodle_url('/lib/form/tests/fixtures/multiselect_default.php'));
+
+echo $OUTPUT->header();
+$mform->display();
+echo $OUTPUT->footer();


### PR DESCRIPTION
Following the behat output displayed in
http://pastebin.com/PFHe0hE2
and looking at
    Then "//input[contains(@id, 'id_surveypro_field_character_2') and contains(@disabled, 'disabled')]" "xpath_element" should exist # /Users/stronk7/git_moodle/survey/mod/surveypro/tests/behat/parent_multiselect.feature:217
      Xpath matching locator "//input[contains(@id, 'id_surveypro_field_character_2') and contains(@disabled, 'disabled')]" not found. (Behat\Mink\Exception\ElementNotFoundException)

I added a specific super short test
to verify if the behat output really rises up an issue visible only in php7.

Can you run this super short test in php 7, please.
If it fails (as I suppose), I will open an issue for moodle core providing the same files that are new in this PR. (multiselect_default7.feature and multiselect_default7.php)
As implicit, here, locally, in php 5.6.10 the test executes without problems.