### PR TITLE
CONTRIB-6635 mod_surveypro: added $groupfilterform->set_data

### DIFF
--- a/report/delayedusers/classes/report.php
+++ b/report/delayedusers/classes/report.php
@@ -47,6 +47,9 @@ class surveyproreport_delayedusers_report extends mod_surveypro_reportbase {
         $this->outputtable = new flexible_table('delayedusers');
 
         $paramurl = array('id' => $this->cm->id);
+        if ($this->groupid) {
+            $paramurl['groupid'] = $this->groupid;
+        }
         $baseurl = new moodle_url('/mod/surveypro/report/delayedusers/view.php', $paramurl);
         $this->outputtable->define_baseurl($baseurl);
 

--- a/report/delayedusers/view.php
+++ b/report/delayedusers/view.php
@@ -37,6 +37,7 @@ if (!empty($id)) {
     $course = $DB->get_record('course', array('id' => $surveypro->course), '*', MUST_EXIST);
     $cm = get_coursemodule_from_instance('surveypro', $surveypro->id, $course->id, false, MUST_EXIST);
 }
+$groupid = optional_param('groupid', 0, PARAM_INT);
 
 require_course_login($course, true, $cm);
 
@@ -44,6 +45,7 @@ $context = context_module::instance($cm->id);
 require_capability('mod/surveypro:accessreports', $context);
 
 $reportman = new surveyproreport_delayedusers_report($cm, $context, $surveypro);
+$reportman->set_groupid($groupid);
 $reportman->setup_outputtable();
 
 // Begin of: define $mform return url.
@@ -89,15 +91,8 @@ echo $OUTPUT->header();
 
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABSUBMISSIONS, SURVEYPRO_SUBMISSION_REPORT);
 
-$reportman->nosubmissions_stop();
-
-// Begin of: manage form submission.
-if ( $showjumper && ($fromform = $groupfilterform->get_data()) ) {
-    $reportman->set_groupid($fromform->groupid);
-}
-// End of: manage form submission.
-
 if ($showjumper) {
+    $groupfilterform->set_data(array('groupid' => $groupid));
     $groupfilterform->display();
 }
 


### PR DESCRIPTION
Go to a course divided into groups.
Go to a surveypro with some submissions.
Ask for delayed users report.
Select a group different from "All groups".
You will see a list of users.
Filter them with a name in the alphabet.
The group menu returns to "All groups"