### PR TITLE
CONTRIB-6733 mod_surveypro: deleted wrong empty message

### DIFF
--- a/field/textarea/classes/field.php
+++ b/field/textarea/classes/field.php
@@ -503,8 +503,6 @@ EOS;
             if (isset($this->maxlength) && ($this->maxlength > 0)) {
                 $a = $this->maxlength;
                 $arrayinstruction[] = get_string('hasmaxlength', 'surveyprofield_textarea', $a);
-            } else {
-                $arrayinstruction[] = '';
             }
         }
         if ($this->trimonsave) {


### PR DESCRIPTION
If a textarea item is added to a surveypro with only the "trim on save" option, the note displayed in the form starts with a semicolon.