### PR TITLE
CONTRIB-6737 mod_surveypro: revision of datetime userform_mform_element

### DIFF
--- a/field/datetime/classes/field.php
+++ b/field/datetime/classes/field.php
@@ -525,12 +525,6 @@ EOS;
                 $hours[SURVEYPRO_INVITEVALUE] = get_string('invitehour', 'surveyprofield_datetime');
                 $minutes[SURVEYPRO_INVITEVALUE] = get_string('inviteminute', 'surveyprofield_datetime');
             }
-        } else {
-            $days[SURVEYPRO_IGNOREMEVALUE] = '';
-            $months[SURVEYPRO_IGNOREMEVALUE] = '';
-            $years[SURVEYPRO_IGNOREMEVALUE] = '';
-            $hours[SURVEYPRO_IGNOREMEVALUE] = '';
-            $minutes[SURVEYPRO_IGNOREMEVALUE] = '';
         }
         // Condition limiting days.
         $condition = true;
@@ -614,76 +608,94 @@ EOS;
 
         $separator = array(' ', ' ', ', ', ':');
         if ($this->required) {
-            $mform->addGroup($elementgroup, $this->itemname.'_group', $elementlabel, $separator, false);
-
             if (!$searchform) {
+                $mform->addGroup($elementgroup, $this->itemname.'_group', $elementlabel, $separator, false);
+
                 // Even if the item is required I CAN NOT ADD ANY RULE HERE because...
                 // I do not want JS form validation if the page is submitted through the "previous" button.
                 // I do not want JS field validation even if this item is required BUT disabled. See: MDL-34815.
                 // Because of this, I simply add a dummy star to the item and the footer note about mandatory fields.
                 $starplace = ($this->position != SURVEYPRO_POSITIONLEFT) ? $this->itemname.'_extrarow' : $this->itemname.'_group';
                 $mform->_required[] = $starplace;
+            } else {
+                $itemname = $this->itemname.'_ignoreme';
+                $starstr = get_string('star', 'mod_surveypro');
+                $attributes['id'] = $idprefix.'_ignoreme';
+                $attributes['class'] = 'character_check';
+                $elementgroup[] = $mform->createElement('mod_surveypro_checkbox', $itemname, '', $starstr, $attributes);
+                $mform->setType($this->itemname, PARAM_RAW);
+
+                $mform->addGroup($elementgroup, $this->itemname.'_group', $elementlabel, ' ', false);
+                $mform->disabledIf($this->itemname.'_group', $this->itemname.'_ignoreme', 'checked');
+                $mform->setDefault($this->itemname.'_ignoreme', '1');
             }
         } else {
             $itemname = $this->itemname.'_noanswer';
-            $noanswerstr = get_string('noanswer', 'mod_surveypro');
             $attributes['id'] = $idprefix.'_noanswer';
             $attributes['class'] = 'datetime_check';
+            $noanswerstr = get_string('noanswer', 'mod_surveypro');
             $elementgroup[] = $mform->createElement('mod_surveypro_checkbox', $itemname, '', $noanswerstr, $attributes);
             $separator[] = ' ';
-            $mform->addGroup($elementgroup, $this->itemname.'_group', $elementlabel, $separator, false);
-            $mform->disabledIf($this->itemname.'_group', $this->itemname.'_noanswer', 'checked');
+
+            if (!$searchform) {
+                $mform->addGroup($elementgroup, $this->itemname.'_group', $elementlabel, $separator, false);
+                $mform->disabledIf($this->itemname.'_group', $this->itemname.'_noanswer', 'checked');
+            } else {
+                $itemname = $this->itemname.'_ignoreme';
+                $starstr = get_string('star', 'mod_surveypro');
+                $attributes['id'] = $idprefix.'_ignoreme';
+                $attributes['class'] = 'character_check';
+                $elementgroup[] = $mform->createElement('mod_surveypro_checkbox', $itemname, '', $starstr, $attributes);
+                $mform->setType($this->itemname, PARAM_RAW);
+
+                $mform->addGroup($elementgroup, $this->itemname.'_group', $elementlabel, ' ', false);
+                $mform->disabledIf($this->itemname.'_group', $this->itemname.'_ignoreme', 'checked');
+                $mform->setDefault($this->itemname.'_ignoreme', '1');
+            }
         }
         // End of: mform element.
 
         // Begin of: default section.
-        if (!$searchform) {
-            if ($this->defaultoption == SURVEYPRO_INVITEDEFAULT) {
-                $mform->setDefault($this->itemname.'_day', SURVEYPRO_INVITEVALUE);
-                $mform->setDefault($this->itemname.'_month', SURVEYPRO_INVITEVALUE);
-                $mform->setDefault($this->itemname.'_year', SURVEYPRO_INVITEVALUE);
-                $mform->setDefault($this->itemname.'_hour', SURVEYPRO_INVITEVALUE);
-                $mform->setDefault($this->itemname.'_minute', SURVEYPRO_INVITEVALUE);
-            } else {
-                switch ($this->defaultoption) {
-                    case SURVEYPRO_CUSTOMDEFAULT:
-                        $datetimearray = self::item_split_unix_time($this->defaultvalue, true);
-                        break;
-                    case SURVEYPRO_TIMENOWDEFAULT:
-                        $datetimearray = self::item_split_unix_time(time(), true);
-                        break;
-                    case SURVEYPRO_NOANSWERDEFAULT:
-                        $datetimearray = self::item_split_unix_time($this->lowerbound, true);
-                        $mform->setDefault($this->itemname.'_noanswer', '1');
-                        break;
-                    case SURVEYPRO_LIKELASTDEFAULT:
-                        // Look for my last submission.
-                        $sql = 'userid = :userid ORDER BY timecreated DESC LIMIT 1';
-                        $where = array('userid' => $USER->id);
-                        $mylastsubmissionid = $DB->get_field_select('surveypro_submission', 'id', $sql, $where, IGNORE_MISSING);
-                        $where = array('itemid' => $this->itemid, 'submissionid' => $mylastsubmissionid);
-                        if ($time = $DB->get_field('surveypro_answer', 'content', $where, IGNORE_MISSING)) {
-                            $datetimearray = self::item_split_unix_time($time, false);
-                        } else { // As in standard default.
-                            $datetimearray = self::item_split_unix_time(time(), true);
-                        }
-                        break;
-                    default:
-                        $message = 'Unexpected $this->defaultoption = '.$this->defaultoption;
-                        debugging('Error at line '.__LINE__.' of '.__FILE__.'. '.$message , DEBUG_DEVELOPER);
+        switch ($this->defaultoption) {
+            case SURVEYPRO_CUSTOMDEFAULT:
+                $datetimearray = self::item_split_unix_time($this->defaultvalue, true);
+                break;
+            case SURVEYPRO_TIMENOWDEFAULT:
+                $datetimearray = self::item_split_unix_time(time(), true);
+                break;
+            case SURVEYPRO_NOANSWERDEFAULT:
+                $datetimearray = self::item_split_unix_time($this->lowerbound, true);
+                $mform->setDefault($this->itemname.'_noanswer', '1');
+                break;
+            case SURVEYPRO_LIKELASTDEFAULT:
+                // Look for my last submission.
+                $sql = 'userid = :userid ORDER BY timecreated DESC LIMIT 1';
+                $where = array('userid' => $USER->id);
+                $mylastsubmissionid = $DB->get_field_select('surveypro_submission', 'id', $sql, $where, IGNORE_MISSING);
+                $where = array('itemid' => $this->itemid, 'submissionid' => $mylastsubmissionid);
+                if ($time = $DB->get_field('surveypro_answer', 'content', $where, IGNORE_MISSING)) {
+                    $datetimearray = self::item_split_unix_time($time, false);
+                } else { // As in standard default.
+                    $datetimearray = self::item_split_unix_time(time(), true);
                 }
-                $mform->setDefault($this->itemname.'_day', $datetimearray['mday']);
-                $mform->setDefault($this->itemname.'_month', $datetimearray['mon']);
-                $mform->setDefault($this->itemname.'_year', $datetimearray['year']);
-                $mform->setDefault($this->itemname.'_hour', $datetimearray['hours']);
-                $mform->setDefault($this->itemname.'_minute', $datetimearray['minutes']);
-            }
-        } else {
-            $mform->setDefault($this->itemname.'_day', SURVEYPRO_IGNOREMEVALUE);
-            $mform->setDefault($this->itemname.'_month', SURVEYPRO_IGNOREMEVALUE);
-            $mform->setDefault($this->itemname.'_year', SURVEYPRO_IGNOREMEVALUE);
-            $mform->setDefault($this->itemname.'_hour', SURVEYPRO_IGNOREMEVALUE);
-            $mform->setDefault($this->itemname.'_minute', SURVEYPRO_IGNOREMEVALUE);
+                break;
+            case SURVEYPRO_INVITEDEFAULT:
+                $datetimearray['mday'] = SURVEYPRO_INVITEVALUE;
+                $datetimearray['mon'] = SURVEYPRO_INVITEVALUE;
+                $datetimearray['year'] = SURVEYPRO_INVITEVALUE;
+                $datetimearray['hours'] = SURVEYPRO_INVITEVALUE;
+                $datetimearray['minutes'] = SURVEYPRO_INVITEVALUE;
+                break;
+            default:
+                $message = 'Unexpected $this->defaultoption = '.$this->defaultoption;
+                debugging('Error at line '.__LINE__.' of '.__FILE__.'. '.$message , DEBUG_DEVELOPER);
+        }
+        $mform->setDefault($this->itemname.'_day', $datetimearray['mday']);
+        $mform->setDefault($this->itemname.'_month', $datetimearray['mon']);
+        $mform->setDefault($this->itemname.'_year', $datetimearray['year']);
+        $mform->setDefault($this->itemname.'_hour', $datetimearray['hours']);
+        $mform->setDefault($this->itemname.'_minute', $datetimearray['minutes']);
+        if ($searchform) {
             if (!$this->required) {
                 $mform->setDefault($this->itemname.'_noanswer', '0');
             }
@@ -704,6 +716,12 @@ EOS;
         // If ($this->required) { if (empty($data[$this->itemname])) { is useless.
 
         if (isset($data[$this->itemname.'_noanswer'])) {
+            return; // Nothing to validate.
+        }
+
+        // Make validation in the search form too.
+        // I can not use if ($searchform) { return; because I still need to validate the correcteness of the date.
+        if (isset($data[$this->itemname.'_ignoreme'])) {
             return; // Nothing to validate.
         }
 


### PR DESCRIPTION
Create a surveypro with a datetime element.
Put it in the search form among other elements.
The search can be performed only using the datetime field. It can't be ignored.