### PR TITLE
CONTRIB-6811 mod_surveypro: protected $this->extranote

### DIFF
--- a/classes/itembase.php
+++ b/classes/itembase.php
@@ -1398,7 +1398,7 @@ class mod_surveypro_itembase {
             if (!$this->get_hideinstructions()) {
                 $fillinginstruction = $this->userform_get_filling_instructions();
             }
-            if (!empty($this->extranote)) {
+            if (isset($this->extranote)) {
                 $extranote = strip_tags($this->extranote);
             }
         } else {
@@ -1408,7 +1408,9 @@ class mod_surveypro_itembase {
                 }
             }
             if ($config->extranoteinsearch) {
-                $extranote = strip_tags($this->extranote);
+                if (isset($this->extranote)) {
+                    $extranote = strip_tags($this->extranote);
+                }
             }
         }
         if (isset($fillinginstruction) && $fillinginstruction && isset($extranote) && $extranote) {


### PR DESCRIPTION
Go to Site administration > Plugins > Activity modules > Surveypro > Surveypro and set "Extra note in search form" to true.
Add a label to a surveypro.
Set it to be available in the search form.
Go to the search form.
The error reported by martinvivek in #322 rise up.