### PR TITLE
NOBUG mod_surveypro: dropped trimonsave from label setup form

### DIFF
--- a/format/label/classes/format.php
+++ b/format/label/classes/format.php
@@ -98,6 +98,7 @@ class surveyproformat_label_format extends mod_surveypro_itembase {
         // No properties here.
 
         // List of fields I do not want to have in the item definition form.
+        $this->insetupform['trimonsave'] = false;
         $this->insetupform['position'] = false;
         $this->insetupform['extranote'] = false;
         $this->insetupform['required'] = false;


### PR DESCRIPTION
In the label setup form was added the "Trim on save" checkbox that is a non sense in that form.
Dropped.