### PR TITLE
NOBUG mod_surveypro: added disappeared select id

### DIFF
--- a/field/select/classes/field.php
+++ b/field/select/classes/field.php
@@ -502,9 +502,9 @@ EOS;
         // End of: element values.
 
         $attributes = array();
+        $attributes['id'] = $idprefix;
+        $attributes['class'] = 'indent-'.$this->indent.' select_select';
         if (!$this->labelother) {
-            $attributes['id'] = $idprefix;
-            $attributes['class'] = 'indent-'.$this->indent.' select_select';
             $mform->addElement('mod_surveypro_select', $this->itemname, $elementlabel, $labels, $attributes);
         } else {
             $elementgroup = array();


### PR DESCRIPTION
For unknown reasons the id of the select was removed but this was detected by the behat test: "test select setup form". Simple to fix. Misterious the reason why I removed it.