### PR TITLE
CONTRIB-6852 mod_surveypro: initialized $fillinginstruction

### DIFF
--- a/field/recurrence/classes/field.php
+++ b/field/recurrence/classes/field.php
@@ -661,6 +661,7 @@ EOS;
         $haslowerbound = ($this->lowerbound != $this->item_recurrence_to_unix_time(1, 1));
         $hasupperbound = ($this->upperbound != $this->item_recurrence_to_unix_time(12, 31));
 
+        $fillinginstruction = '';
         $format = get_string('strftimedateshort', 'langconfig');
         if ($haslowerbound && $hasupperbound) {
             $a = new stdClass();
@@ -677,7 +678,6 @@ EOS;
                 $fillinginstruction = get_string('restriction_upperlower', 'surveyprofield_recurrence', $a);
             }
         } else {
-            $fillinginstruction = '';
             if ($haslowerbound) {
                 $a = userdate($this->lowerbound, $format, 0);
                 $fillinginstruction = get_string('restriction_lower', 'surveyprofield_recurrence', $a);


### PR DESCRIPTION
Adding a "Recurrence" field leaving "Hide filling instruction", "Lower bound" and "Upper boud" untouched, at preview time the following exception rises up:

Exception - Notice: Undefined variable: fillinginstruction in [dirroot]/mod/surveypro/field/recurrence/classes/field.php on line 691

It comes out because $fillinginstruction = something is never executed.