### PR TITLE
CONTRIB-6938 mod_surveypro: prefill now includes _noanswer checkbox

### DIFF
--- a/field/shortdate/classes/field.php
+++ b/field/shortdate/classes/field.php
@@ -703,11 +703,17 @@ EOS;
         if (isset($fromdb->content)) {
             if ($fromdb->content == SURVEYPRO_NOANSWERVALUE) {
                 $prefill[$this->itemname.'_noanswer'] = 1;
-            } else {
-                $shortdatearray = self::item_split_unix_time($fromdb->content);
-                $prefill[$this->itemname.'_month'] = $shortdatearray['mon'];
-                $prefill[$this->itemname.'_year'] = $shortdatearray['year'];
+                return $prefill;
             }
+
+            $shortdatearray = self::item_split_unix_time($fromdb->content);
+            $prefill[$this->itemname.'_month'] = $shortdatearray['mon'];
+            $prefill[$this->itemname.'_year'] = $shortdatearray['year'];
+        }
+
+        // If the "No answer" checkbox is part of the element GUI...
+        if ($this->defaultoption = SURVEYPRO_NOANSWERDEFAULT) {
+            $prefill[$this->itemname.'_noanswer'] = 0;
         }
 
         return $prefill;


### PR DESCRIPTION
If a shortdate item

- equipped with "No answer" option and
- with "No answer" option selected by default

is answered, even if the default option is changed at answer submission time, at editing time the answer always has "No answer" still selected.