### PR TITLE
CONTRIB-6941 mod_surveypro: prefill now includes _noanswer checkbox

### DIFF
--- a/field/recurrence/classes/field.php
+++ b/field/recurrence/classes/field.php
@@ -738,11 +738,17 @@ EOS;
         if (isset($fromdb->content)) {
             if ($fromdb->content == SURVEYPRO_NOANSWERVALUE) {
                 $prefill[$this->itemname.'_noanswer'] = 1;
-            } else {
-                $recurrencearray = self::item_split_unix_time($fromdb->content);
-                $prefill[$this->itemname.'_day'] = $recurrencearray['mday'];
-                $prefill[$this->itemname.'_month'] = $recurrencearray['mon'];
+                return $prefill;
             }
+
+            $recurrencearray = self::item_split_unix_time($fromdb->content);
+            $prefill[$this->itemname.'_day'] = $recurrencearray['mday'];
+            $prefill[$this->itemname.'_month'] = $recurrencearray['mon'];
+        }
+
+        // If the "No answer" checkbox is part of the element GUI...
+        if ($this->defaultoption = SURVEYPRO_NOANSWERDEFAULT) {
+            $prefill[$this->itemname.'_noanswer'] = 0;
         }
 
         return $prefill;


### PR DESCRIPTION
If an age item
- equipped with "No answer" option and
- with "No answer" option selected by default

is answered, even if the default option is changed at answer submission time, at editing time the answer always has "No answer" still selected.
