### PR TITLE
CONTRIB-6942 mod_surveypro: prefill now includes _noanswer checkbox

### DIFF
--- a/field/time/classes/field.php
+++ b/field/time/classes/field.php
@@ -751,11 +751,17 @@ EOS;
         if (isset($fromdb->content)) {
             if ($fromdb->content == SURVEYPRO_NOANSWERVALUE) {
                 $prefill[$this->itemname.'_noanswer'] = 1;
-            } else {
-                $datearray = self::item_split_unix_time($fromdb->content);
-                $prefill[$this->itemname.'_hour'] = $datearray['hours'];
-                $prefill[$this->itemname.'_minute'] = $datearray['minutes'];
+                return $prefill;
             }
+
+            $datearray = self::item_split_unix_time($fromdb->content);
+            $prefill[$this->itemname.'_hour'] = $datearray['hours'];
+            $prefill[$this->itemname.'_minute'] = $datearray['minutes'];
+        }
+
+        // If the "No answer" checkbox is part of the element GUI...
+        if ($this->defaultoption = SURVEYPRO_NOANSWERDEFAULT) {
+            $prefill[$this->itemname.'_noanswer'] = 0;
         }
 
         return $prefill;


### PR DESCRIPTION
If a time item
- equipped with "No answer" option and
- with "No answer" option selected by default

is answered, even if the default option is changed at answer submission time, at editing time the answer always has "No answer" still selected.
