### PR TITLE
CONTRIB-6952 mod_surveypro: umbrella of fixes for multiselect

### DIFF
--- a/classes/utility.php
+++ b/classes/utility.php
@@ -1087,7 +1087,7 @@ class mod_surveypro_utility {
      */
     public static function get_regexp() {
         $regex = '~';
-        $regex .= '(?P<prefix>'.SURVEYPRO_ITEMPREFIX.'|'.SURVEYPRO_DONTSAVEMEPREFIX.')';
+        $regex .= '(?P<prefix>'.SURVEYPRO_ITEMPREFIX.'|'.SURVEYPRO_PLACEHOLDERPREFIX.'|'.SURVEYPRO_DONTSAVEMEPREFIX.')';
         $regex .= '_';
         $regex .= '(?P<type>'.SURVEYPRO_TYPEFIELD.'|'.SURVEYPRO_TYPEFORMAT.')';
         $regex .= '_';

--- a/classes/view_form.php
+++ b/classes/view_form.php
@@ -599,6 +599,18 @@ class mod_surveypro_view_form extends mod_surveypro_formbase {
         // End of: let's start by saving one record in surveypro_submission.
 
         // Generate $itemhelperinfo.
+        foreach ($this->formdata as $elementname => $content) {
+            if ($matches = mod_surveypro_utility::get_item_parts($elementname)) {
+                if ($matches['prefix'] == SURVEYPRO_PLACEHOLDERPREFIX) {
+                    $newelement = SURVEYPRO_ITEMPREFIX.'_'.$matches['type'].'_'.$matches['plugin'].'_'.$matches['itemid'];
+                    if (!isset($this->formdata->$newelement)) {
+                        $this->formdata->$newelement = null;
+                    }
+                    unset($this->formdata->$elementname);
+                }
+            }
+        }
+
         $itemhelperinfo = array();
         foreach ($this->formdata as $elementname => $content) {
             if ($matches = mod_surveypro_utility::get_item_parts($elementname)) {

--- a/field/multiselect/backup/moodle2/backup_surveyprofield_multiselect_subplugin.class.php
+++ b/field/multiselect/backup/moodle2/backup_surveyprofield_multiselect_subplugin.class.php
@@ -44,7 +44,7 @@ class backup_surveyprofield_multiselect_subplugin extends backup_subplugin {
         $subpluginmultiselect = new backup_nested_element('surveyprofield_multiselect', array('id'), array(
             'content', 'contentformat', 'customnumber', 'position', 'extranote',
             'required', 'hideinstructions', 'variable', 'indent', 'options',
-            'defaultvalue', 'downloadformat', 'minimumrequired', 'heightinrows'));
+            'defaultvalue', 'noanswerdefault', 'downloadformat', 'minimumrequired', 'heightinrows'));
 
         // Connect XML elements into the tree.
         $subplugin->add_child($wrapper);

--- a/field/multiselect/db/install.xml
+++ b/field/multiselect/db/install.xml
@@ -25,6 +25,7 @@
         <!-- begin of fields belonging to itemsetup_form.php of this specific plugin -->
         <FIELD NAME="options"          TYPE="text" LENGTH="medium" NOTNULL="false"                             SEQUENCE="false"/>
         <FIELD NAME="defaultvalue"     TYPE="char" LENGTH="255"    NOTNULL="false"                             SEQUENCE="false"/>
+        <FIELD NAME="noanswerdefault"  TYPE="int"  LENGTH="2"      NOTNULL="true"  UNSIGNED="true" DEFAULT="2" SEQUENCE="false"/>
         <FIELD NAME="downloadformat"   TYPE="int"  LENGTH="4"      NOTNULL="false" UNSIGNED="true"             SEQUENCE="false"/>
 
         <FIELD NAME="minimumrequired"  TYPE="int"  LENGTH="4"      NOTNULL="true"  UNSIGNED="true" DEFAULT="0" SEQUENCE="false"/>

--- a/field/multiselect/db/upgrade.php
+++ b/field/multiselect/db/upgrade.php
@@ -103,5 +103,20 @@ function xmldb_surveyprofield_multiselect_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2015123000, 'surveyprofield', 'multiselect');
     }
 
+    if ($oldversion < 2017062301) {
+
+        // Define field noanswerdefault to be added to surveyprofield_checkbox.
+        $table = new xmldb_table('surveyprofield_multiselect');
+        $field = new xmldb_field('noanswerdefault', XMLDB_TYPE_INTEGER, '2', null, XMLDB_NOTNULL, null, '2', 'defaultvalue');
+
+        // Conditionally launch add field noanswerdefault.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Surveypro savepoint reached.
+        upgrade_plugin_savepoint(true, 2017062301, 'surveyprofield', 'multiselect');
+    }
+
     return true;
 }

--- a/field/multiselect/form/itemsetup_form.php
+++ b/field/multiselect/form/itemsetup_form.php
@@ -67,6 +67,12 @@ class mod_surveypro_itemsetupform extends mod_surveypro_itembaseform {
         $mform->addHelpButton($fieldname, $fieldname, 'surveyprofield_multiselect');
         $mform->setType($fieldname, PARAM_TEXT);
 
+        // Item: noanswerdefault.
+        $fieldname = 'noanswerdefault';
+        $mform->addElement('checkbox', $fieldname, get_string($fieldname, 'surveyprofield_multiselect'));
+        $mform->addHelpButton($fieldname, $fieldname, 'surveyprofield_multiselect');
+        $mform->setType($fieldname, PARAM_INT);
+
         // Item: heightinrows.
         $fieldname = 'heightinrows';
         $rowsrange = range(3, 12);
@@ -163,6 +169,13 @@ class mod_surveypro_itemsetupform extends mod_surveypro_itembaseform {
         }
 
         // Third check.
+        // No answer is not allowed if the item is mandatory.
+        if ( isset($data['noanswerdefault']) && (isset($data['required'])) ) {
+            $a = get_string('noanswer', 'mod_surveypro');
+            $errors['noanswerdefault'] = get_string('ierr_notalloweddefault', 'mod_surveypro', $a);
+        }
+
+        // Fourth check.
         // SURVEYPRO_DBMULTICONTENTSEPARATOR can not be contained into values.
         foreach ($values as $value) {
             if (strpos($value, SURVEYPRO_DBMULTICONTENTSEPARATOR) !== false) {
@@ -171,7 +184,7 @@ class mod_surveypro_itemsetupform extends mod_surveypro_itembaseform {
             }
         }
 
-        // Fourth check.
+        // Fifth check.
         // Minimumrequired has to be lower than count($cleanoptions).
         if ($data['minimumrequired'] > count($cleanoptions) - 1) {
             $errors['minimumrequired'] = get_string('ierr_minimumrequired', 'surveyprofield_multiselect', count($cleanoptions));

--- a/field/multiselect/lang/en/surveyprofield_multiselect.php
+++ b/field/multiselect/lang/en/surveyprofield_multiselect.php
@@ -39,6 +39,7 @@ $string['ierr_valuesduplicated'] = 'Values must be different each other';
 $string['ierr_optionswithseparator'] = 'Options can not contain "{$a}"';
 $string['minimumrequired_help'] = 'The minimum number of items the user is forced to choose in his/her answer';
 $string['minimumrequired'] = 'Minimum required items';
+$string['noanswerdefault'] = '"No answer" as defaults';
 $string['option'] = 'Option';
 $string['options_help'] = 'The list of the options for this item. You are allowed to write them as: value'.SURVEYPRO_VALUELABELSEPARATOR.'label in order to define value and label both. The label will be displayed in the element list, the value will be stored in the survey field. If you only specify one word per line (without separator), value and label will both be valued to that word.';
 $string['options'] = 'Options';

--- a/field/multiselect/lang/es_mx/surveyprofield_multiselect.php
+++ b/field/multiselect/lang/es_mx/surveyprofield_multiselect.php
@@ -38,6 +38,7 @@ $string['ierr_optionswithseparator'] = 'Las opciones no pueden contener "{$a}"';
 $string['ierr_valuesduplicated'] = 'Los valores deben de ser diferentes entre sí';
 $string['minimumrequired'] = 'Mínimo de ítems requeridos';
 $string['minimumrequired_help'] = 'El número máximo de ítems que el usuario es forzado a elegir en su contestación';
+$string['noanswerdefault'] = '"sin contestación" como valor por defecto';
 $string['option'] = 'Opción';
 $string['options'] = 'Opciones';
 $string['options_help'] = 'La lista de las opciones para este ítem. Usted tiene permitido escribirlas como: valor::etiqueta para definir ambos valor y etiqueta. La etiqueta será mostrada en el menú desplegable, el valor será almacenado en el campo. Si Usted solamente especifica una palabra por línea (sin separador), ambos el valor y la etiqueta serán valorados para esa palabra.';

--- a/field/multiselect/version.php
+++ b/field/multiselect/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2016061701;
+$plugin->version = 2017062301;
 $plugin->release = '1.0';
 $plugin->requires = 2015111600; // Requires this Moodle version.
 $plugin->component = 'surveyprofield_multiselect'; // Full name of the plugin (used for diagnostics).

--- a/lib.php
+++ b/lib.php
@@ -157,6 +157,7 @@ define('SURVEYPRO_NOFEEDBACK', 0);
  * ITEMPREFIX
  */
 define('SURVEYPRO_ITEMPREFIX', 'surveypro');
+define('SURVEYPRO_PLACEHOLDERPREFIX', 'placeholder');
 define('SURVEYPRO_DONTSAVEMEPREFIX', 'placeholder');
 
 /**


### PR DESCRIPTION
Multiselect item is actually affected by a lot of minor and major issues.

It is almost never really used because checkbox item performs the same tasks and this seems to be the reason why none still rose up with a request bug fixes.

Among them:
- the `"No Answer" as default` option is missing in spite of what it has been done for all the other items
- providing a "blank" answer (each item not selected) saves a wrong answer to the database
- the standard used for the value saved to the db is different from the one used for all the other items