### PR TITLE
CONTRIB-6964 mod_surveypro: added params to url

### DIFF
--- a/layout_items.php
+++ b/layout_items.php
@@ -142,7 +142,15 @@ if ($bulkactioncondition) {
 }
 
 // Output starts here.
-$url = new moodle_url('/mod/surveypro/layout_items.php', array('s' => $surveypro->id));
+$paramurl = array('s' => $surveypro->id);
+if ($itemtomove) {
+    $paramurl['itemid'] = $itemid;
+    $paramurl['type'] = $type;
+    $paramurl['plugin'] = $plugin;
+    $paramurl['view'] = $view;
+    $paramurl['itm'] = $itemtomove;
+}
+$url = new moodle_url('/mod/surveypro/layout_items.php', $paramurl);
 $PAGE->set_url($url);
 $PAGE->set_context($context);
 $PAGE->set_cm($cm);


### PR DESCRIPTION
Pressing the up/down icon to reorder the items of the surveypro, the $PAGE url is wrong. I get it by selecting the "Purge all caches" link at the bottom of the page in developer mode.