### PR TITLE
Behat fixes for clean and boost

### DIFF
--- a/field/age/tests/behat/itemform.feature
+++ b/field/age/tests/behat/itemform.feature
@@ -22,7 +22,7 @@ Feature: test the use of age setup form
       | type  | plugin  |
       | field | boolean |
     And I log in as "teacher1"
-    And I follow "Age setup form"
+    And I am on "Age setup form" course homepage
     And I follow "Test age setup form"
     And I follow "Layout"
 

--- a/field/age/tests/behat/submit_age.feature
+++ b/field/age/tests/behat/submit_age.feature
@@ -21,7 +21,7 @@ Feature: make a submission test for "age" item
       | activity  | name     | intro                          | course              | idnumber   |
       | surveypro | Age test | To test submission of age item | Age submission test | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for age item"
+    And I am on "Test submission for age item" course homepage
     And I follow "Age test"
 
     And I set the field "typeplugin" to "Age"
@@ -44,7 +44,7 @@ Feature: make a submission test for "age" item
 
     # student1 logs in
     When I log in as "student1"
-    And I follow "Test submission for age item"
+    And I am on "Test submission for age item" course homepage
     And I follow "Age test"
     And I press "New response"
 

--- a/field/age/tests/behat/use_advanced_elements.feature
+++ b/field/age/tests/behat/use_advanced_elements.feature
@@ -21,7 +21,7 @@ Feature: test the use of reserved elements
       | activity  | name                  | intro                    | course            | idnumber   |
       | surveypro | Reserved element test | To test reserved element | Reserved elements | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Reserved elements"
+    And I am on "Reserved elements" course homepage
     And I follow "Reserved element test"
 
     # add the first age item generally available
@@ -63,7 +63,7 @@ Feature: test the use of reserved elements
 
     # test the user sees only the first age item
     When I log in as "student1"
-    And I follow "Reserved elements"
+    And I am on "Reserved elements" course homepage
     And I follow "Reserved element test"
     And I press "New response"
     Then I should see "1: First age item"
@@ -79,7 +79,7 @@ Feature: test the use of reserved elements
 
     # test the teacher sees the first and the second age items both
     When I log in as "teacher1"
-    And I follow "Reserved elements"
+    And I am on "Reserved elements" course homepage
     And I follow "Reserved element test"
     And I follow "edit_submission_row_1"
     Then I should see "1: First age item"

--- a/field/autofill/tests/behat/itemform.feature
+++ b/field/autofill/tests/behat/itemform.feature
@@ -22,7 +22,7 @@ Feature: test the use of autofill setup form
       | type  | plugin  |
       | field | boolean |
     And I log in as "teacher1"
-    And I follow "Autofill setup form"
+    And I am on "Autofill setup form" course homepage
     And I follow "Test autofill setup form"
     And I follow "Layout"
 

--- a/field/autofill/tests/behat/submit_autofill.feature
+++ b/field/autofill/tests/behat/submit_autofill.feature
@@ -21,7 +21,7 @@ Feature: make a submission test for "autofill" item
       | activity  | name          | intro                               | course                   | idnumber   |
       | surveypro | Autofill test | To test submission of autofill item | Autofill submission test | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for autofill item"
+    And I am on "Test submission for autofill item" course homepage
     And I follow "Autofill test"
 
     And I set the field "typeplugin" to "Autofill"
@@ -40,7 +40,7 @@ Feature: make a submission test for "autofill" item
 
     # student1 logs in
     When I log in as "student1"
-    And I follow "Test submission for autofill item"
+    And I am on "Test submission for autofill item" course homepage
     And I follow "Autofill test"
     And I press "New response"
 

--- a/field/boolean/tests/behat/itemform.feature
+++ b/field/boolean/tests/behat/itemform.feature
@@ -22,7 +22,7 @@ Feature: test the use of boolean setup form
       | type  | plugin  |
       | field | boolean |
     And I log in as "teacher1"
-    And I follow "Boolean setup form"
+    And I am on "Boolean setup form" course homepage
     And I follow "Test boolean setup form"
     And I follow "Layout"
 

--- a/field/boolean/tests/behat/submit_boolean.feature
+++ b/field/boolean/tests/behat/submit_boolean.feature
@@ -21,7 +21,7 @@ Feature: make a submission test for "boolean" item
       | activity  | name         | intro                              | course                  | idnumber   |
       | surveypro | Boolean test | To test submission of boolean item | Boolean submission test | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for boolean item"
+    And I am on "Test submission for boolean item" course homepage
     And I follow "Boolean test"
 
     And I set the field "typeplugin" to "Boolean"
@@ -67,7 +67,7 @@ Feature: make a submission test for "boolean" item
 
     # student1 logs in
     When I log in as "student1"
-    And I follow "Test submission for boolean item"
+    And I am on "Test submission for boolean item" course homepage
     And I follow "Boolean test"
     And I press "New response"
 

--- a/field/character/tests/behat/itemform.feature
+++ b/field/character/tests/behat/itemform.feature
@@ -22,7 +22,7 @@ Feature: test the use of character setup form
       | type  | plugin  |
       | field | boolean |
     And I log in as "teacher1"
-    And I follow "Character setup form"
+    And I am on "Character setup form" course homepage
     And I follow "Test character setup form"
     And I follow "Layout"
 

--- a/field/character/tests/behat/settings_configuration_01.feature
+++ b/field/character/tests/behat/settings_configuration_01.feature
@@ -21,7 +21,7 @@ Feature: Validate creation and submit for "character" elements using the princip
       | activity  | name           | intro              | course         | idnumber   |
       | surveypro | Surveypro test | For testing backup | Character item | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for character item"
+    And I am on "Test submission for character item" course homepage
     And I follow "Surveypro test"
     And I set the field "typeplugin" to "Text (short)"
     And I press "Add"
@@ -40,7 +40,7 @@ Feature: Validate creation and submit for "character" elements using the princip
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for character item"
+    And I am on "Test submission for character item" course homepage
     And I follow "Surveypro test"
 
     # Test number 1: Student flies over the answer
@@ -72,7 +72,7 @@ Feature: Validate creation and submit for "character" elements using the princip
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for character item"
+    And I am on "Test submission for character item" course homepage
     And I follow "Surveypro test"
 
     # Test number 3: Student flies over the answer

--- a/field/character/tests/behat/settings_configuration_02.feature
+++ b/field/character/tests/behat/settings_configuration_02.feature
@@ -21,7 +21,7 @@ Feature: Validate creation and submit for "character" elements using the princip
       | activity  | name           | intro              | course         | idnumber   |
       | surveypro | Surveypro test | For testing backup | Character item | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for character item"
+    And I am on "Test submission for character item" course homepage
     And I follow "Surveypro test"
     And I set the field "typeplugin" to "Text (short)"
     And I press "Add"
@@ -40,7 +40,7 @@ Feature: Validate creation and submit for "character" elements using the princip
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for character item"
+    And I am on "Test submission for character item" course homepage
     And I follow "Surveypro test"
 
     # Test number 1: Student flies over the answer
@@ -75,7 +75,7 @@ Feature: Validate creation and submit for "character" elements using the princip
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for character item"
+    And I am on "Test submission for character item" course homepage
     And I follow "Surveypro test"
 
     # Test number 3: Student flies over the answer

--- a/field/character/tests/behat/settings_configuration_03.feature
+++ b/field/character/tests/behat/settings_configuration_03.feature
@@ -21,7 +21,7 @@ Feature: Validate creation and submit for "character" elements using the princip
       | activity  | name           | intro              | course         | idnumber   |
       | surveypro | Surveypro test | For testing backup | Character item | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for character item"
+    And I am on "Test submission for character item" course homepage
     And I follow "Surveypro test"
     And I set the field "typeplugin" to "Text (short)"
     And I press "Add"
@@ -40,7 +40,7 @@ Feature: Validate creation and submit for "character" elements using the princip
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for character item"
+    And I am on "Test submission for character item" course homepage
     And I follow "Surveypro test"
 
     # Test number 1: Student flies over the answer
@@ -77,7 +77,7 @@ Feature: Validate creation and submit for "character" elements using the princip
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for character item"
+    And I am on "Test submission for character item" course homepage
     And I follow "Surveypro test"
 
     # Test number 3: Student flies over the answer

--- a/field/character/tests/behat/settings_configuration_04.feature
+++ b/field/character/tests/behat/settings_configuration_04.feature
@@ -21,7 +21,7 @@ Feature: Validate creation and submit for "character" elements using the princip
       | activity  | name           | intro              | course         | idnumber   |
       | surveypro | Surveypro test | For testing backup | Character item | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for character item"
+    And I am on "Test submission for character item" course homepage
     And I follow "Surveypro test"
     And I set the field "typeplugin" to "Text (short)"
     And I press "Add"
@@ -41,7 +41,7 @@ Feature: Validate creation and submit for "character" elements using the princip
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for character item"
+    And I am on "Test submission for character item" course homepage
     And I follow "Surveypro test"
 
     # Test number 1: Student flies over the answer
@@ -78,7 +78,7 @@ Feature: Validate creation and submit for "character" elements using the princip
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for character item"
+    And I am on "Test submission for character item" course homepage
     And I follow "Surveypro test"
 
     # Test number 3: Student flies over the answer

--- a/field/character/tests/behat/settings_configuration_05.feature
+++ b/field/character/tests/behat/settings_configuration_05.feature
@@ -21,7 +21,7 @@ Feature: Validate creation and submit for "character" elements using the princip
       | activity  | name           | intro              | course         | idnumber   |
       | surveypro | Surveypro test | For testing backup | Character item | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for character item"
+    And I am on "Test submission for character item" course homepage
     And I follow "Surveypro test"
     And I set the field "typeplugin" to "Text (short)"
     And I press "Add"
@@ -40,7 +40,7 @@ Feature: Validate creation and submit for "character" elements using the princip
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for character item"
+    And I am on "Test submission for character item" course homepage
     And I follow "Surveypro test"
 
     # Test number 1: Student flies over the answer
@@ -67,7 +67,7 @@ Feature: Validate creation and submit for "character" elements using the princip
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for character item"
+    And I am on "Test submission for character item" course homepage
     And I follow "Surveypro test"
 
     # Test number 2: Student flies over the answer

--- a/field/character/tests/behat/settings_configuration_06.feature
+++ b/field/character/tests/behat/settings_configuration_06.feature
@@ -21,7 +21,7 @@ Feature: Validate creation and submit for "character" elements using the princip
       | activity  | name           | intro              | course         | idnumber   |
       | surveypro | Surveypro test | For testing backup | Character item | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for character item"
+    And I am on "Test submission for character item" course homepage
     And I follow "Surveypro test"
     And I set the field "typeplugin" to "Text (short)"
     And I press "Add"
@@ -40,7 +40,7 @@ Feature: Validate creation and submit for "character" elements using the princip
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for character item"
+    And I am on "Test submission for character item" course homepage
     And I follow "Surveypro test"
 
     # Test number 1: Student flies over the answer
@@ -70,7 +70,7 @@ Feature: Validate creation and submit for "character" elements using the princip
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for character item"
+    And I am on "Test submission for character item" course homepage
     And I follow "Surveypro test"
 
     # Test number 2: Student flies over the answer

--- a/field/character/tests/behat/settings_configuration_07.feature
+++ b/field/character/tests/behat/settings_configuration_07.feature
@@ -21,7 +21,7 @@ Feature: Validate creation and submit for "character" elements using the princip
       | activity  | name           | intro              | course         | idnumber   |
       | surveypro | Surveypro test | For testing backup | Character item | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for character item"
+    And I am on "Test submission for character item" course homepage
     And I follow "Surveypro test"
     And I set the field "typeplugin" to "Text (short)"
     And I press "Add"
@@ -40,7 +40,7 @@ Feature: Validate creation and submit for "character" elements using the princip
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for character item"
+    And I am on "Test submission for character item" course homepage
     And I follow "Surveypro test"
 
     # Test number 1: Student flies over the answer
@@ -70,7 +70,7 @@ Feature: Validate creation and submit for "character" elements using the princip
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for character item"
+    And I am on "Test submission for character item" course homepage
     And I follow "Surveypro test"
 
     # Test number 2: Student flies over the answer

--- a/field/character/tests/behat/trim.feature
+++ b/field/character/tests/behat/trim.feature
@@ -21,7 +21,7 @@ Feature: test the use of character setup form
       | activity  | name                | intro               | course              | idnumber   |
       | surveypro | Test character trim | Test character trim | Character trim test | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Character trim test"
+    And I am on "Character trim test" course homepage
     And I follow "Test character trim"
 
     # add an character item
@@ -56,7 +56,7 @@ Feature: test the use of character setup form
 
     And I log out
     When I log in as "student1"
-    And I follow "Character trim test"
+    And I am on "Character trim test" course homepage
     And I follow "Test character trim"
 
     # Test number 1: Student insert a record

--- a/field/checkbox/tests/behat/itemform.feature
+++ b/field/checkbox/tests/behat/itemform.feature
@@ -22,7 +22,7 @@ Feature: test the use of checkbox setup form
       | type  | plugin  |
       | field | boolean |
     And I log in as "teacher1"
-    And I follow "Checkbox setup form"
+    And I am on "Checkbox setup form" course homepage
     And I follow "Test checkbox setup form"
     And I follow "Layout"
 

--- a/field/checkbox/tests/behat/settings_configuration_01.feature
+++ b/field/checkbox/tests/behat/settings_configuration_01.feature
@@ -22,7 +22,7 @@ Feature: Validate creation and submit for "checkbox" elements using the principa
       | activity  | name           | intro              | course        | idnumber   |
       | surveypro | Surveypro test | For testing backup | Checkbox item | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for checkbox item"
+    And I am on "Test submission for checkbox item" course homepage
     And I follow "Surveypro test"
     And I set the field "typeplugin" to "Checkbox"
     And I press "Add"
@@ -56,7 +56,7 @@ Feature: Validate creation and submit for "checkbox" elements using the principa
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for checkbox item"
+    And I am on "Test submission for checkbox item" course homepage
     And I follow "Surveypro test"
 
     # Test number 1: Student flies over the answer
@@ -114,7 +114,7 @@ Feature: Validate creation and submit for "checkbox" elements using the principa
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for checkbox item"
+    And I am on "Test submission for checkbox item" course homepage
     And I follow "Surveypro test"
 
     # Test number 4: Student flies over the answer

--- a/field/checkbox/tests/behat/settings_configuration_02.feature
+++ b/field/checkbox/tests/behat/settings_configuration_02.feature
@@ -22,7 +22,7 @@ Feature: Validate creation and submit for "checkbox" elements using the principa
       | activity  | name           | intro              | course        | idnumber   |
       | surveypro | Surveypro test | For testing backup | Checkbox item | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for checkbox item"
+    And I am on "Test submission for checkbox item" course homepage
     And I follow "Surveypro test"
     And I set the field "typeplugin" to "Checkbox"
     And I press "Add"
@@ -56,7 +56,7 @@ Feature: Validate creation and submit for "checkbox" elements using the principa
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for checkbox item"
+    And I am on "Test submission for checkbox item" course homepage
     And I follow "Surveypro test"
 
     # Test number 1: Student flies over the answer
@@ -114,7 +114,7 @@ Feature: Validate creation and submit for "checkbox" elements using the principa
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for checkbox item"
+    And I am on "Test submission for checkbox item" course homepage
     And I follow "Surveypro test"
 
     # Test number 4: Student flies over the answer

--- a/field/checkbox/tests/behat/settings_configuration_03.feature
+++ b/field/checkbox/tests/behat/settings_configuration_03.feature
@@ -22,7 +22,7 @@ Feature: Validate creation and submit for "checkbox" elements using the principa
       | activity  | name           | intro              | course        | idnumber   |
       | surveypro | Surveypro test | For testing backup | Checkbox item | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for checkbox item"
+    And I am on "Test submission for checkbox item" course homepage
     And I follow "Surveypro test"
     And I set the field "typeplugin" to "Checkbox"
     And I press "Add"
@@ -56,7 +56,7 @@ Feature: Validate creation and submit for "checkbox" elements using the principa
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for checkbox item"
+    And I am on "Test submission for checkbox item" course homepage
     And I follow "Surveypro test"
 
     # Test number 1: Student flies over the answer
@@ -105,7 +105,7 @@ Feature: Validate creation and submit for "checkbox" elements using the principa
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for checkbox item"
+    And I am on "Test submission for checkbox item" course homepage
     And I follow "Surveypro test"
 
     # Test number 3: Student flies over the answer

--- a/field/checkbox/tests/behat/settings_configuration_04.feature
+++ b/field/checkbox/tests/behat/settings_configuration_04.feature
@@ -22,7 +22,7 @@ Feature: Validate creation and submit for "checkbox" elements using the principa
       | activity  | name           | intro              | course        | idnumber   |
       | surveypro | Surveypro test | For testing backup | Checkbox item | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for checkbox item"
+    And I am on "Test submission for checkbox item" course homepage
     And I follow "Surveypro test"
     And I set the field "typeplugin" to "Checkbox"
     And I press "Add"
@@ -56,7 +56,7 @@ Feature: Validate creation and submit for "checkbox" elements using the principa
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for checkbox item"
+    And I am on "Test submission for checkbox item" course homepage
     And I follow "Surveypro test"
 
     # Test number 1: Student flies over the answer
@@ -105,7 +105,7 @@ Feature: Validate creation and submit for "checkbox" elements using the principa
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for checkbox item"
+    And I am on "Test submission for checkbox item" course homepage
     And I follow "Surveypro test"
 
     # Test number 3: Student flies over the answer

--- a/field/date/tests/behat/itemform.feature
+++ b/field/date/tests/behat/itemform.feature
@@ -22,7 +22,7 @@ Feature: test the use of date setup form
       | type  | plugin  |
       | field | boolean |
     And I log in as "teacher1"
-    And I follow "Date setup form"
+    And I am on "Date setup form" course homepage
     And I follow "Test date setup form"
     And I follow "Layout"
 

--- a/field/date/tests/behat/submit_date.feature
+++ b/field/date/tests/behat/submit_date.feature
@@ -21,7 +21,7 @@ Feature: make a submission test for "date" item
       | activity  | name         | intro                        | course               | idnumber   |
       | surveypro | Date test | To test submission of date item | Date submission test | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for date item"
+    And I am on "Test submission for date item" course homepage
     And I follow "Date test"
 
     And I set the field "typeplugin" to "Date [dd/mm/yyyy]"
@@ -41,7 +41,7 @@ Feature: make a submission test for "date" item
 
     # student1 logs in
     When I log in as "student1"
-    And I follow "Test submission for date item"
+    And I am on "Test submission for date item" course homepage
     And I follow "Date test"
     And I press "New response"
 

--- a/field/datetime/tests/behat/itemform.feature
+++ b/field/datetime/tests/behat/itemform.feature
@@ -22,7 +22,7 @@ Feature: test the use of datetime setup form
       | type  | plugin  |
       | field | boolean |
     And I log in as "teacher1"
-    And I follow "Datetime setup form"
+    And I am on "Datetime setup form" course homepage
     And I follow "Test datetime setup form"
     And I follow "Layout"
 

--- a/field/datetime/tests/behat/submit_datetime.feature
+++ b/field/datetime/tests/behat/submit_datetime.feature
@@ -21,7 +21,7 @@ Feature: make a submission test for "datetime" item
       | activity  | name          | intro                           | course                   | idnumber   |
       | surveypro | Datetime test | To test submission of date item | Datetime submission test | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for datetime item"
+    And I am on "Test submission for datetime item" course homepage
     And I follow "Datetime test"
 
     And I set the field "typeplugin" to "Date and time [dd/mm/yyyy;hh:mm]"
@@ -41,7 +41,7 @@ Feature: make a submission test for "datetime" item
 
     # student1 logs in
     When I log in as "student1"
-    And I follow "Test submission for datetime item"
+    And I am on "Test submission for datetime item" course homepage
     And I follow "Datetime test"
     And I press "New response"
 

--- a/field/fileupload/tests/behat/itemform.feature
+++ b/field/fileupload/tests/behat/itemform.feature
@@ -22,7 +22,7 @@ Feature: test the use of fileupload setup form
       | type  | plugin  |
       | field | boolean |
     And I log in as "teacher1"
-    And I follow "Fileupload setup form"
+    And I am on "Fileupload setup form" course homepage
     And I follow "Test fileupload setup form"
     And I follow "Layout"
 

--- a/field/fileupload/tests/behat/submit_attachment.feature
+++ b/field/fileupload/tests/behat/submit_attachment.feature
@@ -21,7 +21,7 @@ Feature: make a submission test for "fileupload" item
       | activity  | name            | intro                                 | course                     | idnumber   |
       | surveypro | Attachment test | To test submission of attachment item | Attachment submission test | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for attachment item"
+    And I am on "Test submission for attachment item" course homepage
     And I follow "Attachment test"
 
     And I set the field "typeplugin" to "Attachment"
@@ -41,7 +41,7 @@ Feature: make a submission test for "fileupload" item
 
     # student1 logs in
     When I log in as "student1"
-    And I follow "Test submission for attachment item"
+    And I am on "Test submission for attachment item" course homepage
     And I follow "Attachment test"
     And I press "New response"
 

--- a/field/integer/tests/behat/itemform.feature
+++ b/field/integer/tests/behat/itemform.feature
@@ -22,7 +22,7 @@ Feature: test the use of integer setup form
       | type  | plugin  |
       | field | boolean |
     And I log in as "teacher1"
-    And I follow "Integer setup form"
+    And I am on "Integer setup form" course homepage
     And I follow "Test integer setup form"
     And I follow "Layout"
 

--- a/field/integer/tests/behat/submit_integer.feature
+++ b/field/integer/tests/behat/submit_integer.feature
@@ -21,7 +21,7 @@ Feature: make a submission test for "integer" item
       | activity  | name         | intro                           | course                  | idnumber   |
       | surveypro | Integer test | To test submission of date item | Integer submission test | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for integer item"
+    And I am on "Test submission for integer item" course homepage
     And I follow "Integer test"
 
     And I set the field "typeplugin" to "Integer (small)"
@@ -40,7 +40,7 @@ Feature: make a submission test for "integer" item
 
     # student1 logs in
     When I log in as "student1"
-    And I follow "Test submission for integer item"
+    And I am on "Test submission for integer item" course homepage
     And I follow "Integer test"
     And I press "New response"
 

--- a/field/multiselect/tests/behat/itemform.feature
+++ b/field/multiselect/tests/behat/itemform.feature
@@ -22,7 +22,7 @@ Feature: test the use of multiselect setup form
       | type  | plugin  |
       | field | boolean |
     And I log in as "teacher1"
-    And I follow "Multiselect setup form"
+    And I am on "Multiselect setup form" course homepage
     And I follow "Test multiselect setup form"
     And I follow "Layout"
 

--- a/field/multiselect/tests/behat/settings_configuration_01.feature
+++ b/field/multiselect/tests/behat/settings_configuration_01.feature
@@ -22,7 +22,7 @@ Feature: Validate creation and submit for "multiselect" elements using the princ
       | activity  | name           | intro              | course           | idnumber   |
       | surveypro | Surveypro test | For testing backup | Multiselect item | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for multiselect item"
+    And I am on "Test submission for multiselect item" course homepage
     And I follow "Surveypro test"
     And I set the field "typeplugin" to "Multiple selection"
     And I press "Add"
@@ -56,7 +56,7 @@ Feature: Validate creation and submit for "multiselect" elements using the princ
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for multiselect item"
+    And I am on "Test submission for multiselect item" course homepage
     And I follow "Surveypro test"
 
     # Test number 1: Student flies over the answer
@@ -112,7 +112,7 @@ Feature: Validate creation and submit for "multiselect" elements using the princ
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for multiselect item"
+    And I am on "Test submission for multiselect item" course homepage
     And I follow "Surveypro test"
 
     # Test number 4: Student flies over the answer

--- a/field/multiselect/tests/behat/settings_configuration_02.feature
+++ b/field/multiselect/tests/behat/settings_configuration_02.feature
@@ -22,7 +22,7 @@ Feature: Validate creation and submit for "multiselect" elements using the princ
       | activity  | name           | intro              | course           | idnumber   |
       | surveypro | Surveypro test | For testing backup | Multiselect item | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for multiselect item"
+    And I am on "Test submission for multiselect item" course homepage
     And I follow "Surveypro test"
     And I set the field "typeplugin" to "Multiple selection"
     And I press "Add"
@@ -56,7 +56,7 @@ Feature: Validate creation and submit for "multiselect" elements using the princ
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for multiselect item"
+    And I am on "Test submission for multiselect item" course homepage
     And I follow "Surveypro test"
 
     # Test number 1: Student flies over the answer
@@ -112,7 +112,7 @@ Feature: Validate creation and submit for "multiselect" elements using the princ
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for multiselect item"
+    And I am on "Test submission for multiselect item" course homepage
     And I follow "Surveypro test"
 
     # Test number 4: Student flies over the answer

--- a/field/multiselect/tests/behat/settings_configuration_03.feature
+++ b/field/multiselect/tests/behat/settings_configuration_03.feature
@@ -22,7 +22,7 @@ Feature: Validate creation and submit for "multiselect" elements using the princ
       | activity  | name           | intro              | course           | idnumber   |
       | surveypro | Surveypro test | For testing backup | Multiselect item | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for multiselect item"
+    And I am on "Test submission for multiselect item" course homepage
     And I follow "Surveypro test"
     And I set the field "typeplugin" to "Multiple selection"
     And I press "Add"
@@ -56,7 +56,7 @@ Feature: Validate creation and submit for "multiselect" elements using the princ
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for multiselect item"
+    And I am on "Test submission for multiselect item" course homepage
     And I follow "Surveypro test"
 
     # Test number 1: Student flies over the answer
@@ -103,7 +103,7 @@ Feature: Validate creation and submit for "multiselect" elements using the princ
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for multiselect item"
+    And I am on "Test submission for multiselect item" course homepage
     And I follow "Surveypro test"
 
     # Test number 3: Student flies over the answer

--- a/field/multiselect/tests/behat/settings_configuration_04.feature
+++ b/field/multiselect/tests/behat/settings_configuration_04.feature
@@ -22,7 +22,7 @@ Feature: Validate creation and submit for "multiselect" elements using the princ
       | activity  | name           | intro              | course           | idnumber   |
       | surveypro | Surveypro test | For testing backup | Multiselect item | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for multiselect item"
+    And I am on "Test submission for multiselect item" course homepage
     And I follow "Surveypro test"
     And I set the field "typeplugin" to "Multiple selection"
     And I press "Add"
@@ -56,7 +56,7 @@ Feature: Validate creation and submit for "multiselect" elements using the princ
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for multiselect item"
+    And I am on "Test submission for multiselect item" course homepage
     And I follow "Surveypro test"
 
     # Test number 1: Student flies over the answer
@@ -103,7 +103,7 @@ Feature: Validate creation and submit for "multiselect" elements using the princ
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for multiselect item"
+    And I am on "Test submission for multiselect item" course homepage
     And I follow "Surveypro test"
 
     # Test number 3: Student flies over the answer

--- a/field/numeric/tests/behat/itemform.feature
+++ b/field/numeric/tests/behat/itemform.feature
@@ -22,7 +22,7 @@ Feature: test the use of numeric setup form
       | type  | plugin  |
       | field | boolean |
     And I log in as "teacher1"
-    And I follow "Numeric setup form"
+    And I am on "Numeric setup form" course homepage
     And I follow "Test numeric setup form"
     And I follow "Layout"
 

--- a/field/numeric/tests/behat/submit_numeric.feature
+++ b/field/numeric/tests/behat/submit_numeric.feature
@@ -21,7 +21,7 @@ Feature: make a submission test for "numeric" item
       | activity  | name         | intro                         | course                  | idnumber   |
       | surveypro | Numeric test | To test submission of numeric | Numeric submission test | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for numeric item"
+    And I am on "Test submission for numeric item" course homepage
     And I follow "Numeric test"
 
     And I set the field "typeplugin" to "Numeric"
@@ -42,7 +42,7 @@ Feature: make a submission test for "numeric" item
 
     # student1 logs in
     When I log in as "student1"
-    And I follow "Test submission for numeric item"
+    And I am on "Test submission for numeric item" course homepage
     And I follow "Numeric test"
     And I press "New response"
 

--- a/field/radiobutton/tests/behat/itemform.feature
+++ b/field/radiobutton/tests/behat/itemform.feature
@@ -22,7 +22,7 @@ Feature: test the use of radiobutton setup form
       | type  | plugin  |
       | field | boolean |
     And I log in as "teacher1"
-    And I follow "Radiobutton setup form"
+    And I am on "Radiobutton setup form" course homepage
     And I follow "Test radiobutton setup form"
     And I follow "Layout"
 

--- a/field/radiobutton/tests/behat/submit_radiobutton.feature
+++ b/field/radiobutton/tests/behat/submit_radiobutton.feature
@@ -21,7 +21,7 @@ Feature: make a submission test for "radiobutton" item
       | activity  | name             | intro                                  | course                      | idnumber   |
       | surveypro | Radiobutton test | To test submission of radiobutton item | Radiobutton submission test | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for radio buttons item"
+    And I am on "Test submission for radio buttons item" course homepage
     And I follow "Radiobutton test"
 
     And I set the field "typeplugin" to "Radio buttons"
@@ -80,7 +80,7 @@ hills
 
     # student1 logs in
     When I log in as "student1"
-    And I follow "Test submission for radio buttons item"
+    And I am on "Test submission for radio buttons item" course homepage
     And I follow "Radiobutton test"
     And I press "New response"
 

--- a/field/rate/tests/behat/itemform.feature
+++ b/field/rate/tests/behat/itemform.feature
@@ -22,7 +22,7 @@ Feature: test the use of rate setup form
       | type  | plugin  |
       | field | boolean |
     And I log in as "teacher1"
-    And I follow "Rate setup form"
+    And I am on "Rate setup form" course homepage
     And I follow "Test rate setup form"
     And I follow "Layout"
 

--- a/field/rate/tests/behat/submit_rate.feature
+++ b/field/rate/tests/behat/submit_rate.feature
@@ -21,7 +21,7 @@ Feature: make a submission test for "rate" item
       | activity  | name      | intro                           | course               | idnumber   |
       | surveypro | Rate test | To test submission of date item | Rate submission test | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for rate item"
+    And I am on "Test submission for rate item" course homepage
     And I follow "Rate test"
 
     And I set the field "typeplugin" to "Rate"
@@ -102,7 +102,7 @@ Feature: make a submission test for "rate" item
 
     # student1 logs in
     When I log in as "student1"
-    And I follow "Test submission for rate item"
+    And I am on "Test submission for rate item" course homepage
     And I follow "Rate test"
     And I press "New response"
 

--- a/field/recurrence/tests/behat/itemform.feature
+++ b/field/recurrence/tests/behat/itemform.feature
@@ -22,7 +22,7 @@ Feature: test the use of recurrence setup form
       | type  | plugin  |
       | field | boolean |
     And I log in as "teacher1"
-    And I follow "Recurrence setup form"
+    And I am on "Recurrence setup form" course homepage
     And I follow "Test recurrence setup form"
     And I follow "Layout"
 

--- a/field/recurrence/tests/behat/submit_recurrence.feature
+++ b/field/recurrence/tests/behat/submit_recurrence.feature
@@ -21,7 +21,7 @@ Feature: make a submission test for "recurrence" item
       | activity  | name            | intro                           | course                     | idnumber   |
       | surveypro | Recurrence test | To test submission of date item | Recurrence submission test | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for recurrence item"
+    And I am on "Test submission for recurrence item" course homepage
     And I follow "Recurrence test"
 
     And I set the field "typeplugin" to "Recurrence [dd/mm]"
@@ -41,7 +41,7 @@ Feature: make a submission test for "recurrence" item
 
     # student1 logs in
     When I log in as "student1"
-    And I follow "Test submission for recurrence item"
+    And I am on "Test submission for recurrence item" course homepage
     And I follow "Recurrence test"
     And I press "New response"
 

--- a/field/select/tests/behat/itemform.feature
+++ b/field/select/tests/behat/itemform.feature
@@ -22,7 +22,7 @@ Feature: test the use of select setup form
       | type  | plugin  |
       | field | boolean |
     And I log in as "teacher1"
-    And I follow "Select setup form"
+    And I am on "Select setup form" course homepage
     And I follow "Test select setup form"
     And I follow "Layout"
 

--- a/field/select/tests/behat/submit_select.feature
+++ b/field/select/tests/behat/submit_select.feature
@@ -21,7 +21,7 @@ Feature: make a submission test for "select" item
       | activity  | name        | intro                             | course                 | idnumber   |
       | surveypro | Select test | To test submission of select item | Select submission test | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for select item"
+    And I am on "Test submission for select item" course homepage
     And I follow "Select test"
 
     And I set the field "typeplugin" to "Select"
@@ -55,7 +55,7 @@ Feature: make a submission test for "select" item
 
     # student1 logs in
     When I log in as "student1"
-    And I follow "Test submission for select item"
+    And I am on "Test submission for select item" course homepage
     And I follow "Select test"
     And I press "New response"
 

--- a/field/shortdate/tests/behat/itemform.feature
+++ b/field/shortdate/tests/behat/itemform.feature
@@ -22,7 +22,7 @@ Feature: test the use of shortdate setup form
       | type  | plugin  |
       | field | boolean |
     And I log in as "teacher1"
-    And I follow "Shortdate setup form"
+    And I am on "Shortdate setup form" course homepage
     And I follow "Test shortdate setup form"
     And I follow "Layout"
 

--- a/field/shortdate/tests/behat/submit_shortdate.feature
+++ b/field/shortdate/tests/behat/submit_shortdate.feature
@@ -21,7 +21,7 @@ Feature: make a submission test for "shortdate" item
       | activity  | name           | intro                           | course                    | idnumber   |
       | surveypro | Shortdate test | To test submission of shortdate | Shortdate submission test | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for shortdate item"
+    And I am on "Test submission for shortdate item" course homepage
     And I follow "Shortdate test"
 
     And I set the field "typeplugin" to "Date (short) [mm/yyyy]"
@@ -41,7 +41,7 @@ Feature: make a submission test for "shortdate" item
 
     # student1 logs in
     When I log in as "student1"
-    And I follow "Test submission for shortdate item"
+    And I am on "Test submission for shortdate item" course homepage
     And I follow "Shortdate test"
     And I press "New response"
 

--- a/field/textarea/tests/behat/itemform.feature
+++ b/field/textarea/tests/behat/itemform.feature
@@ -22,7 +22,7 @@ Feature: test the use of textarea setup form
       | type  | plugin  |
       | field | boolean |
     And I log in as "teacher1"
-    And I follow "Textarea setup form"
+    And I am on "Textarea setup form" course homepage
     And I follow "Test textarea setup form"
     And I follow "Layout"
 

--- a/field/textarea/tests/behat/itemform.feature
+++ b/field/textarea/tests/behat/itemform.feature
@@ -47,7 +47,7 @@ Feature: test the use of textarea setup form
       | Parent element                 | Boolean [1]: Is this true?            |
       | Parent content                 | 1                                     |
       | Use html editor                | 1                                     |
-      | Area heigh in rows             | 7                                     |
+      | Area height in rows            | 7                                     |
       | Area width in columns          | 40                                    |
       | Minimum length (in characters) | 14                                    |
       | Maximum length (in characters) | 4                                     |
@@ -74,7 +74,7 @@ Feature: test the use of textarea setup form
     Then the field "Parent element" matches value "Boolean [1]: Is this true?"
     Then the field "Parent content" matches value "1"
     Then the field "Use html editor" matches value "1"
-    Then the field "Area heigh in rows" matches value "7"
+    Then the field "Area height in rows" matches value "7"
     Then the field "Area width in columns" matches value "40"
     Then the field "Minimum length (in characters)" matches value "14"
     Then the field "Maximum length (in characters)" matches value "40"

--- a/field/textarea/tests/behat/settings_configuration.feature
+++ b/field/textarea/tests/behat/settings_configuration.feature
@@ -22,7 +22,7 @@ Feature: Validate creation and submit for textarea elements using the principal 
       | activity  | name           | intro              | course        | idnumber   |
       | surveypro | Surveypro test | For testing backup | Textarea item | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for textarea item"
+    And I am on "Test submission for textarea item" course homepage
     And I follow "Surveypro test"
     And I set the field "typeplugin" to "Text (long)"
     And I press "Add"
@@ -49,7 +49,7 @@ Feature: Validate creation and submit for textarea elements using the principal 
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for textarea item"
+    And I am on "Test submission for textarea item" course homepage
     And I follow "Surveypro test"
 
     # Test number 2: Student flies over the answer
@@ -90,7 +90,7 @@ Feature: Validate creation and submit for textarea elements using the principal 
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for textarea item"
+    And I am on "Test submission for textarea item" course homepage
     And I follow "Surveypro test"
 
     # Test number 5: student submits an empty answer
@@ -136,7 +136,7 @@ Feature: Validate creation and submit for textarea elements using the principal 
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for textarea item"
+    And I am on "Test submission for textarea item" course homepage
     And I follow "Surveypro test"
 
     # Test number 9: Student flies over the answer
@@ -177,7 +177,7 @@ Feature: Validate creation and submit for textarea elements using the principal 
 
     And I log out
     When I log in as "student1"
-    And I follow "Test submission for textarea item"
+    And I am on "Test submission for textarea item" course homepage
     And I follow "Surveypro test"
 
     # Test number 12: student submits an empty answer

--- a/field/textarea/tests/behat/trim.feature
+++ b/field/textarea/tests/behat/trim.feature
@@ -21,7 +21,7 @@ Feature: test the use of textarea setup form
       | activity  | name               | intro              | course             | idnumber   |
       | surveypro | Test textarea trim | Test textarea trim | Textarea trim test | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Textarea trim test"
+    And I am on "Textarea trim test" course homepage
     And I follow "Test textarea trim"
 
     # add an textarea item
@@ -54,7 +54,7 @@ Feature: test the use of textarea setup form
 
     And I log out
     When I log in as "student1"
-    And I follow "Textarea trim test"
+    And I am on "Textarea trim test" course homepage
     And I follow "Test textarea trim"
 
     # Test number 1: Student insert a record

--- a/field/time/tests/behat/itemform.feature
+++ b/field/time/tests/behat/itemform.feature
@@ -22,7 +22,7 @@ Feature: test the use of time setup form
       | type  | plugin  |
       | field | boolean |
     And I log in as "teacher1"
-    And I follow "Datetime setup form"
+    And I am on "Datetime setup form" course homepage
     And I follow "Test time setup form"
     And I follow "Layout"
 

--- a/field/time/tests/behat/submit_time.feature
+++ b/field/time/tests/behat/submit_time.feature
@@ -21,7 +21,7 @@ Feature: make a submission test for "time" item
       | activity  | name      | intro                           | course               | idnumber   |
       | surveypro | Time test | To test submission of time item | Time submission test | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Test submission for time item"
+    And I am on "Test submission for time item" course homepage
     And I follow "Time test"
 
     And I set the field "typeplugin" to "Time"
@@ -38,7 +38,7 @@ Feature: make a submission test for "time" item
     And I log out
 
     When I log in as "student1"
-    And I follow "Test submission for time item"
+    And I am on "Test submission for time item" course homepage
     And I follow "Time test"
 
     # student1 submits

--- a/format/fieldset/tests/behat/add_fieldset.feature
+++ b/format/fieldset/tests/behat/add_fieldset.feature
@@ -19,7 +19,7 @@ Feature: verify a fieldset item can be added to a survey
       | activity  | name          | intro                             | course       | idnumber   |
       | surveypro | Fieldset test | To test addition of fieldset item | Add fieldset | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Add fieldset item"
+    And I am on "Add fieldset item" course homepage
     And I follow "Fieldset test"
 
     And I set the field "typeplugin" to "Fieldset"

--- a/format/fieldsetend/tests/behat/add_fieldsetend.feature
+++ b/format/fieldsetend/tests/behat/add_fieldsetend.feature
@@ -19,7 +19,7 @@ Feature: verify a fieldsetend item can be added to a survey
       | activity  | name          | intro                                | course          | idnumber   |
       | surveypro | Fieldset test | To test addition of fieldsetend item | Add fieldsetend | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Add fieldsetend item"
+    And I am on "Add fieldsetend item" course homepage
     And I follow "Fieldset test"
 
     And I set the field "typeplugin" to "Fieldset closure"

--- a/format/label/tests/behat/add_label.feature
+++ b/format/label/tests/behat/add_label.feature
@@ -19,7 +19,7 @@ Feature: verify a label item can be added to a survey
       | activity  | name       | intro                          | course    | idnumber   |
       | surveypro | Label test | To test addition of label item | Add label | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Add label item"
+    And I am on "Add label item" course homepage
     And I follow "Label test"
 
     And I set the field "typeplugin" to "Label"

--- a/format/pagebreak/tests/behat/add_pagebreak.feature
+++ b/format/pagebreak/tests/behat/add_pagebreak.feature
@@ -19,7 +19,7 @@ Feature: verify a pagebreak item can be added to a survey
       | activity  | name           | intro                              | course        | idnumber   |
       | surveypro | Pagebreak test | To test addition of pagebreak item | Add pagebreak | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Add pagebreak item"
+    And I am on "Add pagebreak item" course homepage
     And I follow "Pagebreak test"
 
     And I set the field "typeplugin" to "Page break"

--- a/template/attls/tests/behat/apply_mastertemplate.feature
+++ b/template/attls/tests/behat/apply_mastertemplate.feature
@@ -18,7 +18,7 @@ Feature: apply ATTLS (20 item version) mastertemplate
       | activity  | name           | intro         | course               | idnumber   |
       | surveypro | To apply ATTLS | To test ATTLS | Apply mastertemplate | surveypro1 |
     And I log in as "teacher1"
-    And I follow "To apply mastertemplate"
+    And I am on "To apply mastertemplate" course homepage
 
   @javascript
   Scenario: apply ATTLS (20 item version) master template

--- a/template/collesactual/tests/behat/apply_mastertemplate.feature
+++ b/template/collesactual/tests/behat/apply_mastertemplate.feature
@@ -18,7 +18,7 @@ Feature: apply COLLES (Actual) mastertemplate
       | activity  | name                     | intro                   | course               | idnumber   |
       | surveypro | To apply COLLES (Actual) | To test COLLES (Actual) | Apply mastertemplate | surveypro1 |
     And I log in as "teacher1"
-    And I follow "To apply mastertemplate"
+    And I am on "To apply mastertemplate" course homepage
 
   @javascript
   Scenario: apply COLLES (Actual) master template

--- a/template/collesactual/tests/behat/graphs.feature
+++ b/template/collesactual/tests/behat/graphs.feature
@@ -20,7 +20,7 @@ Feature: apply a COLLES (actual) mastertemplate to test graphs
       | activity  | name              | intro                         | course      | idnumber   |
       | surveypro | Run COLLES report | This is to test COLLES graphs | Test graphs | surveypro1 |
     And I log in as "teacher1"
-    And I follow "To test COLLES graphs"
+    And I am on "To test COLLES graphs" course homepage
 
   @javascript
   Scenario: apply COLLES (Actual) master template, add a record and call reports
@@ -34,7 +34,7 @@ Feature: apply a COLLES (actual) mastertemplate to test graphs
 
     # student1 logs in
     When I log in as "student1"
-    And I follow "To test COLLES graphs"
+    And I am on "To test COLLES graphs" course homepage
     And I follow "Run COLLES report"
     And I press "New response"
 
@@ -75,7 +75,7 @@ Feature: apply a COLLES (actual) mastertemplate to test graphs
     And I log out
 
     When I log in as "teacher1"
-    And I follow "To test COLLES graphs"
+    And I am on "To test COLLES graphs" course homepage
     And I follow "Run COLLES report"
 
     And I navigate to "Summary" node in "Surveypro administration > Report > Colles report"

--- a/template/collesactualpreferred/tests/behat/apply_mastertemplate.feature
+++ b/template/collesactualpreferred/tests/behat/apply_mastertemplate.feature
@@ -18,7 +18,7 @@ Feature: apply COLLES (Preferred and Actual) mastertemplate
       | activity  | name                                   | intro                                 | course               | idnumber   |
       | surveypro | To apply COLLES (Preferred and Actual) | To test COLLES (Preferred and Actual) | Apply mastertemplate | surveypro1 |
     And I log in as "teacher1"
-    And I follow "To apply mastertemplate"
+    And I am on "To apply mastertemplate" course homepage
 
   @javascript
   Scenario: apply COLLES (Preferred and Actual) master template

--- a/template/collesactualpreferred/tests/behat/graphs.feature
+++ b/template/collesactualpreferred/tests/behat/graphs.feature
@@ -20,7 +20,7 @@ Feature: apply a COLLES (actual and preferred) mastertemplate to test graphs
       | activity  | name              | intro                         | course      | idnumber   |
       | surveypro | Run COLLES report | This is to test COLLES graphs | Test graphs | surveypro1 |
     And I log in as "teacher1"
-    And I follow "To test COLLES graphs"
+    And I am on "To test COLLES graphs" course homepage
 
   @javascript
   Scenario: apply COLLES (Preferred and Actual) master template, add a record and call reports
@@ -34,7 +34,7 @@ Feature: apply a COLLES (actual and preferred) mastertemplate to test graphs
 
     # student1 logs in
     When I log in as "student1"
-    And I follow "To test COLLES graphs"
+    And I am on "To test COLLES graphs" course homepage
     And I follow "Run COLLES report"
     And I press "New response"
 
@@ -105,7 +105,7 @@ Feature: apply a COLLES (actual and preferred) mastertemplate to test graphs
     And I log out
 
     When I log in as "teacher1"
-    And I follow "To test COLLES graphs"
+    And I am on "To test COLLES graphs" course homepage
     And I follow "Run COLLES report"
 
     And I navigate to "Summary" node in "Surveypro administration > Report > Colles report"

--- a/template/collespreferred/tests/behat/apply_mastertemplate.feature
+++ b/template/collespreferred/tests/behat/apply_mastertemplate.feature
@@ -18,7 +18,7 @@ Feature: apply COLLES (Preferred) mastertemplate
       | activity  | name                        | intro                      | course               | idnumber   |
       | surveypro | To apply COLLES (Preferred) | To test COLLES (Preferred) | Apply mastertemplate | surveypro1 |
     And I log in as "teacher1"
-    And I follow "To apply mastertemplate"
+    And I am on "To apply mastertemplate" course homepage
 
   @javascript
   Scenario: apply COLLES (Preferred) master template

--- a/template/collespreferred/tests/behat/graphs.feature
+++ b/template/collespreferred/tests/behat/graphs.feature
@@ -20,7 +20,7 @@ Feature: apply a COLLES (preferred) mastertemplate to test graphs
       | activity  | name              | intro                         | course      | idnumber   |
       | surveypro | Run COLLES report | This is to test COLLES graphs | Test graphs | surveypro1 |
     And I log in as "teacher1"
-    And I follow "To test COLLES graphs"
+    And I am on "To test COLLES graphs" course homepage
 
   @javascript
   Scenario: apply COLLES (Preferred) master template, add a record and call reports
@@ -34,7 +34,7 @@ Feature: apply a COLLES (preferred) mastertemplate to test graphs
 
     # student1 logs in
     When I log in as "student1"
-    And I follow "To test COLLES graphs"
+    And I am on "To test COLLES graphs" course homepage
     And I follow "Run COLLES report"
     And I press "New response"
 
@@ -75,7 +75,7 @@ Feature: apply a COLLES (preferred) mastertemplate to test graphs
     And I log out
 
     When I log in as "teacher1"
-    And I follow "To test COLLES graphs"
+    And I am on "To test COLLES graphs" course homepage
     And I follow "Run COLLES report"
 
     And I navigate to "Summary" node in "Surveypro administration > Report > Colles report"

--- a/template/criticalincidents/tests/behat/apply_mastertemplate.feature
+++ b/template/criticalincidents/tests/behat/apply_mastertemplate.feature
@@ -18,7 +18,7 @@ Feature: apply CI mastertemplate
       | activity  | name                        | intro                      | course               | idnumber   |
       | surveypro | To apply Critical Incidents | To test Critical Incidents | Apply mastertemplate | surveypro1 |
     And I log in as "teacher1"
-    And I follow "To apply mastertemplate"
+    And I am on "To apply mastertemplate" course homepage
 
   @javascript
   Scenario: apply Critical Incidents master template

--- a/tests/behat/activity_deletion.feature
+++ b/tests/behat/activity_deletion.feature
@@ -44,7 +44,7 @@ Feature: verify instance deletion
       | field  | time        |
 
     And I log in as "teacher1"
-    And I follow "Activity deletion"
+    And I am on "Test activity deletion" course homepage
     Then I should see "Activity delenda est" in the "#region-main" "css_element"
     And I navigate to "Turn editing on" in current page administration
     And I delete "Activity delenda est" activity

--- a/tests/behat/navigation.feature
+++ b/tests/behat/navigation.feature
@@ -26,7 +26,7 @@ Feature: verify urls really redirect to existing pages
   @javascript
   Scenario: select each available link as a teacher
     Given I log in as "teacher1"
-    And I follow "Test links course"
+    And I am on "Test links course" course homepage
     And I follow "sPro test links"
     #
     # Layout TAB
@@ -152,7 +152,7 @@ Feature: verify urls really redirect to existing pages
   @javascript
   Scenario: select each available link as a student
     Given I log in as "student1"
-    And I follow "Test links course"
+    And I am on "Test links course" course homepage
     And I follow "sPro test links"
     And I follow "Dashboard" page in tab bar
     And I follow "Responses"

--- a/tests/behat/overwrite_mastertemplate.feature
+++ b/tests/behat/overwrite_mastertemplate.feature
@@ -19,7 +19,7 @@ Feature: verify the deletion of old items works as expected during master templa
       | activity  | name                          | intro                                | course                   | idnumber   |
       | surveypro | To overwrite master templates | To test overwrite of master template | Overwrite mastertemplate | surveypro1 |
     And I log in as "teacher1"
-    And I follow "Overwrite mastertemplate"
+    And I am on "Overwrite mastertemplate" course homepage
     And I follow "To overwrite master templates"
 
     And I set the field "mastertemplate" to "ATTLS (20 item version)"

--- a/tests/behat/parent_boolean.feature
+++ b/tests/behat/parent_boolean.feature
@@ -24,7 +24,7 @@ Feature: test the use of boolean as parent item
       | type   | plugin  |
       | field  | boolean |
     And I log in as "teacher1"
-    And I follow "Boolean as parent"
+    And I am on "Boolean as parent" course homepage
     And I follow "Test boolean as parent"
     And I follow "Layout"
 
@@ -43,7 +43,7 @@ Feature: test the use of boolean as parent item
 
     # test the the child item correctly appear or not appear
     When I log in as "student1"
-    And I follow "Boolean as parent"
+    And I am on "Boolean as parent" course homepage
     And I follow "Test boolean as parent"
 
     And I press "New response"
@@ -72,7 +72,7 @@ Feature: test the use of boolean as parent item
     And I log out
 
     And I log in as "teacher1"
-    And I follow "Boolean as parent"
+    And I am on "Boolean as parent" course homepage
     And I follow "Test boolean as parent"
     And I follow "Layout"
     And I follow "edit_item_2"
@@ -84,7 +84,7 @@ Feature: test the use of boolean as parent item
 
     # test the the child item correctly appear or not appear
     When I log in as "student1"
-    And I follow "Boolean as parent"
+    And I am on "Boolean as parent" course homepage
     And I follow "Test boolean as parent"
 
     And I press "New response"
@@ -113,7 +113,7 @@ Feature: test the use of boolean as parent item
     And I log out
 
     And I log in as "teacher1"
-    And I follow "Boolean as parent"
+    And I am on "Boolean as parent" course homepage
     And I follow "Test boolean as parent"
     And I navigate to "Edit settings" node in "Surveypro administration"
     And I expand all fieldsets
@@ -124,7 +124,7 @@ Feature: test the use of boolean as parent item
 
     # test the the child item is correctly enabled or disabled
     When I log in as "student1"
-    And I follow "Boolean as parent"
+    And I am on "Boolean as parent" course homepage
     And I follow "Test boolean as parent"
 
     And I press "New response"
@@ -142,7 +142,7 @@ Feature: test the use of boolean as parent item
     And I log out
 
     And I log in as "teacher1"
-    And I follow "Boolean as parent"
+    And I am on "Boolean as parent" course homepage
     And I follow "Test boolean as parent"
     And I follow "Layout"
     And I follow "edit_item_2"
@@ -154,7 +154,7 @@ Feature: test the use of boolean as parent item
 
     # test the the child item is correctly enabled or disabled
     When I log in as "student1"
-    And I follow "Boolean as parent"
+    And I am on "Boolean as parent" course homepage
     And I follow "Test boolean as parent"
 
     And I press "New response"

--- a/tests/behat/parent_checkbox.feature
+++ b/tests/behat/parent_checkbox.feature
@@ -24,7 +24,7 @@ Feature: test the use of checkbox as parent item
       | type   | plugin   |
       | field  | checkbox |
     And I log in as "teacher1"
-    And I follow "Checkbox as parent"
+    And I am on "Checkbox as parent" course homepage
     And I follow "Test checkbox as parent"
     And I follow "Layout"
 
@@ -43,7 +43,7 @@ Feature: test the use of checkbox as parent item
 
     # test the the child item correctly appear or not appear
     When I log in as "student1"
-    And I follow "Checkbox as parent"
+    And I am on "Checkbox as parent" course homepage
     And I follow "Test checkbox as parent"
 
     And I press "New response"
@@ -145,7 +145,7 @@ Feature: test the use of checkbox as parent item
     And I log out
 
     And I log in as "teacher1"
-    And I follow "Checkbox as parent"
+    And I am on "Checkbox as parent" course homepage
     And I follow "Test checkbox as parent"
     And I follow "Layout"
     And I follow "edit_item_2"
@@ -161,7 +161,7 @@ Feature: test the use of checkbox as parent item
 
     # test the the child item correctly appear or not appear
     When I log in as "student1"
-    And I follow "Checkbox as parent"
+    And I am on "Checkbox as parent" course homepage
     And I follow "Test checkbox as parent"
 
     And I press "New response"
@@ -263,7 +263,7 @@ Feature: test the use of checkbox as parent item
     And I log out
 
     And I log in as "teacher1"
-    And I follow "Checkbox as parent"
+    And I am on "Checkbox as parent" course homepage
     And I follow "Test checkbox as parent"
     And I navigate to "Edit settings" node in "Surveypro administration"
     And I expand all fieldsets
@@ -274,7 +274,7 @@ Feature: test the use of checkbox as parent item
 
     # test the the child item is correctly enabled or disabled
     When I log in as "student1"
-    And I follow "Checkbox as parent"
+    And I am on "Checkbox as parent" course homepage
     And I follow "Test checkbox as parent"
 
     And I press "New response"
@@ -319,7 +319,7 @@ Feature: test the use of checkbox as parent item
     And I log out
 
     And I log in as "teacher1"
-    And I follow "Checkbox as parent"
+    And I am on "Checkbox as parent" course homepage
     And I follow "Test checkbox as parent"
     And I follow "Layout"
     And I follow "edit_item_2"
@@ -331,7 +331,7 @@ Feature: test the use of checkbox as parent item
 
     # test the the child item is correctly enabled or disabled
     When I log in as "student1"
-    And I follow "Checkbox as parent"
+    And I am on "Checkbox as parent" course homepage
     And I follow "Test checkbox as parent"
 
     And I press "New response"

--- a/tests/behat/parent_integer.feature
+++ b/tests/behat/parent_integer.feature
@@ -24,7 +24,7 @@ Feature: test the use of integer as parent item
       | type   | plugin  |
       | field  | integer |
     And I log in as "teacher1"
-    And I follow "Integer as parent"
+    And I am on "Integer as parent" course homepage
     And I follow "Test integer as parent"
     And I follow "Layout"
 
@@ -43,7 +43,7 @@ Feature: test the use of integer as parent item
 
     # test the the child item correctly appear or not appear
     When I log in as "student1"
-    And I follow "Integer as parent"
+    And I am on "Integer as parent" course homepage
     And I follow "Test integer as parent"
 
     And I press "New response"
@@ -78,7 +78,7 @@ Feature: test the use of integer as parent item
     And I log out
 
     And I log in as "teacher1"
-    And I follow "Integer as parent"
+    And I am on "Integer as parent" course homepage
     And I follow "Test integer as parent"
     And I follow "Layout"
     And I follow "edit_item_2"
@@ -90,7 +90,7 @@ Feature: test the use of integer as parent item
 
     # test the the child item correctly appear or not appear
     When I log in as "student1"
-    And I follow "Integer as parent"
+    And I am on "Integer as parent" course homepage
     And I follow "Test integer as parent"
 
     And I press "New response"
@@ -125,7 +125,7 @@ Feature: test the use of integer as parent item
     And I log out
 
     And I log in as "teacher1"
-    And I follow "Integer as parent"
+    And I am on "Integer as parent" course homepage
     And I follow "Test integer as parent"
     And I navigate to "Edit settings" node in "Surveypro administration"
     And I expand all fieldsets
@@ -136,7 +136,7 @@ Feature: test the use of integer as parent item
 
     # test the the child item is correctly enabled or disabled
     When I log in as "student1"
-    And I follow "Integer as parent"
+    And I am on "Integer as parent" course homepage
     And I follow "Test integer as parent"
 
     And I press "New response"
@@ -157,7 +157,7 @@ Feature: test the use of integer as parent item
     And I log out
 
     And I log in as "teacher1"
-    And I follow "Integer as parent"
+    And I am on "Integer as parent" course homepage
     And I follow "Test integer as parent"
     And I follow "Layout"
     And I follow "edit_item_2"
@@ -169,7 +169,7 @@ Feature: test the use of integer as parent item
 
     # test the the child item is correctly enabled or disabled
     When I log in as "student1"
-    And I follow "Integer as parent"
+    And I am on "Integer as parent" course homepage
     And I follow "Test integer as parent"
 
     And I press "New response"

--- a/tests/behat/parent_multiselect.feature
+++ b/tests/behat/parent_multiselect.feature
@@ -24,7 +24,7 @@ Feature: test the use of multiselect as parent item
       | type   | plugin      |
       | field  | multiselect |
     And I log in as "teacher1"
-    And I follow "Multiselect as parent"
+    And I am on "Multiselect as parent" course homepage
     And I follow "Test multiselect as parent"
     And I follow "Layout"
 
@@ -43,7 +43,7 @@ Feature: test the use of multiselect as parent item
 
     # test the the child item correctly appear or not appear
     When I log in as "student1"
-    And I follow "Multiselect as parent"
+    And I am on "Multiselect as parent" course homepage
     And I follow "Test multiselect as parent"
 
     And I press "New response"
@@ -113,7 +113,7 @@ Feature: test the use of multiselect as parent item
     And I log out
 
     And I log in as "teacher1"
-    And I follow "Multiselect as parent"
+    And I am on "Multiselect as parent" course homepage
     And I follow "Test multiselect as parent"
     And I follow "Layout"
     And I follow "edit_item_2"
@@ -129,7 +129,7 @@ Feature: test the use of multiselect as parent item
 
     # test the the child item correctly appear or not appear
     When I log in as "student1"
-    And I follow "Multiselect as parent"
+    And I am on "Multiselect as parent" course homepage
     And I follow "Test multiselect as parent"
 
     And I press "New response"
@@ -199,7 +199,7 @@ Feature: test the use of multiselect as parent item
     And I log out
 
     And I log in as "teacher1"
-    And I follow "Multiselect as parent"
+    And I am on "Multiselect as parent" course homepage
     And I follow "Test multiselect as parent"
     And I navigate to "Edit settings" node in "Surveypro administration"
     And I expand all fieldsets
@@ -210,7 +210,7 @@ Feature: test the use of multiselect as parent item
 
     # test the the child item is correctly enabled or disabled
     When I log in as "student1"
-    And I follow "Multiselect as parent"
+    And I am on "Multiselect as parent" course homepage
     And I follow "Test multiselect as parent"
 
     And I press "New response"
@@ -243,7 +243,7 @@ Feature: test the use of multiselect as parent item
     And I log out
 
     And I log in as "teacher1"
-    And I follow "Multiselect as parent"
+    And I am on "Multiselect as parent" course homepage
     And I follow "Test multiselect as parent"
     And I follow "Layout"
     And I follow "edit_item_2"
@@ -255,7 +255,7 @@ Feature: test the use of multiselect as parent item
 
     # test the the child item is correctly enabled or disabled
     When I log in as "student1"
-    And I follow "Multiselect as parent"
+    And I am on "Multiselect as parent" course homepage
     And I follow "Test multiselect as parent"
 
     And I press "New response"

--- a/tests/behat/parent_radiobutton.feature
+++ b/tests/behat/parent_radiobutton.feature
@@ -24,7 +24,7 @@ Feature: test the use of radiobutton as parent item
       | type   | plugin      |
       | field  | radiobutton |
     And I log in as "teacher1"
-    And I follow "Radiobutton as parent"
+    And I am on "Radiobutton as parent" course homepage
     And I follow "Test radiobutton as parent"
     And I follow "Layout"
 
@@ -43,7 +43,7 @@ Feature: test the use of radiobutton as parent item
 
     # test the the child item correctly appear or not appear
     When I log in as "student1"
-    And I follow "Radiobutton as parent"
+    And I am on "Radiobutton as parent" course homepage
     And I follow "Test radiobutton as parent"
 
     And I press "New response"
@@ -78,7 +78,7 @@ Feature: test the use of radiobutton as parent item
     And I log out
 
     And I log in as "teacher1"
-    And I follow "Radiobutton as parent"
+    And I am on "Radiobutton as parent" course homepage
     And I follow "Test radiobutton as parent"
     And I follow "Layout"
     And I follow "edit_item_2"
@@ -90,7 +90,7 @@ Feature: test the use of radiobutton as parent item
 
     # test the the child item correctly appear or not appear
     When I log in as "student1"
-    And I follow "Radiobutton as parent"
+    And I am on "Radiobutton as parent" course homepage
     And I follow "Test radiobutton as parent"
 
     And I press "New response"
@@ -125,7 +125,7 @@ Feature: test the use of radiobutton as parent item
     And I log out
 
     And I log in as "teacher1"
-    And I follow "Radiobutton as parent"
+    And I am on "Radiobutton as parent" course homepage
     And I follow "Test radiobutton as parent"
     And I navigate to "Edit settings" node in "Surveypro administration"
     And I expand all fieldsets
@@ -136,7 +136,7 @@ Feature: test the use of radiobutton as parent item
 
     # test the the child item is correctly enabled or disabled
     When I log in as "student1"
-    And I follow "Radiobutton as parent"
+    And I am on "Radiobutton as parent" course homepage
     And I follow "Test radiobutton as parent"
 
     And I press "New response"
@@ -157,7 +157,7 @@ Feature: test the use of radiobutton as parent item
     And I log out
 
     And I log in as "teacher1"
-    And I follow "Radiobutton as parent"
+    And I am on "Radiobutton as parent" course homepage
     And I follow "Test radiobutton as parent"
     And I follow "Layout"
     And I follow "edit_item_2"
@@ -169,7 +169,7 @@ Feature: test the use of radiobutton as parent item
 
     # test the the child item is correctly enabled or disabled
     When I log in as "student1"
-    And I follow "Radiobutton as parent"
+    And I am on "Radiobutton as parent" course homepage
     And I follow "Test radiobutton as parent"
 
     And I press "New response"

--- a/tests/behat/parent_select.feature
+++ b/tests/behat/parent_select.feature
@@ -24,7 +24,7 @@ Feature: test the use of select as parent item
       | type   | plugin |
       | field  | select |
     And I log in as "teacher1"
-    And I follow "Select as parent"
+    And I am on "Select as parent" course homepage
     And I follow "Test select as parent"
     And I follow "Layout"
 
@@ -43,7 +43,7 @@ Feature: test the use of select as parent item
 
     # test the the child item correctly appear or not appear
     When I log in as "student1"
-    And I follow "Select as parent"
+    And I am on "Select as parent" course homepage
     And I follow "Test select as parent"
 
     And I press "New response"
@@ -72,7 +72,7 @@ Feature: test the use of select as parent item
     And I log out
 
     And I log in as "teacher1"
-    And I follow "Select as parent"
+    And I am on "Select as parent" course homepage
     And I follow "Test select as parent"
     And I follow "Layout"
     And I follow "edit_item_2"
@@ -84,7 +84,7 @@ Feature: test the use of select as parent item
 
     # test the the child item correctly appear or not appear
     When I log in as "student1"
-    And I follow "Select as parent"
+    And I am on "Select as parent" course homepage
     And I follow "Test select as parent"
 
     And I press "New response"
@@ -113,7 +113,7 @@ Feature: test the use of select as parent item
     And I log out
 
     And I log in as "teacher1"
-    And I follow "Select as parent"
+    And I am on "Select as parent" course homepage
     And I follow "Test select as parent"
     And I navigate to "Edit settings" node in "Surveypro administration"
     And I expand all fieldsets
@@ -124,7 +124,7 @@ Feature: test the use of select as parent item
 
     # test the the child item is correctly enabled or disabled
     When I log in as "student1"
-    And I follow "Select as parent"
+    And I am on "Select as parent" course homepage
     And I follow "Test select as parent"
 
     And I press "New response"
@@ -143,7 +143,7 @@ Feature: test the use of select as parent item
     And I log out
 
     And I log in as "teacher1"
-    And I follow "Select as parent"
+    And I am on "Select as parent" course homepage
     And I follow "Test select as parent"
     And I follow "Layout"
     And I follow "edit_item_2"
@@ -155,7 +155,7 @@ Feature: test the use of select as parent item
 
     # test the the child item is correctly enabled or disabled
     When I log in as "student1"
-    And I follow "Select as parent"
+    And I am on "Select as parent" course homepage
     And I follow "Test select as parent"
 
     And I press "New response"

--- a/tests/behat/preserve_autofillpersonaldata.feature
+++ b/tests/behat/preserve_autofillpersonaldata.feature
@@ -37,7 +37,7 @@ Feature: editing a submission, autofill userID is not overwritten
       | surveypro | Preserve autofill | Test that editing a submission, autofill userID is not overwritten | Course grouped | surveypro1 | Separate groups |
 
     And I log in as "teacher1"
-    And I follow "Course divided into groups"
+    And I am on "Course divided into groups" course homepage
     And I follow "Preserve autofill"
 
     And I set the field "typeplugin" to "Autofill"
@@ -90,7 +90,7 @@ Feature: editing a submission, autofill userID is not overwritten
 
     # student1 logs in
     When I log in as "student1"
-    And I follow "Course divided into groups"
+    And I am on "Course divided into groups" course homepage
     And I follow "Preserve autofill"
 
     And I press "New response"
@@ -109,7 +109,7 @@ Feature: editing a submission, autofill userID is not overwritten
 
     # student2 logs in
     When I log in as "student2"
-    And I follow "Course divided into groups"
+    And I am on "Course divided into groups" course homepage
     And I follow "Preserve autofill"
 
     And I follow "Responses"
@@ -125,7 +125,7 @@ Feature: editing a submission, autofill userID is not overwritten
 
     # student1 logs in
     When I log in as "student1"
-    And I follow "Course divided into groups"
+    And I am on "Course divided into groups" course homepage
     And I follow "Preserve autofill"
 
     And I follow "Responses"
@@ -138,7 +138,7 @@ Feature: editing a submission, autofill userID is not overwritten
 
     # teacher1 logs in
     When I log in as "teacher1"
-    And I follow "Course divided into groups"
+    And I am on "Course divided into groups" course homepage
     And I follow "Preserve autofill"
 
     And I follow "edit_submission_row_1"
@@ -152,7 +152,7 @@ Feature: editing a submission, autofill userID is not overwritten
 
     # student1 logs in
     When I log in as "student1"
-    And I follow "Course divided into groups"
+    And I am on "Course divided into groups" course homepage
     And I follow "Preserve autofill"
 
     And I follow "Responses"

--- a/tests/behat/see_onlygroupsubmissions.feature
+++ b/tests/behat/see_onlygroupsubmissions.feature
@@ -35,7 +35,7 @@ Feature: test students can see submissions from their groups only
       | student3 | G2    |
 
     And I log in as "teacher1"
-    And I follow "Course divided into groups"
+    And I am on "Course divided into groups" course homepage
     And I turn editing mode on
     And I add a "Surveypro" to section "1" and I fill the form with:
       | Name        | Get only my group submission                                  |
@@ -73,7 +73,7 @@ Feature: test students can see submissions from their groups only
 
     # student1 logs in
     When I log in as "student1"
-    And I follow "Course divided into groups"
+    And I am on "Course divided into groups" course homepage
     And I follow "Get only my group submission"
 
     And I follow "Responses"
@@ -102,7 +102,7 @@ Feature: test students can see submissions from their groups only
 
     # student2 logs in
     When I log in as "student2"
-    And I follow "Course divided into groups"
+    And I am on "Course divided into groups" course homepage
     And I follow "Get only my group submission"
 
     And I follow "Responses"
@@ -126,7 +126,7 @@ Feature: test students can see submissions from their groups only
 
     # student3 logs in
     When I log in as "student3"
-    And I follow "Course divided into groups"
+    And I am on "Course divided into groups" course homepage
     And I follow "Get only my group submission"
 
     And I follow "Responses"
@@ -150,7 +150,7 @@ Feature: test students can see submissions from their groups only
 
     # student1 goes to check for his personal submissions
     When I log in as "student1"
-    And I follow "Course divided into groups"
+    And I am on "Course divided into groups" course homepage
     And I follow "Get only my group submission"
 
     And I follow "Responses"

--- a/tests/behat/see_onlypersonalsubmissions.feature
+++ b/tests/behat/see_onlypersonalsubmissions.feature
@@ -23,7 +23,7 @@ Feature: test each student sees only personal submissions
       | activity  | name                        | intro                                                  | course                    | idnumber   |
       | surveypro | Get only my own submissions | Test each student can only see his/her own submissions | Only personal submissions | surveypro1 |
     And I log in as "teacher1"
-    And I follow "See only personal submissions"
+    And I am on "See only personal submissions" course homepage
     And I follow "Get only my own submissions"
 
     And I set the field "typeplugin" to "Text (short)"
@@ -56,7 +56,7 @@ Feature: test each student sees only personal submissions
 
     # student1 logs in
     When I log in as "student1"
-    And I follow "See only personal submissions"
+    And I am on "See only personal submissions" course homepage
     And I follow "Get only my own submissions"
     And I press "New response"
 
@@ -78,7 +78,7 @@ Feature: test each student sees only personal submissions
 
     # student2 logs in
     When I log in as "student2"
-    And I follow "See only personal submissions"
+    And I am on "See only personal submissions" course homepage
     And I follow "Get only my own submissions"
     And I follow "Responses"
     Then I should see "Nothing to display"
@@ -99,7 +99,7 @@ Feature: test each student sees only personal submissions
 
     # student1 goes to check for his personal submissions
     When I log in as "student1"
-    And I follow "See only personal submissions"
+    And I am on "See only personal submissions" course homepage
     And I follow "Get only my own submissions"
 
     And I follow "Responses"

--- a/tests/behat/submission_test.feature
+++ b/tests/behat/submission_test.feature
@@ -49,7 +49,7 @@ Feature: make a submission test for each available item
       | field  | time        |
       | format | label       |
     And I log in as "teacher1"
-    And I follow "Test submission for each available item"
+    And I am on "Test submission for each available item" course homepage
     And I follow "Each item submission"
     And I follow "Layout"
     And I follow "Preview"
@@ -60,7 +60,7 @@ Feature: make a submission test for each available item
 
     # student1 logs in
     When I log in as "student1"
-    And I follow "Test submission for each available item"
+    And I am on "Test submission for each available item" course homepage
     And I follow "Each item submission"
     And I press "New response"
 

--- a/tests/behat/submission_test.feature
+++ b/tests/behat/submission_test.feature
@@ -125,7 +125,7 @@ Feature: make a submission test for each available item
 
     When I log in as "teacher1"
 
-    And I follow "Test submission for each available item"
+    And I am on "Test submission for each available item" course homepage
     And I follow "Each item submission"
     And I follow "edit_submission_row_1"
     And I press "Next page >>"

--- a/tests/behat/thankspage.feature
+++ b/tests/behat/thankspage.feature
@@ -72,14 +72,12 @@ Feature: test the use of boolean setup form
   @javascript
   Scenario: test the thanks page with images
     When I log in as "teacher1"
-    And I am on "Manage private files" course homepage
+    And I follow "Manage private files"
     # And I upload "mod/lesson/tests/fixtures/moodle_logo.jpg" file to "Files" filemanager
     And I upload "mod/surveypro/tests/fixtures/thankyou.png" file to "Files" filemanager
     And I click on "Save changes" "button"
 
-    When I am on homepage
-
-    And I follow "Thank you"
+    And I am on "Thank you" course homepage
     And I follow "Thanks surveypro"
 
     And I navigate to "Edit settings" node in "Surveypro administration"

--- a/tests/behat/thankspage.feature
+++ b/tests/behat/thankspage.feature
@@ -29,7 +29,7 @@ Feature: test the use of boolean setup form
   @javascript
   Scenario: test the empty thanks page
     When I log in as "teacher1"
-    And I follow "Thank you"
+    And I am on "Thank you" course homepage
     And I follow "Thanks surveypro"
     And I navigate to "Edit settings" node in "Surveypro administration"
     And I expand all fieldsets
@@ -39,7 +39,7 @@ Feature: test the use of boolean setup form
 
     # student1 logs in
     When I log in as "student1"
-    And I follow "Thank you"
+    And I am on "Thank you" course homepage
     And I follow "Thanks surveypro"
     And I press "New response"
     And I set the field "Is this true?" to "Yes"
@@ -56,7 +56,7 @@ Feature: test the use of boolean setup form
   Scenario: test the thanks page with plain text
     # student1 logs in
     When I log in as "student1"
-    And I follow "Thank you"
+    And I am on "Thank you" course homepage
     And I follow "Thanks surveypro"
     And I press "New response"
     And I set the field "Is this true?" to "Yes"
@@ -72,7 +72,7 @@ Feature: test the use of boolean setup form
   @javascript
   Scenario: test the thanks page with images
     When I log in as "teacher1"
-    And I follow "Manage private files"
+    And I am on "Manage private files" course homepage
     # And I upload "mod/lesson/tests/fixtures/moodle_logo.jpg" file to "Files" filemanager
     And I upload "mod/surveypro/tests/fixtures/thankyou.png" file to "Files" filemanager
     And I click on "Save changes" "button"
@@ -99,7 +99,7 @@ Feature: test the use of boolean setup form
 
     # student1 logs in
     When I log in as "student1"
-    And I follow "Thank you"
+    And I am on "Thank you" course homepage
     And I follow "Thanks surveypro"
     And I press "New response"
     And I set the field "Is this true?" to "Yes"

--- a/tests/behat/usertemplate_apply.feature
+++ b/tests/behat/usertemplate_apply.feature
@@ -19,7 +19,7 @@ Feature: Load and apply usertemplates in order to test, among others, partial it
       | activity  | name                 | intro                             | course             | idnumber   |
       | surveypro | Apply a usertemplate | Surveypro to apply a usertemplate | Apply usertemplate | surveypro1 |
     And I log in as "teacher1"
-    And I follow "To apply usertemplate"
+    And I am on "To apply usertemplate" course homepage
     And I follow "Apply a usertemplate"
 
     And I navigate to "Import" node in "Surveypro administration > User templates"

--- a/tests/behat/usertemplate_apply.feature
+++ b/tests/behat/usertemplate_apply.feature
@@ -31,6 +31,7 @@ Feature: Load and apply usertemplates in order to test, among others, partial it
 
     # now I am in the "Manage" page
     And I navigate to "Apply" node in "Surveypro administration > User templates"
+    And I pause
 
     # now I am in the "Apply" page
     And I set the following fields to these values:

--- a/tests/behat/usertemplate_applyall.feature
+++ b/tests/behat/usertemplate_applyall.feature
@@ -19,7 +19,7 @@ Feature: Load and apply usertemplates in order to test if they apply correctly
       | activity  | name      | intro                                | course                  | idnumber   |
       | surveypro | Apply all | Surveypro to apply all usertemplates | Apply each usertemplate | surveypro1 |
     And I log in as "teacher1"
-    And I follow "To apply all usertemplates"
+    And I am on "To apply all usertemplates" course homepage
     And I follow "Apply all"
 
     And I navigate to "Import" node in "Surveypro administration > User templates"

--- a/tests/behat/usertemplate_create.feature
+++ b/tests/behat/usertemplate_create.feature
@@ -19,7 +19,7 @@ Feature: Load, apply and save a usertemplate in order to test, among others, use
       | activity  | name                  | intro                              | course              | idnumber   |
       | surveypro | Create a usertemplate | Surveypro to cretae a usertemplate | Create usertemplate | surveypro1 |
     And I log in as "teacher1"
-    And I follow "To create usertemplate"
+    And I am on "To create usertemplate" course homepage
     And I follow "Create a usertemplate"
 
     And I navigate to "Import" node in "Surveypro administration > User templates"


### PR DESCRIPTION
This just makes the behat tests to work with the new default page after login (dashboard) in Moodle 3.3 and up.

Still there are a few error under clean, see https://pastebin.com/hzySczpt , basically:

- a missing lang string (a number of times).
- problems validating uploaded xml templates, there is something that does not match.
- and other 2 issues.

I've not solved it because they seem legit and surely require changes in code, not in tests.

Also, note that, under boost, there are still LOTs of tests. The changes in this PR are just to solve the initial navigation to course that was making all tests to fail.