### PR TITLE
NOBUG mod_surveypro: fixed bad multiselect xml

### DIFF
--- a/tests/fixtures/usertemplate/MMM_2015123000.xml
+++ b/tests/fixtures/usertemplate/MMM_2015123000.xml
@@ -612,6 +612,7 @@ jam
 chocolate</options>
       <defaultvalue>jam
 chocolate</defaultvalue>
+      <noanswerdefault>0</noanswerdefault>
       <downloadformat>0</downloadformat>
       <minimumrequired>0</minimumrequired>
       <heightinrows>4</heightinrows>

--- a/tests/fixtures/usertemplate/parent-child_2015123000.xml
+++ b/tests/fixtures/usertemplate/parent-child_2015123000.xml
@@ -297,6 +297,7 @@ h::ham
 t::tomatoes</options>
       <defaultvalue>milk
 ham</defaultvalue>
+      <noanswerdefault>0</noanswerdefault>
       <downloadformat>0</downloadformat>
       <minimumrequired>0</minimumrequired>
       <heightinrows>4</heightinrows>


### PR DESCRIPTION
Modified xml for multiselect elements in order to fix 

```javascript019 Scenario: load and save a usertemplate            # /Users/stronk7/git_moodle/survey/mod/surveypro/tests/behat/usertemplate_create.feature:8
      And I set the following fields to these values: # /Users/stronk7/git_moodle/survey/mod/surveypro/tests/behat/usertemplate_create.feature:36
        Select option with value|text "(Course) MMM_2015123000.xml" not found. (Behat\Mink\Exception\ElementNotFoundException)```