### PR TITLE
NOBUG mod_surveypro: multiselect as parent fixes

### DIFF
--- a/field/boolean/classes/field.php
+++ b/field/boolean/classes/field.php
@@ -365,9 +365,9 @@ EOS;
 
     /**
      * I can not make ANY assumption about $childparentvalue because of the following explanation:
-     * At child save time, I encode its $parentcontent to $parentvalue
-     * The encoding is done through a parent method according to parent values
-     * Once the child is saved, I can return to parent and I can change it as much as I want
+     * At child save time, I encode its $parentcontent to $parentvalue.
+     * The encoding is done through a parent method according to parent values.
+     * Once the child is saved, I can return to parent and I can change it as much as I want.
      * For instance by changing the number and the content of its options
      * At parent save time, the child parentvalue is rewritten
      * -> but it may result in a too short or too long list of keys

--- a/field/checkbox/classes/field.php
+++ b/field/checkbox/classes/field.php
@@ -431,9 +431,9 @@ EOS;
 
     /**
      * I can not make ANY assumption about $childparentvalue because of the following explanation:
-     * At child save time, I encode its $parentcontent to $parentvalue
-     * The encoding is done through a parent method according to parent values
-     * Once the child is saved, I can return to parent and I can change it as much as I want
+     * At child save time, I encode its $parentcontent to $parentvalue.
+     * The encoding is done through a parent method according to parent values.
+     * Once the child is saved, I can return to parent and I can change it as much as I want.
      * For instance by changing the number and the content of its options
      * At parent save time, the child parentvalue is rewritten
      * -> but it may result in a too short or too long list of keys
@@ -464,7 +464,7 @@ EOS;
             }
 
             $key++;
-            // Only garbage after the first index, but user wrote it.
+            // Only garbage after the first label, but user wrote it.
             for ($i = $key; $i < $actualcount; $i++) {
                 $childparentcontent[] = $parentvalues[$i];
             }

--- a/field/integer/classes/field.php
+++ b/field/integer/classes/field.php
@@ -344,9 +344,9 @@ EOS;
 
     /**
      * I can not make ANY assumption about $childparentvalue because of the following explanation:
-     * At child save time, I encode its $parentcontent to $parentvalue
-     * The encoding is done through a parent method according to parent values
-     * Once the child is saved, I can return to parent and I can change it as much as I want
+     * At child save time, I encode its $parentcontent to $parentvalue.
+     * The encoding is done through a parent method according to parent values.
+     * Once the child is saved, I can return to parent and I can change it as much as I want.
      * For instance by changing the number and the content of its options
      * At parent save time, the child parentvalue is rewritten
      * -> but it may result in a too short or too long list of keys

--- a/field/radiobutton/classes/field.php
+++ b/field/radiobutton/classes/field.php
@@ -388,9 +388,9 @@ EOS;
 
     /**
      * I can not make ANY assumption about $childparentvalue because of the following explanation:
-     * At child save time, I encode its $parentcontent to $parentvalue
-     * The encoding is done through a parent method according to parent values
-     * Once the child is saved, I can return to parent and I can change it as much as I want
+     * At child save time, I encode its $parentcontent to $parentvalue.
+     * The encoding is done through a parent method according to parent values.
+     * Once the child is saved, I can return to parent and I can change it as much as I want.
      * For instance by changing the number and the content of its options
      * At parent save time, the child parentvalue is rewritten
      * -> but it may result in a too short or too long list of keys

--- a/field/select/classes/field.php
+++ b/field/select/classes/field.php
@@ -381,9 +381,9 @@ EOS;
 
     /**
      * I can not make ANY assumption about $childparentvalue because of the following explanation:
-     * At child save time, I encode its $parentcontent to $parentvalue
-     * The encoding is done through a parent method according to parent values
-     * Once the child is saved, I can return to parent and I can change it as much as I want
+     * At child save time, I encode its $parentcontent to $parentvalue.
+     * The encoding is done through a parent method according to parent values.
+     * Once the child is saved, I can return to parent and I can change it as much as I want.
      * For instance by changing the number and the content of its options
      * At parent save time, the child parentvalue is rewritten
      * -> but it may result in a too short or too long list of keys

--- a/tests/behat/parent_multiselect.feature
+++ b/tests/behat/parent_multiselect.feature
@@ -60,6 +60,14 @@ Feature: test the use of multiselect as parent item
     And I press "<< Previous page"
     Then the field "id_surveypro_field_multiselect_1" matches value "milk"
     Then the field "id_surveypro_field_multiselect_1_noanswer" matches value "0"
+    And I set the field "id_surveypro_field_multiselect_1_noanswer" to "1"
+    And I press "Next page >>"
+    Then I should see "On the basis of the answers provided, no more elements remain to display."
+
+    And I press "<< Previous page"
+    Then the field "id_surveypro_field_multiselect_1" matches value ""
+    Then the field "id_surveypro_field_multiselect_1_noanswer" matches value "1"
+    And I set the field "id_surveypro_field_multiselect_1_noanswer" to "0"
     And I set the field "id_surveypro_field_multiselect_1" to "sugar"
     And I press "Next page >>"
     Then I should see "On the basis of the answers provided, no more elements remain to display."
@@ -67,12 +75,12 @@ Feature: test the use of multiselect as parent item
     And I press "<< Previous page"
     Then the field "id_surveypro_field_multiselect_1" matches value "sugar"
     Then the field "id_surveypro_field_multiselect_1_noanswer" matches value "0"
-    And I set the field "id_surveypro_field_multiselect_1" to "jam"
+    And I set the field "id_surveypro_field_multiselect_1" to "chocolate"
     And I press "Next page >>"
     Then I should see "On the basis of the answers provided, no more elements remain to display."
 
     And I press "<< Previous page"
-    Then the field "id_surveypro_field_multiselect_1" matches value "jam"
+    Then the field "id_surveypro_field_multiselect_1" matches value "chocolate"
     Then the field "id_surveypro_field_multiselect_1_noanswer" matches value "0"
     And I set the field "id_surveypro_field_multiselect_1" to "milk, sugar"
     And I press "Next page >>"
@@ -101,6 +109,13 @@ Feature: test the use of multiselect as parent item
 
     And I press "<< Previous page"
     Then the field "id_surveypro_field_multiselect_1" matches value "milk, sugar, jam"
+    Then the field "id_surveypro_field_multiselect_1_noanswer" matches value "0"
+    And I set the field "id_surveypro_field_multiselect_1" to "milk, sugar, jam, chocolate"
+    And I press "Next page >>"
+    Then I should see "On the basis of the answers provided, no more elements remain to display."
+
+    And I press "<< Previous page"
+    Then the field "id_surveypro_field_multiselect_1" matches value "milk, sugar, jam, chocolate"
     Then the field "id_surveypro_field_multiselect_1_noanswer" matches value "0"
     And I set the field "id_surveypro_field_multiselect_1_noanswer" to "1"
     And I press "Next page >>"
@@ -153,13 +168,6 @@ Feature: test the use of multiselect as parent item
     And I press "<< Previous page"
     Then the field "id_surveypro_field_multiselect_1" matches value "sugar"
     Then the field "id_surveypro_field_multiselect_1_noanswer" matches value "0"
-    And I set the field "id_surveypro_field_multiselect_1" to "jam"
-    And I press "Next page >>"
-    Then I should see "On the basis of the answers provided, no more elements remain to display."
-
-    And I press "<< Previous page"
-    Then the field "id_surveypro_field_multiselect_1" matches value "jam"
-    Then the field "id_surveypro_field_multiselect_1_noanswer" matches value "0"
     And I set the field "id_surveypro_field_multiselect_1" to "milk, sugar"
     And I press "Next page >>"
     Then I should see "On the basis of the answers provided, no more elements remain to display."
@@ -181,12 +189,27 @@ Feature: test the use of multiselect as parent item
     And I press "<< Previous page"
     Then the field "id_surveypro_field_multiselect_1" matches value "milk, chocolate"
     Then the field "id_surveypro_field_multiselect_1_noanswer" matches value "0"
+    And I set the field "id_surveypro_field_multiselect_1_noanswer" to "1"
+    And I press "Next page >>"
+    Then I should see "On the basis of the answers provided, no more elements remain to display."
+
+    And I press "<< Previous page"
+    Then the field "id_surveypro_field_multiselect_1" matches value ""
+    Then the field "id_surveypro_field_multiselect_1_noanswer" matches value "1"
+    And I set the field "id_surveypro_field_multiselect_1_noanswer" to "0"
     And I set the field "id_surveypro_field_multiselect_1" to "milk, sugar, jam"
     And I press "Next page >>"
     Then I should see "On the basis of the answers provided, no more elements remain to display."
 
     And I press "<< Previous page"
     Then the field "id_surveypro_field_multiselect_1" matches value "milk, sugar, jam"
+    Then the field "id_surveypro_field_multiselect_1_noanswer" matches value "0"
+    And I set the field "id_surveypro_field_multiselect_1" to "milk, sugar, jam, chocolate"
+    And I press "Next page >>"
+    Then I should see "On the basis of the answers provided, no more elements remain to display."
+
+    And I press "<< Previous page"
+    Then the field "id_surveypro_field_multiselect_1" matches value "milk, sugar, jam, chocolate"
     Then the field "id_surveypro_field_multiselect_1_noanswer" matches value "0"
     And I set the field "id_surveypro_field_multiselect_1_noanswer" to "1"
     And I press "Next page >>"
@@ -234,7 +257,14 @@ Feature: test the use of multiselect as parent item
     And I set the field "id_surveypro_field_multiselect_1" to "milk, chocolate"
     Then the "Write down your name" "field" should be enabled
 
+    And I set the field "id_surveypro_field_multiselect_1_noanswer" to "1"
+    Then the "Write down your name" "field" should be disabled
+
+    And I set the field "id_surveypro_field_multiselect_1_noanswer" to "0"
     And I set the field "id_surveypro_field_multiselect_1" to "milk, sugar, jam"
+    Then the "Write down your name" "field" should be disabled
+
+    And I set the field "id_surveypro_field_multiselect_1" to "milk, sugar, jam, chocolate"
     Then the "Write down your name" "field" should be disabled
 
     And I set the field "id_surveypro_field_multiselect_1_noanswer" to "1"
@@ -264,6 +294,10 @@ Feature: test the use of multiselect as parent item
     And I set the field "id_surveypro_field_multiselect_1" to "milk"
     Then the "Write down your name" "field" should be enabled
 
+    And I set the field "id_surveypro_field_multiselect_1_noanswer" to "1"
+    Then the "Write down your name" "field" should be disabled
+
+    And I set the field "id_surveypro_field_multiselect_1_noanswer" to "0"
     And I set the field "id_surveypro_field_multiselect_1" to "sugar"
     Then the "Write down your name" "field" should be disabled
 
@@ -277,6 +311,9 @@ Feature: test the use of multiselect as parent item
     Then the "Write down your name" "field" should be disabled
 
     And I set the field "id_surveypro_field_multiselect_1" to "milk, sugar, jam"
+    Then the "Write down your name" "field" should be disabled
+
+    And I set the field "id_surveypro_field_multiselect_1" to "milk, sugar, jam, chocolate"
     Then the "Write down your name" "field" should be disabled
 
     And I set the field "id_surveypro_field_multiselect_1_noanswer" to "1"


### PR DESCRIPTION
Few comments about this PR:
1) relevant changes are only in field/multiselect/classes/field.php
2) the fix comes from 
```script
001 Scenario: test multiselect as parent                                           # /Applications/MAMP/htdocs/head/mod/surveypro/tests/behat/parent_multiselect.feature:8
      Then the field "id_surveypro_field_multiselect_1_noanswer" matches value "0" # /Applications/MAMP/htdocs/head/mod/surveypro/tests/behat/parent_multiselect.feature:55
        The 'id_surveypro_field_multiselect_1_noanswer' value is '1', '0' expected (Behat\Mink\Exception\ExpectationException)
```
3) the issue was in the missing code to save multiselect settings, in the wrong encode/decode child parentvalue and in the wrong function userform_mform_validation($data, &$errors, $searchform)