### PR TITLE
NOBUG mod_surveypro: added click on div

### DIFF
--- a/report/colles/classes/report.php
+++ b/report/colles/classes/report.php
@@ -554,7 +554,12 @@ class surveyproreport_colles_report extends mod_surveypro_reportbase {
     public function output_questionsdata($area) {
         $paramnexturl = array();
         $paramnexturl['s'] = $this->surveypro->id;
-        $paramnexturl['type'] = 'summary';
+        if ($area == 5) {
+            $paramnexturl['type'] = 'summary';
+        } else {
+            $paramnexturl['type'] = 'questions';
+            $paramnexturl['area'] = 1 + $area%5;
+        }
         $nexturl = new moodle_url('/mod/surveypro/report/colles/view.php', $paramnexturl);
 
         $paramurl = array();

--- a/template/collesactual/tests/behat/graphs.feature
+++ b/template/collesactual/tests/behat/graphs.feature
@@ -79,25 +79,73 @@ Feature: apply a COLLES (actual) mastertemplate to test graphs
     And I follow "Run COLLES report"
 
     And I navigate to "Summary" node in "Surveypro administration > Report > Colles report"
+    # now I should be in front of "Colles report > Summary"
     Then I should not see "Summary report"
 
-    And I navigate to "Scales" node in "Surveypro administration > Report > Colles report"
+    And I click on "div.centerpara a" "css_element"
+    # now I should be in front of "Colles report > Scales"
     Then I should not see "Scales report"
 
+    And I click on "div.centerpara a" "css_element"
+    # now I should be in front of "Colles report > Questions > Relevance"
+    Then I should not see "Questions report"
+
+    And I click on "div.centerpara a" "css_element"
+    # now I should be in front of "Colles report > Questions > Reflective thinking"
+    Then I should not see "Questions report"
+
+    And I click on "div.centerpara a" "css_element"
+    # now I should be in front of "Colles report > Questions > Interactivity"
+    Then I should not see "Questions report"
+
+    And I click on "div.centerpara a" "css_element"
+    # now I should be in front of "Colles report > Questions > Tutor support"
+    Then I should not see "Questions report"
+
+    And I click on "div.centerpara a" "css_element"
+    # now I should be in front of "Colles report > Questions > Peer support"
+    Then I should not see "Questions report"
+
+    And I click on "div.centerpara a" "css_element"
+    # now I should be in front of "Colles report > Questions > Interpretation"
+    Then I should not see "Questions report"
+
+    And I click on "div.centerpara a" "css_element"
+    Then I should not see "Summary report"
+
+    # now test links provided by Admin menu
+
+    And I follow "Run COLLES report"
+    And I navigate to "Scales" node in "Surveypro administration > Report > Colles report"
+    # now I should be in front of "Colles report > Scales"
+    Then I should not see "Scales report"
+
+    And I follow "Run COLLES report"
     And I navigate to "Relevance" node in "Surveypro administration > Report > Colles report > Questions"
+    # now I should be in front of "Colles report > Questions > Relevance"
     Then I should not see "Questions report"
 
+    And I follow "Run COLLES report"
     And I navigate to "Reflective thinking" node in "Surveypro administration > Report > Colles report > Questions"
+    # now I should be in front of "Colles report > Questions > Reflective thinking"
     Then I should not see "Questions report"
 
+    And I follow "Run COLLES report"
     And I navigate to "Interactivity" node in "Surveypro administration > Report > Colles report > Questions"
+    # now I should be in front of "Colles report > Questions > Interactivity"
     Then I should not see "Questions report"
 
+    And I follow "Run COLLES report"
     And I navigate to "Tutor support" node in "Surveypro administration > Report > Colles report > Questions"
+    # now I should be in front of "Colles report > Questions > Tutor support"
     Then I should not see "Questions report"
 
+    And I follow "Run COLLES report"
     And I navigate to "Peer support" node in "Surveypro administration > Report > Colles report > Questions"
+    # now I should be in front of "Colles report > Questions > Peer support"
     Then I should not see "Questions report"
 
+    And I follow "Run COLLES report"
     And I navigate to "Interpretation" node in "Surveypro administration > Report > Colles report > Questions"
+    # now I should be in front of "Colles report > Questions > Interpretation"
     Then I should not see "Questions report"

--- a/template/collesactualpreferred/tests/behat/graphs.feature
+++ b/template/collesactualpreferred/tests/behat/graphs.feature
@@ -109,25 +109,73 @@ Feature: apply a COLLES (actual and preferred) mastertemplate to test graphs
     And I follow "Run COLLES report"
 
     And I navigate to "Summary" node in "Surveypro administration > Report > Colles report"
+    # now I should be in front of "Colles report > Summary"
     Then I should not see "Summary report"
 
-    And I navigate to "Scales" node in "Surveypro administration > Report > Colles report"
+    And I click on "div.centerpara a" "css_element"
+    # now I should be in front of "Colles report > Scales"
     Then I should not see "Scales report"
 
+    And I click on "div.centerpara a" "css_element"
+    # now I should be in front of "Colles report > Questions > Relevance"
+    Then I should not see "Questions report"
+
+    And I click on "div.centerpara a" "css_element"
+    # now I should be in front of "Colles report > Questions > Reflective thinking"
+    Then I should not see "Questions report"
+
+    And I click on "div.centerpara a" "css_element"
+    # now I should be in front of "Colles report > Questions > Interactivity"
+    Then I should not see "Questions report"
+
+    And I click on "div.centerpara a" "css_element"
+    # now I should be in front of "Colles report > Questions > Tutor support"
+    Then I should not see "Questions report"
+
+    And I click on "div.centerpara a" "css_element"
+    # now I should be in front of "Colles report > Questions > Peer support"
+    Then I should not see "Questions report"
+
+    And I click on "div.centerpara a" "css_element"
+    # now I should be in front of "Colles report > Questions > Interpretation"
+    Then I should not see "Questions report"
+
+    And I click on "div.centerpara a" "css_element"
+    Then I should not see "Summary report"
+
+    # now test links provided by Admin menu
+
+    And I follow "Run COLLES report"
+    And I navigate to "Scales" node in "Surveypro administration > Report > Colles report"
+    # now I should be in front of "Colles report > Scales"
+    Then I should not see "Scales report"
+
+    And I follow "Run COLLES report"
     And I navigate to "Relevance" node in "Surveypro administration > Report > Colles report > Questions"
+    # now I should be in front of "Colles report > Questions > Relevance"
     Then I should not see "Questions report"
 
+    And I follow "Run COLLES report"
     And I navigate to "Reflective thinking" node in "Surveypro administration > Report > Colles report > Questions"
+    # now I should be in front of "Colles report > Questions > Reflective thinking"
     Then I should not see "Questions report"
 
+    And I follow "Run COLLES report"
     And I navigate to "Interactivity" node in "Surveypro administration > Report > Colles report > Questions"
+    # now I should be in front of "Colles report > Questions > Interactivity"
     Then I should not see "Questions report"
 
+    And I follow "Run COLLES report"
     And I navigate to "Tutor support" node in "Surveypro administration > Report > Colles report > Questions"
+    # now I should be in front of "Colles report > Questions > Tutor support"
     Then I should not see "Questions report"
 
+    And I follow "Run COLLES report"
     And I navigate to "Peer support" node in "Surveypro administration > Report > Colles report > Questions"
+    # now I should be in front of "Colles report > Questions > Peer support"
     Then I should not see "Questions report"
 
+    And I follow "Run COLLES report"
     And I navigate to "Interpretation" node in "Surveypro administration > Report > Colles report > Questions"
+    # now I should be in front of "Colles report > Questions > Interpretation"
     Then I should not see "Questions report"

--- a/template/collespreferred/tests/behat/graphs.feature
+++ b/template/collespreferred/tests/behat/graphs.feature
@@ -78,26 +78,77 @@ Feature: apply a COLLES (preferred) mastertemplate to test graphs
     And I am on "To test COLLES graphs" course homepage
     And I follow "Run COLLES report"
 
+    # now test links provided by img's
+
     And I navigate to "Summary" node in "Surveypro administration > Report > Colles report"
+    # now I should be in front of "Colles report > Summary"
     Then I should not see "Summary report"
 
-    And I navigate to "Scales" node in "Surveypro administration > Report > Colles report"
+    And I click on "div.centerpara a" "css_element"
+    # now I should be in front of "Colles report > Scales"
     Then I should not see "Scales report"
 
+    And I click on "div.centerpara a" "css_element"
+    # now I should be in front of "Colles report > Questions > Relevance"
+    Then I should not see "Questions report"
+
+    And I click on "div.centerpara a" "css_element"
+    # now I should be in front of "Colles report > Questions > Reflective thinking"
+    Then I should not see "Questions report"
+
+    And I click on "div.centerpara a" "css_element"
+    # now I should be in front of "Colles report > Questions > Interactivity"
+    Then I should not see "Questions report"
+
+    And I click on "div.centerpara a" "css_element"
+    # now I should be in front of "Colles report > Questions > Tutor support"
+    Then I should not see "Questions report"
+
+    And I click on "div.centerpara a" "css_element"
+    # now I should be in front of "Colles report > Questions > Peer support"
+    Then I should not see "Questions report"
+
+    And I click on "div.centerpara a" "css_element"
+    # now I should be in front of "Colles report > Questions > Interpretation"
+    Then I should not see "Questions report"
+
+    And I click on "div.centerpara a" "css_element"
+    # now I should be in front of "Colles report > Summary"
+    Then I should not see "Summary report"
+
+    # now test links provided by Admin menu
+
+    And I follow "Run COLLES report"
+    And I navigate to "Scales" node in "Surveypro administration > Report > Colles report"
+    # now I should be in front of "Colles report > Scales"
+    Then I should not see "Scales report"
+
+    And I follow "Run COLLES report"
     And I navigate to "Relevance" node in "Surveypro administration > Report > Colles report > Questions"
+    # now I should be in front of "Colles report > Questions > Relevance"
     Then I should not see "Questions report"
 
+    And I follow "Run COLLES report"
     And I navigate to "Reflective thinking" node in "Surveypro administration > Report > Colles report > Questions"
+    # now I should be in front of "Colles report > Questions > Reflective thinking"
     Then I should not see "Questions report"
 
+    And I follow "Run COLLES report"
     And I navigate to "Interactivity" node in "Surveypro administration > Report > Colles report > Questions"
+    # now I should be in front of "Colles report > Questions > Interactivity"
     Then I should not see "Questions report"
 
+    And I follow "Run COLLES report"
     And I navigate to "Tutor support" node in "Surveypro administration > Report > Colles report > Questions"
+    # now I should be in front of "Colles report > Questions > Tutor support"
     Then I should not see "Questions report"
 
+    And I follow "Run COLLES report"
     And I navigate to "Peer support" node in "Surveypro administration > Report > Colles report > Questions"
+    # now I should be in front of "Colles report > Questions > Peer support"
     Then I should not see "Questions report"
 
+    And I follow "Run COLLES report"
     And I navigate to "Interpretation" node in "Surveypro administration > Report > Colles report > Questions"
+    # now I should be in front of "Colles report > Questions > Interpretation"
     Then I should not see "Questions report"


### PR DESCRIPTION
Simply returning to report home, the "Page administration menu" become available once again.

This patch fixes:
001 Scenario: apply COLLES (Actual) master template, add a record and call reports           # /Users/stronk7/git_moodle/survey/mod/surveypro/template/collesactual/tests/behat/graphs.feature:26
      And I navigate to "Scales" node in "Surveypro administration > Report > Colles report" # /Users/stronk7/git_moodle/survey/mod/surveypro/template/collesactual/tests/behat/graphs.feature:84
        Page administration menu is not found not found. (Behat\Mink\Exception\ElementNotFoundException)

002 Scenario: apply COLLES (Preferred and Actual) master template, add a record and call reports # /Users/stronk7/git_moodle/survey/mod/surveypro/template/collesactualpreferred/tests/behat/graphs.feature:26
      And I navigate to "Scales" node in "Surveypro administration > Report > Colles report"     # /Users/stronk7/git_moodle/survey/mod/surveypro/template/collesactualpreferred/tests/behat/graphs.feature:114
        Page administration menu is not found not found. (Behat\Mink\Exception\ElementNotFoundException)
 
003 Scenario: apply COLLES (Preferred) master template, add a record and call reports        # /Users/stronk7/git_moodle/survey/mod/surveypro/template/collespreferred/tests/behat/graphs.feature:26
      And I navigate to "Scales" node in "Surveypro administration > Report > Colles report" # /Users/stronk7/git_moodle/survey/mod/surveypro/template/collespreferred/tests/behat/graphs.feature:84
        Page administration menu is not found not found. (Behat\Mink\Exception\ElementNotFoundException)