### PR TITLE
NOBUG mod_surveypro: examples are not aligned in boost

### DIFF
--- a/form/items/itembase_form.php
+++ b/form/items/itembase_form.php
@@ -272,20 +272,22 @@ class mod_surveypro_itembaseform extends moodleform {
             $fieldname = 'parentformat';
             $a = new stdClass();
             $a->fieldname = get_string('parentcontent', 'mod_surveypro');
-            $a->examples = html_writer::start_tag('ul');
+            $rowparity = 0;
+            $a->examples = html_writer::start_tag('table', array('class' => 'generaltable exampletable'));
             foreach ($pluginlist as $plugin) {
-                $pluginnamestr = get_string('pluginname', 'surveyprofield_'.$plugin);
-                $parentformatstr = get_string('parentformat', 'surveyprofield_'.$plugin);
-                $a->examples .= html_writer::start_tag('li');
-                $a->examples .= html_writer::start_tag('div');
-                $a->examples .= html_writer::tag('div', $pluginnamestr, array('class' => 'pluginname'));
-                $a->examples .= html_writer::tag('div', $parentformatstr, array('class' => 'inputformat'));
-                $a->examples .= html_writer::end_tag('div');
-                $a->examples .= html_writer::end_tag('li');
-                $a->examples .= "\n";
+                $rowparity = 1 - $rowparity;
+                $a->examples .= html_writer::start_tag('tr', array('class' => 'r' . $rowparity));
+                $a->examples .= html_writer::start_tag('td', array('class' => 'pluginname'));
+                $a->examples .= get_string('pluginname', 'surveyprofield_'.$plugin);
+                $a->examples .= html_writer::end_tag('td');
+
+                $a->examples .= html_writer::start_tag('td', array('class' => 'inputformat'));
+                $a->examples .= get_string('parentformat', 'surveyprofield_'.$plugin);
+                $a->examples .= html_writer::end_tag('td');
+                $a->examples .= html_writer::end_tag('tr');
             }
+            $a->examples .= html_writer::end_tag('table');
             $notestr = get_string('note', 'mod_surveypro');
-            $a->examples .= html_writer::end_tag('ul');
             $mform->addElement('static', $fieldname, $notestr, get_string($fieldname, 'mod_surveypro', $a));
         }
 

--- a/styles.css
+++ b/styles.css
@@ -275,18 +275,22 @@
 /* End of: Page break and fieldset presentation in the items table and during deletion confirmation */
 
 /* Begin of: selectors for the static field explaining the format needed by each plugin in parentcontent field */
-#page-mod-surveypro-layout_itemsetup .pluginname {
-    /* border:1px green solid; */
-    float:left;
-    left:0;
-    width:25%;
+#page-mod-surveypro-layout_itemsetup table.exampletable {
+    padding:0;
+    margin: 0 0 0 20px;
+    width:auto;
 }
 
-#page-mod-surveypro-layout_itemsetup .inputformat {
-    /* border:1px blue solid; */
-    margin-left:26%;
-    padding-left:26%;
-    position:relative;
+#page-mod-surveypro-layout_itemsetup td.pluginname {
+    padding:0 20px 0 0;
+    vertical-align: top;
+    /* width:60%; */
+}
+
+#page-mod-surveypro-layout_itemsetup td.inputformat {
+    padding:0;
+    vertical-align: top;
+    /* width:40%; */
 }
 
 #page-mod-surveypro-layout_itemsetup .felement.fstatic ul {


### PR DESCRIPTION
Last example in the branching section of the element creation form is misaligned in boost.
In spite of this, all is fine in clean.
I replaced the \<ul>\<li> structure with a table and the validator is still happy.