### PR TITLE
CONTRIB-7112 mod_surveypro: changed id with itemid

### DIFF
--- a/classes/itembase.php
+++ b/classes/itembase.php
@@ -526,7 +526,7 @@ class mod_surveypro_itembase {
         $usednames = array();
         foreach ($pluginlist as $plugin) {
             $tablename = 'surveypro'.SURVEYPRO_TYPEFIELD.'_'.$plugin;
-            $sql = 'SELECT p.id, p.variable
+            $sql = 'SELECT p.itemid, p.variable
                     FROM {surveypro_item} i
                       JOIN {'.$tablename.'} p ON p.itemid = i.id
                     WHERE ((i.surveyproid = :surveyproid)


### PR DESCRIPTION
The error was because the code was collecting each preexisting 'variable name' in a associative array.
The problem rose up because the index of the array was, badly, the plugin id and not, as it is correct, the id of the element in the surveypro. This lead to deletions of elements with the same index (and this was possible because each plugin starts with element id = 1) from the array of previous variable name and the routine failed.