### PR TITLE
NOBUG mod_surveypro: removed fileupload fillinginstruction

### DIFF
--- a/field/fileupload/backup/moodle2/backup_surveyprofield_fileupload_subplugin.class.php
+++ b/field/fileupload/backup/moodle2/backup_surveyprofield_fileupload_subplugin.class.php
@@ -45,7 +45,7 @@ class backup_surveyprofield_fileupload_subplugin extends backup_subplugin {
         $wrapper = new backup_nested_element($this->get_recommended_name());
         $subpluginfileupload = new backup_nested_element('surveyprofield_fileupload', array('id'), array(
             'content', 'contentformat', 'customnumber', 'position',
-            'extranote', 'required', 'hideinstructions', 'variable', 'indent',
+            'extranote', 'required', 'variable', 'indent',
             'maxfiles', 'maxbytes', 'filetypes'));
 
         // Connect XML elements into the tree.

--- a/field/fileupload/classes/field.php
+++ b/field/fileupload/classes/field.php
@@ -130,6 +130,7 @@ class surveyprofield_fileupload_field extends mod_surveypro_itembase {
         // List of fields I do not want to have in the item definition form.
         $this->insetupform['trimonsave'] = false;
         $this->insetupform['insearchform'] = false;
+        $this->insetupform['hideinstructions'] = false;
 
         if (!empty($itemid)) {
             $this->item_load($itemid, $getparentcontent);
@@ -257,7 +258,6 @@ class surveyprofield_fileupload_field extends mod_surveypro_itembase {
                 <xs:element type="xs:int" name="position"/>
                 <xs:element type="xs:string" name="extranote" minOccurs="0"/>
                 <xs:element type="xs:int" name="required"/>
-                <xs:element type="xs:int" name="hideinstructions"/>
                 <xs:element type="xs:string" name="variable"/>
                 <xs:element type="xs:int" name="indent"/>
 
@@ -337,24 +337,6 @@ EOS;
                 return;
             }
         }
-    }
-
-    /**
-     * Prepare the string with the filling instruction.
-     *
-     * @return string $fillinginstruction
-     */
-    public function userform_get_filling_instructions() {
-
-        if ($this->filetypes != '*') {
-            $filetypelist = preg_replace('~,(?! )~', ', ', $this->filetypes); // Credits to Sam Marshall.
-
-            $fillinginstruction = get_string('fileextensions', 'surveyprofield_fileupload').$filetypelist;
-        } else {
-            $fillinginstruction = '';
-        }
-
-        return $fillinginstruction;
     }
 
     /**

--- a/field/fileupload/db/install.xml
+++ b/field/fileupload/db/install.xml
@@ -17,7 +17,7 @@
         <FIELD NAME="position"         TYPE="int"  LENGTH="4"     NOTNULL="true"  UNSIGNED="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="extranote"        TYPE="char" LENGTH="255"   NOTNULL="false"                             SEQUENCE="false"/>
         <FIELD NAME="required"         TYPE="int"  LENGTH="4"     NOTNULL="false"                             SEQUENCE="false"/>
-        <FIELD NAME="hideinstructions" TYPE="int"  LENGTH="4"     NOTNULL="false"                             SEQUENCE="false"/>
+        <!-- <FIELD NAME="hideinstructions" TYPE="int"  LENGTH="4"     NOTNULL="false"                             SEQUENCE="false"/> -->
         <FIELD NAME="variable"         TYPE="char" LENGTH="64"    NOTNULL="false"                             SEQUENCE="false"/>
         <FIELD NAME="indent"           TYPE="int"  LENGTH="4"     NOTNULL="false"                             SEQUENCE="false"/>
         <!-- end of fields belonging to itembase_form.php -->

--- a/field/fileupload/db/upgrade.php
+++ b/field/fileupload/db/upgrade.php
@@ -70,5 +70,21 @@ function xmldb_surveyprofield_fileupload_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2016072001, 'surveyprofield', 'fileupload');
     }
 
+    // Moodle core added the list of allowed extensions to fileupload elements, so my instructions are no longer needed.
+    if ($oldversion < 2017110701) {
+
+        // Define field hideinstructions to be dropped from surveyprofield_fileupload.
+        $table = new xmldb_table('surveyprofield_fileupload');
+        $field = new xmldb_field('hideinstructions');
+
+        // Conditionally launch drop field hideinstructions.
+        if ($dbman->field_exists($table, $field)) {
+            $dbman->drop_field($table, $field);
+        }
+
+        // Surveypro savepoint reached.
+        upgrade_plugin_savepoint(true, 2017110701, 'surveyprofield', 'fileupload');
+    }
+
     return true;
 }

--- a/field/fileupload/version.php
+++ b/field/fileupload/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2016072001;
+$plugin->version = 2017110701;
 $plugin->release = '1.0';
 $plugin->requires = 2015111600; // Requires this Moodle version.
 $plugin->component = 'surveyprofield_fileupload'; // Full name of the plugin (used for diagnostics).


### PR DESCRIPTION
This PR was opened on top of "aligned backup to tables structure" #390 because I needed well written xml table structures, well written install.xml and well written backup structures before editing them.
This issue rose up because moodle HQ added to the fileupload element a note listing the allowed extensions. Because of this my instructions are no longer needed.



In the frame of this branch I also added three not relevant changes.

The first
- I added to backup_surveyprofield_integer_subplugin.class.php the field 'hideinstructions' that was missing
- I changed the position of 'hideinstructions' into the field/integer/db/install.xml. Useless but homogeneous with the other plugins.

The second: 
- I added to backup_surveyprofield_time_subplugin.class.php the field 'step' that was missing.

The last:
- I cleaned the backup_surveyproformat_fieldsetend_subplugin.class.php that was still full of not existing fields.