### PR TITLE
NOBUG mod_surveypro: changed old function name

### DIFF
--- a/classes/usertemplate.php
+++ b/classes/usertemplate.php
@@ -463,7 +463,7 @@ class mod_surveypro_usertemplate extends mod_surveypro_templatebase {
                 break;
             case SURVEYPRO_HIDEALLITEMS:
                 $whereparams = array('surveyproid' => $this->surveypro->id);
-                $utilityman->hide_items($whereparams, 0);
+                $utilityman->items_set_visibility($whereparams, 0);
 
                 $utilityman->reset_items_pages();
 


### PR DESCRIPTION
incredible but... hide_items is a function name that has never been used. This wrong name is there since its first implementation. I really can't believe this.