### PR TITLE
NOBUG mod_surveypro: changed field order at installation time

### DIFF
--- a/field/integer/db/install.xml
+++ b/field/integer/db/install.xml
@@ -16,8 +16,8 @@
         <FIELD NAME="customnumber"     TYPE="char" LENGTH="64"    NOTNULL="false"                              SEQUENCE="false"/>
         <FIELD NAME="position"         TYPE="int"  LENGTH="4"     NOTNULL="true"  UNSIGNED="true"  DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="extranote"        TYPE="char" LENGTH="255"   NOTNULL="false"                              SEQUENCE="false"/>
-        <FIELD NAME="hideinstructions" TYPE="int"  LENGTH="4"      NOTNULL="false"                             SEQUENCE="false"/>
         <FIELD NAME="required"         TYPE="int"  LENGTH="4"     NOTNULL="false"                              SEQUENCE="false"/>
+        <FIELD NAME="hideinstructions" TYPE="int"  LENGTH="4"     NOTNULL="false"                              SEQUENCE="false"/>
         <FIELD NAME="variable"         TYPE="char" LENGTH="64"    NOTNULL="false"                              SEQUENCE="false"/>
         <FIELD NAME="indent"           TYPE="int"  LENGTH="4"     NOTNULL="false"                              SEQUENCE="false"/>
         <!-- end of fields belonging to itembase_form.php -->


### PR DESCRIPTION
I have no idea about how I could fix this database problem for installations made between "a long time ago that I still don't know" and today. Maybe a $dbman or e $DB query? At the moment, I start by fixing it.

Is this an good solution?
```
    if ($oldversion < 2017110701) {

        // Move the field hideinstructions from where it is to just after the field required.
        $sql = 'ALTER TABLE {surveyprofield_integer} CHANGE COLUMN hideinstructions hideinstructions smallint(4) AFTER required';
        $DB->execute($sql);

        // Fileupload savepoint reached.
        upgrade_plugin_savepoint(true, 2017110701, 'surveyprofield', 'integer');
    }
```