### PR TITLE
NOBUG mod_surveypro: added missing trimonsave to textarea xml

### DIFF
--- a/template/collesactual/template.xml
+++ b/template/collesactual/template.xml
@@ -732,6 +732,7 @@
       <contentformat>1</contentformat>
       <position>0</position>
       <required>0</required>
+      <trimonsave>0</trimonsave>
       <hideinstructions>0</hideinstructions>
       <variable>ca_textarea</variable>
       <indent>0</indent>

--- a/template/collesactualpreferred/template.xml
+++ b/template/collesactualpreferred/template.xml
@@ -1260,6 +1260,7 @@
       <contentformat>1</contentformat>
       <position>0</position>
       <required>0</required>
+      <trimonsave>0</trimonsave>
       <hideinstructions>0</hideinstructions>
       <variable>cap_textarea</variable>
       <indent>0</indent>

--- a/template/collespreferred/template.xml
+++ b/template/collespreferred/template.xml
@@ -732,6 +732,7 @@
       <contentformat>1</contentformat>
       <position>0</position>
       <required>0</required>
+      <trimonsave>0</trimonsave>
       <hideinstructions>0</hideinstructions>
       <variable>cp_textarea</variable>
       <indent>0</indent>

--- a/template/criticalincidents/template.xml
+++ b/template/criticalincidents/template.xml
@@ -27,6 +27,7 @@
       <contentformat>1</contentformat>
       <position>0</position>
       <required>1</required>
+      <trimonsave>0</trimonsave>
       <hideinstructions>0</hideinstructions>
       <variable>ci_textarea_01</variable>
       <indent>0</indent>
@@ -49,6 +50,7 @@
       <contentformat>1</contentformat>
       <position>0</position>
       <required>1</required>
+      <trimonsave>0</trimonsave>
       <hideinstructions>0</hideinstructions>
       <variable>ci_textarea_02</variable>
       <indent>0</indent>
@@ -71,6 +73,7 @@
       <contentformat>1</contentformat>
       <position>0</position>
       <required>1</required>
+      <trimonsave>0</trimonsave>
       <hideinstructions>0</hideinstructions>
       <variable>ci_textarea_03</variable>
       <indent>0</indent>
@@ -93,6 +96,7 @@
       <contentformat>1</contentformat>
       <position>0</position>
       <required>1</required>
+      <trimonsave>0</trimonsave>
       <hideinstructions>0</hideinstructions>
       <variable>ci_textarea_04</variable>
       <indent>0</indent>
@@ -115,6 +119,7 @@
       <contentformat>1</contentformat>
       <position>0</position>
       <required>1</required>
+      <trimonsave>0</trimonsave>
       <hideinstructions>0</hideinstructions>
       <variable>ci_textarea_05</variable>
       <indent>0</indent>

--- a/tests/fixtures/usertemplate/MMM_2015123000.xml
+++ b/tests/fixtures/usertemplate/MMM_2015123000.xml
@@ -921,6 +921,7 @@ hill</options>
       <contentformat>1</contentformat>
       <position>0</position>
       <required>0</required>
+      <trimonsave>0</trimonsave>
       <hideinstructions>0</hideinstructions>
       <variable>textarea_001</variable>
       <indent>0</indent>
@@ -942,6 +943,7 @@ hill</options>
       <contentformat>1</contentformat>
       <position>0</position>
       <required>0</required>
+      <trimonsave>0</trimonsave>
       <hideinstructions>0</hideinstructions>
       <variable>textarea_002</variable>
       <indent>0</indent>

--- a/tests/fixtures/usertemplate/parent-child_2015123000.xml
+++ b/tests/fixtures/usertemplate/parent-child_2015123000.xml
@@ -191,6 +191,7 @@ A4 paper</options>
       <position>0</position>
       <extranote>This item should be enabled if the answer to the parent item is "pen" ONLY but this is a missing funtionality as described in MDL-25067</extranote>
       <required>0</required>
+      <trimonsave>0</trimonsave>
       <hideinstructions>0</hideinstructions>
       <variable>textarea_001</variable>
       <indent>1</indent>

--- a/tests/fixtures/usertemplate/textarea_only_2015123000.xml
+++ b/tests/fixtures/usertemplate/textarea_only_2015123000.xml
@@ -39,6 +39,7 @@
       <customnumber>1</customnumber>
       <position>0</position>
       <required>1</required>
+      <trimonsave>0</trimonsave>
       <hideinstructions>0</hideinstructions>
       <variable>textarea_001</variable>
       <indent>0</indent>
@@ -74,6 +75,7 @@
       <customnumber>2</customnumber>
       <position>0</position>
       <required>0</required>
+      <trimonsave>0</trimonsave>
       <hideinstructions>0</hideinstructions>
       <variable>textarea_002</variable>
       <indent>0</indent>
@@ -109,6 +111,7 @@
       <customnumber>3</customnumber>
       <position>0</position>
       <required>1</required>
+      <trimonsave>0</trimonsave>
       <hideinstructions>0</hideinstructions>
       <variable>textarea_003</variable>
       <indent>0</indent>
@@ -144,6 +147,7 @@
       <customnumber>4</customnumber>
       <position>0</position>
       <required>0</required>
+      <trimonsave>0</trimonsave>
       <hideinstructions>0</hideinstructions>
       <variable>textarea_004</variable>
       <indent>0</indent>


### PR DESCRIPTION
XML of templates having textarea element were not loaded because the tag <trimonsave> was missing.