### PR TITLE
replaced ! with the more readable empty

### DIFF
--- a/classes/reportbase.php
+++ b/classes/reportbase.php
@@ -81,8 +81,8 @@ class mod_surveypro_reportbase {
     /**
      * Return if this report applies.
      *
-     * true means: the report apply
-     * (!$this->surveypro->anonymous) means that reports applies ONLY IF user is not anonymous
+     * true means: the report applies
+     * empty($this->surveypro->anonymous) means that reports applies ONLY IF the survey is not anonymous
      *
      * @return boolean
      */

--- a/classes/view_export.php
+++ b/classes/view_export.php
@@ -605,7 +605,7 @@ class mod_surveypro_view_export {
                     if ($olduserid != $richsubmission->userid) {
                         // New user.
                         // Add a new folder named fullname($richsubmission).'_'.$richsubmission->userid.
-                        if ($this->surveypro->anonymous) {
+                        if (!empty($this->surveypro->anonymous)) {
                             $dummyuserid++;
                             $tempuserdir = $anonymousstr.'_'.$dummyuserid;
                         } else {
@@ -729,7 +729,7 @@ class mod_surveypro_view_export {
 
                     // New user or forced by new item.
                     // Add a new folder named $richsubmission->userid.
-                    if ($this->surveypro->anonymous) {
+                    if (!empty($this->surveypro->anonymous)) {
                         $dummyuserid++;
                         $tempuserdir = $anonymousstr.'_'.$dummyuserid;
                     } else {

--- a/form/data/export_form.php
+++ b/form/data/export_form.php
@@ -87,7 +87,7 @@ class mod_surveypro_exportform extends moodleform {
         }
 
         // Submissionexport: includenames.
-        if (empty($this->surveypro->anonymous)) {
+        if (empty($surveypro->anonymous)) {
             $fieldname = 'includenames';
             $mform->addElement('checkbox', $fieldname, get_string($fieldname, 'mod_surveypro'), get_string('import_rawwarning', 'mod_surveypro'));
             $mform->setDefault($fieldname, 1);

--- a/report/attachments/classes/report.php
+++ b/report/attachments/classes/report.php
@@ -43,13 +43,13 @@ class surveyproreport_attachments_report extends mod_surveypro_reportbase {
     /**
      * Return if this report applies.
      *
-     * true means: the report apply
-     * (!$this->surveypro->anonymous) means that reports applies ONLY IF user is not anonymous
+     * true means: the report applies
+     * empty($this->surveypro->anonymous) means that reports applies ONLY IF the survey is not anonymous
      *
      * @return boolean
      */
     public function report_apply() {
-        return (!$this->surveypro->anonymous);
+        return (empty($this->surveypro->anonymous));
     }
 
     /**
@@ -224,7 +224,7 @@ class surveyproreport_attachments_report extends mod_surveypro_reportbase {
      * @return void
      */
     public function prevent_direct_user_input() {
-        if ($this->surveypro->anonymous) {
+        if (!empty($this->surveypro->anonymous)) {
             print_error('incorrectaccessdetected', 'mod_surveypro');
         }
     }


### PR DESCRIPTION
The export form was using $this->surveypro->anonymous that does not exist.
The correct one is: $surveypro->anonymous
Very silly PR.

  