### PR TITLE
useless <parentvalue> dropped

### DIFF
--- a/classes/itembase.php
+++ b/classes/itembase.php
@@ -891,7 +891,7 @@ class mod_surveypro_itembase {
             <xs:sequence>
                 <xs:element name="hidden" type="xs:int"/>
                 <xs:element name="insearchform" type="xs:int"/>
-                <xs:element name="reserved" type="xs:int" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="reserved" type="xs:int"/>
                 <xs:element name="parentid" type="xs:int" minOccurs="0"/>
                 <xs:element name="parentvalue" type="xs:string" minOccurs="0"/>
             </xs:sequence>

--- a/template/attls/template.xml
+++ b/template/attls/template.xml
@@ -5,7 +5,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_label>
       <content>label_content_01</content>
@@ -20,7 +19,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_fieldset>
       <content>fieldset_content_01</content>
@@ -31,7 +29,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_02</content>
@@ -53,7 +50,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_03</content>
@@ -75,7 +71,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_04</content>
@@ -97,7 +92,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_05</content>
@@ -119,7 +113,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_06</content>
@@ -141,7 +134,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_07</content>
@@ -163,7 +155,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_08</content>
@@ -185,7 +176,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_09</content>
@@ -207,7 +197,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_10</content>
@@ -229,7 +218,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_11</content>
@@ -251,7 +239,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_12</content>
@@ -273,7 +260,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_13</content>
@@ -295,7 +281,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_14</content>
@@ -317,7 +302,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_15</content>
@@ -339,7 +323,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_16</content>
@@ -361,7 +344,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_17</content>
@@ -383,7 +365,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_18</content>
@@ -405,7 +386,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_19</content>
@@ -427,7 +407,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_20</content>
@@ -449,7 +428,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_21</content>

--- a/template/collesactual/template.xml
+++ b/template/collesactual/template.xml
@@ -5,7 +5,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_label>
       <content>label_content_01</content>
@@ -20,7 +19,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_fieldset>
       <content>fieldset_content_01</content>
@@ -31,7 +29,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_label>
       <content>label_content_02</content>
@@ -46,7 +43,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_03</content>
@@ -68,7 +64,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_04</content>
@@ -90,7 +85,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_05</content>
@@ -112,7 +106,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_06</content>
@@ -134,7 +127,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_fieldset>
       <content>fieldset_content_02</content>
@@ -145,7 +137,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_label>
       <content>label_content_02</content>
@@ -160,7 +151,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_07</content>
@@ -182,7 +172,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_08</content>
@@ -204,7 +193,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_09</content>
@@ -226,7 +214,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_10</content>
@@ -248,7 +235,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_fieldset>
       <content>fieldset_content_03</content>
@@ -259,7 +245,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_label>
       <content>label_content_02</content>
@@ -274,7 +259,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_11</content>
@@ -296,7 +280,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_12</content>
@@ -318,7 +301,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_13</content>
@@ -340,7 +322,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_14</content>
@@ -362,7 +343,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_fieldset>
       <content>fieldset_content_04</content>
@@ -373,7 +353,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_label>
       <content>label_content_02</content>
@@ -388,7 +367,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_15</content>
@@ -410,7 +388,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_16</content>
@@ -432,7 +409,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_17</content>
@@ -454,7 +430,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_18</content>
@@ -476,7 +451,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_fieldset>
       <content>fieldset_content_05</content>
@@ -487,7 +461,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_label>
       <content>label_content_02</content>
@@ -502,7 +475,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_19</content>
@@ -524,7 +496,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_20</content>
@@ -546,7 +517,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_21</content>
@@ -568,7 +538,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_22</content>
@@ -590,7 +559,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_fieldset>
       <content>fieldset_content_06</content>
@@ -601,7 +569,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_label>
       <content>label_content_02</content>
@@ -616,7 +583,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_23</content>
@@ -638,7 +604,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_24</content>
@@ -660,7 +625,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_25</content>
@@ -682,7 +646,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_26</content>
@@ -704,7 +667,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_select>
       <content>select_content_27</content>
@@ -725,7 +687,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_textarea>
       <content>textarea_content_28</content>

--- a/template/collesactualpreferred/template.xml
+++ b/template/collesactualpreferred/template.xml
@@ -5,7 +5,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_label>
       <content>label_content_01</content>
@@ -20,7 +19,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_fieldset>
       <content>fieldset_content_01</content>
@@ -31,7 +29,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_label>
       <content>label_content_02</content>
@@ -46,7 +43,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_03</content>
@@ -68,7 +64,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_04</content>
@@ -90,7 +85,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_05</content>
@@ -112,7 +106,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_06</content>
@@ -134,7 +127,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_07</content>
@@ -156,7 +148,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_08</content>
@@ -178,7 +169,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_09</content>
@@ -200,7 +190,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_10</content>
@@ -222,7 +211,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_fieldset>
       <content>fieldset_content_02</content>
@@ -233,7 +221,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_label>
       <content>label_content_02</content>
@@ -248,7 +235,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_11</content>
@@ -270,7 +256,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_12</content>
@@ -292,7 +277,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_13</content>
@@ -314,7 +298,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_14</content>
@@ -336,7 +319,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_15</content>
@@ -358,7 +340,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_16</content>
@@ -380,7 +361,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_17</content>
@@ -402,7 +382,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_18</content>
@@ -424,7 +403,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_fieldset>
       <content>fieldset_content_03</content>
@@ -435,7 +413,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_label>
       <content>label_content_02</content>
@@ -450,7 +427,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_19</content>
@@ -472,7 +448,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_20</content>
@@ -494,7 +469,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_21</content>
@@ -516,7 +490,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_22</content>
@@ -538,7 +511,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_23</content>
@@ -560,7 +532,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_24</content>
@@ -582,7 +553,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_25</content>
@@ -604,7 +574,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_26</content>
@@ -626,7 +595,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_fieldset>
       <content>fieldset_content_04</content>
@@ -637,7 +605,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_label>
       <content>label_content_02</content>
@@ -652,7 +619,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_27</content>
@@ -674,7 +640,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_28</content>
@@ -696,7 +661,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_29</content>
@@ -718,7 +682,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_30</content>
@@ -740,7 +703,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_31</content>
@@ -762,7 +724,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_32</content>
@@ -784,7 +745,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_33</content>
@@ -806,7 +766,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_34</content>
@@ -828,7 +787,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_fieldset>
       <content>fieldset_content_05</content>
@@ -839,7 +797,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_label>
       <content>label_content_02</content>
@@ -854,7 +811,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_35</content>
@@ -876,7 +832,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_36</content>
@@ -898,7 +853,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_37</content>
@@ -920,7 +874,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_38</content>
@@ -942,7 +895,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_39</content>
@@ -964,7 +916,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_40</content>
@@ -986,7 +937,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_41</content>
@@ -1008,7 +958,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_42</content>
@@ -1030,7 +979,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_fieldset>
       <content>fieldset_content_06</content>
@@ -1041,7 +989,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_label>
       <content>label_content_02</content>
@@ -1056,7 +1003,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_43</content>
@@ -1078,7 +1024,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_44</content>
@@ -1100,7 +1045,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_45</content>
@@ -1122,7 +1066,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_46</content>
@@ -1144,7 +1087,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_47</content>
@@ -1166,7 +1108,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_48</content>
@@ -1188,7 +1129,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_49</content>
@@ -1210,7 +1150,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_50</content>
@@ -1232,7 +1171,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_select>
       <content>select_content_51</content>
@@ -1253,7 +1191,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_textarea>
       <content>textarea_content_52</content>

--- a/template/collespreferred/template.xml
+++ b/template/collespreferred/template.xml
@@ -5,7 +5,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_label>
       <content>label_content_01</content>
@@ -20,7 +19,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_fieldset>
       <content>fieldset_content_01</content>
@@ -31,7 +29,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_label>
       <content>label_content_02</content>
@@ -46,7 +43,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_03</content>
@@ -68,7 +64,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_04</content>
@@ -90,7 +85,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_05</content>
@@ -112,7 +106,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_06</content>
@@ -134,7 +127,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_fieldset>
       <content>fieldset_content_02</content>
@@ -145,7 +137,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_label>
       <content>label_content_02</content>
@@ -160,7 +151,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_07</content>
@@ -182,7 +172,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_08</content>
@@ -204,7 +193,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_09</content>
@@ -226,7 +214,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_10</content>
@@ -248,7 +235,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_fieldset>
       <content>fieldset_content_03</content>
@@ -259,7 +245,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_label>
       <content>label_content_02</content>
@@ -274,7 +259,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_11</content>
@@ -296,7 +280,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_12</content>
@@ -318,7 +301,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_13</content>
@@ -340,7 +322,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_14</content>
@@ -362,7 +343,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_fieldset>
       <content>fieldset_content_04</content>
@@ -373,7 +353,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_label>
       <content>label_content_02</content>
@@ -388,7 +367,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_15</content>
@@ -410,7 +388,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_16</content>
@@ -432,7 +409,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_17</content>
@@ -454,7 +430,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_18</content>
@@ -476,7 +451,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_fieldset>
       <content>fieldset_content_05</content>
@@ -487,7 +461,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_label>
       <content>label_content_02</content>
@@ -502,7 +475,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_19</content>
@@ -524,7 +496,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_20</content>
@@ -546,7 +517,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_21</content>
@@ -568,7 +538,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_22</content>
@@ -590,7 +559,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_fieldset>
       <content>fieldset_content_06</content>
@@ -601,7 +569,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_label>
       <content>label_content_02</content>
@@ -616,7 +583,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_23</content>
@@ -638,7 +604,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_24</content>
@@ -660,7 +625,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_25</content>
@@ -682,7 +646,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_radiobutton>
       <content>radiobutton_content_26</content>
@@ -704,7 +667,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_select>
       <content>select_content_27</content>
@@ -725,7 +687,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_textarea>
       <content>textarea_content_28</content>

--- a/template/criticalincidents/template.xml
+++ b/template/criticalincidents/template.xml
@@ -5,7 +5,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyproformat_label>
       <content>label_content_01</content>
@@ -20,7 +19,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_textarea>
       <content>textarea_content_02</content>
@@ -43,7 +41,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_textarea>
       <content>textarea_content_03</content>
@@ -66,7 +63,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_textarea>
       <content>textarea_content_04</content>
@@ -89,7 +85,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_textarea>
       <content>textarea_content_05</content>
@@ -112,7 +107,6 @@
       <hidden>0</hidden>
       <insearchform>1</insearchform>
       <reserved>0</reserved>
-      <parentvalue>item_parentvalue_01</parentvalue>
     </surveypro_item>
     <surveyprofield_textarea>
       <content>textarea_content_06</content>


### PR DESCRIPTION
<parentvalue> is 100% useless without <parentcontent>. So I dropped it.

Moreover, when <parentcontent> is missing, <parentvalue> MUST be missing too.
I will fix it tomorrow.