### PR TITLE
changed the name of the duplicate classes

### DIFF
--- a/field/age/form/itemsetup_form.php
+++ b/field/age/form/itemsetup_form.php
@@ -35,7 +35,7 @@ require_once($CFG->dirroot.'/mod/surveypro/field/age/lib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_surveypro_itemsetupform extends mod_surveypro_itembaseform {
+class mod_surveypro_age_setupform extends mod_surveypro_itembaseform {
 
     /**
      * Definition.

--- a/field/autofill/form/itemsetup_form.php
+++ b/field/autofill/form/itemsetup_form.php
@@ -35,7 +35,7 @@ require_once($CFG->dirroot.'/mod/surveypro/field/autofill/lib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_surveypro_itemsetupform extends mod_surveypro_itembaseform {
+class mod_surveypro_autofill_setupform extends mod_surveypro_itembaseform {
 
     /**
      * Definition.

--- a/field/boolean/form/itemsetup_form.php
+++ b/field/boolean/form/itemsetup_form.php
@@ -35,7 +35,7 @@ require_once($CFG->dirroot.'/mod/surveypro/field/boolean/lib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_surveypro_itemsetupform extends mod_surveypro_itembaseform {
+class mod_surveypro_boolean_setupform extends mod_surveypro_itembaseform {
 
     /**
      * Definition.

--- a/field/character/form/itemsetup_form.php
+++ b/field/character/form/itemsetup_form.php
@@ -35,7 +35,7 @@ require_once($CFG->dirroot.'/mod/surveypro/field/character/lib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_surveypro_itemsetupform extends mod_surveypro_itembaseform {
+class mod_surveypro_character_setupform extends mod_surveypro_itembaseform {
 
     /**
      * Definition.

--- a/field/checkbox/form/itemsetup_form.php
+++ b/field/checkbox/form/itemsetup_form.php
@@ -35,7 +35,7 @@ require_once($CFG->dirroot.'/mod/surveypro/field/checkbox/lib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_surveypro_itemsetupform extends mod_surveypro_itembaseform {
+class mod_surveypro_checkbox_setupform extends mod_surveypro_itembaseform {
 
     /**
      * Definition.

--- a/field/date/form/itemsetup_form.php
+++ b/field/date/form/itemsetup_form.php
@@ -35,7 +35,7 @@ require_once($CFG->dirroot.'/mod/surveypro/field/date/lib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_surveypro_itemsetupform extends mod_surveypro_itembaseform {
+class mod_surveypro_date_setupform extends mod_surveypro_itembaseform {
 
     /**
      * Definition.

--- a/field/datetime/form/itemsetup_form.php
+++ b/field/datetime/form/itemsetup_form.php
@@ -35,7 +35,7 @@ require_once($CFG->dirroot.'/mod/surveypro/field/datetime/lib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_surveypro_itemsetupform extends mod_surveypro_itembaseform {
+class mod_surveypro_datetime_setupform extends mod_surveypro_itembaseform {
 
     /**
      * Definition.

--- a/field/fileupload/form/itemsetup_form.php
+++ b/field/fileupload/form/itemsetup_form.php
@@ -35,7 +35,7 @@ require_once($CFG->dirroot.'/mod/surveypro/field/fileupload/lib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_surveypro_itemsetupform extends mod_surveypro_itembaseform {
+class mod_surveypro_fileupload_setupform extends mod_surveypro_itembaseform {
 
     /**
      * Definition.

--- a/field/integer/form/itemsetup_form.php
+++ b/field/integer/form/itemsetup_form.php
@@ -35,7 +35,7 @@ require_once($CFG->dirroot.'/mod/surveypro/field/integer/lib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_surveypro_itemsetupform extends mod_surveypro_itembaseform {
+class mod_surveypro_integer_setupform extends mod_surveypro_itembaseform {
 
     /**
      * Definition.

--- a/field/multiselect/form/itemsetup_form.php
+++ b/field/multiselect/form/itemsetup_form.php
@@ -35,7 +35,7 @@ require_once($CFG->dirroot.'/mod/surveypro/field/multiselect/lib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_surveypro_itemsetupform extends mod_surveypro_itembaseform {
+class mod_surveypro_multiselect_setupform extends mod_surveypro_itembaseform {
 
     /**
      * Definition.

--- a/field/numeric/form/itemsetup_form.php
+++ b/field/numeric/form/itemsetup_form.php
@@ -35,7 +35,7 @@ require_once($CFG->dirroot.'/mod/surveypro/field/numeric/lib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_surveypro_itemsetupform extends mod_surveypro_itembaseform {
+class mod_surveypro_numeric_setupform extends mod_surveypro_itembaseform {
 
     /**
      * Definition.

--- a/field/radiobutton/form/itemsetup_form.php
+++ b/field/radiobutton/form/itemsetup_form.php
@@ -35,7 +35,7 @@ require_once($CFG->dirroot.'/mod/surveypro/field/radiobutton/lib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_surveypro_itemsetupform extends mod_surveypro_itembaseform {
+class mod_surveypro_radiobutton_setupform extends mod_surveypro_itembaseform {
 
     /**
      * Definition.

--- a/field/rate/form/itemsetup_form.php
+++ b/field/rate/form/itemsetup_form.php
@@ -35,7 +35,7 @@ require_once($CFG->dirroot.'/mod/surveypro/field/rate/lib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_surveypro_itemsetupform extends mod_surveypro_itembaseform {
+class mod_surveypro_rate_setupform extends mod_surveypro_itembaseform {
 
     /**
      * Definition.

--- a/field/recurrence/form/itemsetup_form.php
+++ b/field/recurrence/form/itemsetup_form.php
@@ -35,7 +35,7 @@ require_once($CFG->dirroot.'/mod/surveypro/field/recurrence/lib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_surveypro_itemsetupform extends mod_surveypro_itembaseform {
+class mod_surveypro_recurrence_setupform extends mod_surveypro_itembaseform {
 
     /**
      * Definition.

--- a/field/select/form/itemsetup_form.php
+++ b/field/select/form/itemsetup_form.php
@@ -35,7 +35,7 @@ require_once($CFG->dirroot.'/mod/surveypro/field/select/lib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_surveypro_itemsetupform extends mod_surveypro_itembaseform {
+class mod_surveypro_select_setupform extends mod_surveypro_itembaseform {
 
     /**
      * Definition.

--- a/field/shortdate/form/itemsetup_form.php
+++ b/field/shortdate/form/itemsetup_form.php
@@ -35,7 +35,7 @@ require_once($CFG->dirroot.'/mod/surveypro/field/shortdate/lib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_surveypro_itemsetupform extends mod_surveypro_itembaseform {
+class mod_surveypro_shortdate_setupform extends mod_surveypro_itembaseform {
 
     /**
      * Definition.

--- a/field/textarea/form/itemsetup_form.php
+++ b/field/textarea/form/itemsetup_form.php
@@ -35,7 +35,7 @@ require_once($CFG->dirroot.'/mod/surveypro/field/textarea/lib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_surveypro_itemsetupform extends mod_surveypro_itembaseform {
+class mod_surveypro_textarea_setupform extends mod_surveypro_itembaseform {
 
     /**
      * Definition.

--- a/field/time/form/itemsetup_form.php
+++ b/field/time/form/itemsetup_form.php
@@ -35,7 +35,7 @@ require_once($CFG->dirroot.'/mod/surveypro/field/time/lib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_surveypro_itemsetupform extends mod_surveypro_itembaseform {
+class mod_surveypro_time_setupform extends mod_surveypro_itembaseform {
 
     /**
      * Definition.

--- a/format/fieldset/form/itemsetup_form.php
+++ b/format/fieldset/form/itemsetup_form.php
@@ -35,7 +35,7 @@ require_once($CFG->dirroot.'/mod/surveypro/format/fieldset/lib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_surveypro_itemsetupform extends mod_surveypro_itembaseform {
+class mod_surveypro_fieldset_setupform extends mod_surveypro_itembaseform {
 
     /**
      * Definition.

--- a/format/fieldsetend/form/itemsetup_form.php
+++ b/format/fieldsetend/form/itemsetup_form.php
@@ -35,7 +35,7 @@ require_once($CFG->dirroot.'/mod/surveypro/format/fieldsetend/lib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_surveypro_itemsetupform extends mod_surveypro_itembaseform {
+class mod_surveypro_fieldsetend_setupform extends mod_surveypro_itembaseform {
 
     /**
      * Definition.

--- a/format/label/form/itemsetup_form.php
+++ b/format/label/form/itemsetup_form.php
@@ -35,7 +35,7 @@ require_once($CFG->dirroot.'/mod/surveypro/format/label/lib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_surveypro_itemsetupform extends mod_surveypro_itembaseform {
+class mod_surveypro_label_setupform extends mod_surveypro_itembaseform {
 
     /**
      * Definition.

--- a/format/pagebreak/form/itemsetup_form.php
+++ b/format/pagebreak/form/itemsetup_form.php
@@ -35,7 +35,7 @@ require_once($CFG->dirroot.'/mod/surveypro/format/pagebreak/lib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_surveypro_itemsetupform extends mod_surveypro_itembaseform {
+class mod_surveypro_pagebreak_setupform extends mod_surveypro_itembaseform {
 
     /**
      * Definition.

--- a/layout_itemsetup.php
+++ b/layout_itemsetup.php
@@ -98,7 +98,9 @@ $itemlistman->prevent_direct_user_input();
 require_once($CFG->dirroot.'/mod/surveypro/'.$itemlistman->get_type().'/'.$itemlistman->get_plugin().'/form/itemsetup_form.php');
 
 // Begin of: get item.
-$item = surveypro_get_item($cm, $surveypro, $itemid, $itemlistman->get_type(), $itemlistman->get_plugin(), true);
+$itemtype = $itemlistman->get_type();
+$itemplugin = $itemlistman->get_plugin();
+$item = surveypro_get_item($cm, $surveypro, $itemid, $itemtype, $itemplugin, true);
 $item->item_set_editor();
 // End of: get item.
 
@@ -111,7 +113,9 @@ $formurl = new moodle_url('/mod/surveypro/layout_itemsetup.php', $paramurl);
 $formparams = new stdClass();
 $formparams->item = $item; // Needed in many situations.
 $formparams->surveypro = $surveypro; // Needed to setup date boundaries in date fields.
-$itemform = new mod_surveypro_itemsetupform($formurl, $formparams);
+
+$classname = 'mod_surveypro_'.$itemplugin.'_setupform';
+$itemform = new $classname($formurl, $formparams);
 // End of: prepare params for the form.
 
 // Begin of: manage form submission.


### PR DESCRIPTION
Fixed the warning in each of its occurrences:
```
------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
------------------------------------------------------------------------------------------------------------------------
 38 | WARNING | Duplicate class name "mod_surveypro_itemsetupform" found; first defined in
    |         | /home/travis/build/moodle/mod/surveypro/field/age/form/itemsetup_form.php on line 38
------------------------------------------------------------------------------------------------------------------------
```