### PR TITLE
forced different var in var quickchange

### DIFF
--- a/classes/itemlist_variable.php
+++ b/classes/itemlist_variable.php
@@ -67,7 +67,9 @@ class mod_surveypro_itemlist_variable extends \core\output\inplace_editable {
         $record->plugin = $itemrecord->plugin;
 
         $item->item_validate_variablename($record, $itemid);
+
         $tablename = 'surveypro'.$itemrecord->type.'_'.$itemrecord->plugin;
+        $newvarname = $record->variable;
         $DB->set_field($tablename, 'variable', $newvarname, array('itemid' => $itemid));
 
         return new static($itemid, $newvarname);


### PR DESCRIPTION
There was a silly missing assignment in public static function update($itemid, $newvarname) { for variable quick change that was not allowing the verification of the uniqueness of the variable name. Fixed.