### PR TITLE
added missing sort for usual export

### DIFF
--- a/classes/view_export.php
+++ b/classes/view_export.php
@@ -168,9 +168,10 @@ class mod_surveypro_view_export {
 
         if ($this->formdata->downloadtype == SURVEYPRO_FILESBYUSER) {
             $sql .= ' ORDER BY s.userid, submissionid, a.itemid';
-        }
-        if ($this->formdata->downloadtype == SURVEYPRO_FILESBYITEM) {
+        } else if ($this->formdata->downloadtype == SURVEYPRO_FILESBYITEM) {
             $sql .= ' ORDER BY a.itemid, s.userid, submissionid';
+        } else {
+            $sql .= ' ORDER BY submissionid';
         }
 
         return array($sql, $whereparams);


### PR DESCRIPTION
If records are not sorted by submissionid then output_to_xls (or output_to_csv) adds one more line to the output file each time it meets a record with submissionid different from the one of the previous record.