### PR TITLE
conditionally add items

### DIFF
--- a/classes/view_export.php
+++ b/classes/view_export.php
@@ -568,6 +568,26 @@ class mod_surveypro_view_export {
     }
 
     /**
+     * Check if attachments were added to the current surveypro
+     *
+     * @return boolean
+     */
+    public function are_attachments_onboard() {
+        global $DB;
+
+        $checkattachmentssql = 'SELECT s.id, si.plugin
+            FROM {surveypro} s
+	            JOIN {surveypro_item} si ON si.id = s.id
+            WHERE s.id = :surveyproid
+	            AND si.plugin = :plugin';
+	    $whereparams = array('surveyproid' => $this->surveypro->id, 'plugin' => 'fileupload');
+
+        $attachments = $DB->get_recordset_sql($checkattachmentssql, $whereparams);
+
+        return ($attachments->valid());
+    }
+
+    /**
      * Craft each uploaded attachment by user and compress the package.
      *
      * @return void
@@ -586,7 +606,6 @@ class mod_surveypro_view_export {
 
         $fs = get_file_storage();
         list($richsubmissionssql, $whereparams) = $this->get_export_sql(true);
-
         $richsubmissions = $DB->get_recordset_sql($richsubmissionssql, $whereparams);
 
         if ($richsubmissions->valid()) {

--- a/form/data/export_form.php
+++ b/form/data/export_form.php
@@ -49,6 +49,7 @@ class mod_surveypro_exportform extends moodleform {
         $surveypro = $this->_customdata->surveypro;
         $activityisgrouped = $this->_customdata->activityisgrouped;
         $context = $this->_customdata->context;
+        $attachmentshere = $this->_customdata->attachmentshere;
 
         // Submissionexport: settingsheader.
         $mform->addElement('header', 'settingsheader', get_string('download'));
@@ -120,8 +121,10 @@ class mod_surveypro_exportform extends moodleform {
         $pluginlist[SURVEYPRO_DOWNLOADCSV] = get_string('downloadtocsv', 'mod_surveypro');
         $pluginlist[SURVEYPRO_DOWNLOADTSV] = get_string('downloadtotsv', 'mod_surveypro');
         $pluginlist[SURVEYPRO_DOWNLOADXLS] = get_string('downloadtoxls', 'mod_surveypro');
-        $pluginlist[SURVEYPRO_FILESBYUSER] = get_string('downloadtozipbyuser', 'mod_surveypro');
-        $pluginlist[SURVEYPRO_FILESBYITEM] = get_string('downloadtozipbysubmission', 'mod_surveypro');
+        if ($attachmentshere) {
+            $pluginlist[SURVEYPRO_FILESBYUSER] = get_string('downloadtozipbyuser', 'mod_surveypro');
+            $pluginlist[SURVEYPRO_FILESBYITEM] = get_string('downloadtozipbysubmission', 'mod_surveypro');
+        }
         $mform->addElement('select', $fieldname, get_string($fieldname, 'mod_surveypro'), $pluginlist);
 
         // Submissionexport: outputstyle.

--- a/view_export.php
+++ b/view_export.php
@@ -57,6 +57,7 @@ $formparams = new stdClass();
 $formparams->surveypro = $surveypro;
 $formparams->activityisgrouped = groups_get_activity_groupmode($cm, $course);
 $formparams->context = $context;
+$formparams->attachmentshere = $exportman->are_attachments_onboard();
 $exportform = new mod_surveypro_exportform($formurl, $formparams);
 // End of: prepare params for the form.
 


### PR DESCRIPTION
The two items "download attachments by user to zip" and "download attachments by item to zip" are not welcome in the "download file type" drop down menu of the administration > Survey > Export form if the surveypro has not items with type = 'fileupload'