### PR TITLE
added code to detect empty "other" text

### DIFF
--- a/field/select/classes/field.php
+++ b/field/select/classes/field.php
@@ -581,6 +581,13 @@ EOS;
 
         if ($data[$this->itemname] == SURVEYPRO_INVITEVALUE) {
             $errors[$errorkey] = get_string('uerr_optionnotset', 'surveyprofield_select');
+            return;
+        }
+
+        if (!empty($this->labelother)) {
+            if (($data[$this->itemname] == 'other') && empty($data[$this->itemname.'_text']) ) {
+                $errors[$errorkey] = get_string('uerr_missingothertext', 'surveyprofield_select');
+            }
         }
     }
 

--- a/field/select/lang/en/surveyprofield_select.php
+++ b/field/select/lang/en/surveyprofield_select.php
@@ -45,5 +45,6 @@ $string['pluginname'] = 'Select';
 $string['returnlabels'] = 'label of selected item';
 $string['returnposition'] = 'positional answer';
 $string['returnvalues'] = 'value of selected item';
+$string['uerr_missingothertext'] = 'Please add the text required by your selection';
 $string['uerr_optionnotset'] = 'Please choose an option';
 $string['userfriendlypluginname'] = 'Select';

--- a/field/select/lang/es_mx/surveyprofield_select.php
+++ b/field/select/lang/es_mx/surveyprofield_select.php
@@ -45,5 +45,6 @@ $string['pluginname'] = 'Seleccionar';
 $string['returnlabels'] = 'etiqueta del ítem seleccionado';
 $string['returnposition'] = 'contestación posicional';
 $string['returnvalues'] = 'valor del ítem seleccionado';
+$string['uerr_missingothertext'] = 'Por favor añada el texto requerido por su selección';
 $string['uerr_optionnotset'] = 'Por favor elija una opción';
 $string['userfriendlypluginname'] = 'Seleccionar';

--- a/field/select/lang/it/surveyprofield_select.php
+++ b/field/select/lang/it/surveyprofield_select.php
@@ -26,3 +26,4 @@
 require_once(dirname(dirname(dirname(dirname(dirname(__FILE__))))).'/lib.php');
 
 $string['uerr_optionnotset'] = 'Si selezioni una opzione';
+$string['uerr_missingothertext'] = 'Si aggiunga un contenuto al campo corrispondente alla selezione';


### PR DESCRIPTION
The select plugin was not checking the field "_text" when the option "other" was selected.