### PR TITLE
added condition for regex pattern

### DIFF
--- a/field/character/classes/field.php
+++ b/field/character/classes/field.php
@@ -303,7 +303,9 @@ class surveyprofield_character_field extends mod_surveypro_itembase {
      */
     public function item_get_generic_property($field) {
         if ($field == 'pattern') {
-            if ($this->pattern == SURVEYPROFIELD_CHARACTER_CUSTOMPATTERN) {
+            $condition = ($this->pattern == SURVEYPROFIELD_CHARACTER_CUSTOMPATTERN);
+            $condition = $condition || ($this->pattern == SURVEYPROFIELD_CHARACTER_REGEXPATTERN);
+            if ($condition) {
                 return $this->patterntext;
             } else {
                 return $this->pattern;


### PR DESCRIPTION
Saving a surveypro to usertemplate it was saved a wrong content in the pattern field.
Actually, when the surveypro designer choose to have a character item using regex validation, the pattern field is supposed to hold the regex anf not the kind of validation required.
The same behaviour was already in use for custom pattern.