### PR TITLE
added response_get_whereclause to autofill

### DIFF
--- a/field/autofill/classes/field.php
+++ b/field/autofill/classes/field.php
@@ -398,6 +398,24 @@ EOS;
         return false;
     }
 
+    // MARK response.
+
+    /**
+     * Report how the sql query does fit for this plugin
+     *
+     * @param int $itemid
+     * @param string $searchrestriction
+     * @return the specific where clause for this plugin
+     */
+    public static function response_get_whereclause($itemid, $searchrestriction) {
+        global $DB;
+
+        $whereclause = $DB->sql_like('a.content', ':content_'.$itemid, false);
+        $whereparam = '%'.$searchrestriction.'%';
+
+        return array($whereclause, $whereparam);
+    }
+
     // MARK userform.
 
     /**


### PR DESCRIPTION
A submission search using the autofill field was not successfull using substrings.
Now it is, so if my autofill field holds the user fullname, for instance, I can also search for the submissions of that user writing only a part of his/her name.