### PR TITLE
Update travis php73, 36_STABLE, OpenJDK...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: php
 
-sudo: false
+sudo: required
 
 addons:
   firefox: "47.0.1"
   postgresql: "9.4"
   apt:
     packages:
-      - oracle-java8-installer
-      - oracle-java8-set-default
+      - openjdk-8-jre-headless
 
 cache:
   directories:
@@ -16,6 +15,8 @@ cache:
     - $HOME/.npm
 
 php:
+ - 7.3
+ - 7.2
  - 7.1
  - 7.0
 
@@ -23,16 +24,41 @@ php:
 env:
   - MOODLE_BRANCH=master           DB=pgsql
   - MOODLE_BRANCH=master           DB=mysqli
+  - MOODLE_BRANCH=MOODLE_36_STABLE DB=pgsql
   - MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli
   - MOODLE_BRANCH=MOODLE_34_STABLE DB=pgsql
   - MOODLE_BRANCH=MOODLE_33_STABLE DB=mysqli
   - MOODLE_BRANCH=MOODLE_32_STABLE DB=pgsql
 
 matrix:
-  include:
-    - php: 5.6
+  exclude:
+    - php: 7.2
+      env: MOODLE_BRANCH=master           DB=mysqli
+    - php: 7.2
+      env: MOODLE_BRANCH=master           DB=pgsql
+    - php: 7.0
+      env: MOODLE_BRANCH=master           DB=mysqli
+    - php: 7.0
+      env: MOODLE_BRANCH=master           DB=pgsql
+    - php: 7.2
+      env: MOODLE_BRANCH=MOODLE_36_STABLE DB=pgsql
+    - php: 7.1
+      env: MOODLE_BRANCH=MOODLE_36_STABLE DB=pgsql
+    - php: 7.3
+      env: MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli
+    - php: 7.1
+      env: MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli
+    - php: 7.3
+      env: MOODLE_BRANCH=MOODLE_34_STABLE DB=pgsql
+    - php: 7.1
+      env: MOODLE_BRANCH=MOODLE_34_STABLE DB=pgsql
+    - php: 7.3
       env: MOODLE_BRANCH=MOODLE_33_STABLE DB=mysqli
-    - php: 5.6
+    - php: 7.2
+      env: MOODLE_BRANCH=MOODLE_33_STABLE DB=mysqli
+    - php: 7.3
+      env: MOODLE_BRANCH=MOODLE_32_STABLE DB=pgsql
+    - php: 7.2
       env: MOODLE_BRANCH=MOODLE_32_STABLE DB=pgsql
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,15 @@ env:
   - MOODLE_BRANCH=MOODLE_32_STABLE DB=pgsql
 
 matrix:
+  include:
+    # These are selected runs for behat, by default we don't want all combos running it
+    # so just pick the lowest version supported in each of the branches.
+    - php: 7.1
+      env: BEHAT=yes MOODLE_BRANCH=master           DB=mysqli
+    - php: 7.0
+      env: BEHAT=yes MOODLE_BRANCH=MOODLE_36_STABLE DB=pgsql
+    - php: 7.0
+      env: BEHAT=yes MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli
   exclude:
     - php: 7.2
       env: MOODLE_BRANCH=master           DB=mysqli
@@ -82,4 +91,6 @@ script:
   - moodle-plugin-ci mustache
   - moodle-plugin-ci grunt
 #  - moodle-plugin-ci phpunit
-#  - moodle-plugin-ci behat
+  - if [ $BEHAT == 'yes' ]; then
+        moodle-plugin-ci behat || travis_terminate 1;
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,6 @@ env:
   - MOODLE_BRANCH=master           DB=mysqli
   - MOODLE_BRANCH=MOODLE_36_STABLE DB=pgsql
   - MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli
-  - MOODLE_BRANCH=MOODLE_34_STABLE DB=pgsql
-  - MOODLE_BRANCH=MOODLE_33_STABLE DB=mysqli
-  - MOODLE_BRANCH=MOODLE_32_STABLE DB=pgsql
 
 matrix:
   include:
@@ -57,18 +54,6 @@ matrix:
       env: MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli
     - php: 7.1
       env: MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli
-    - php: 7.3
-      env: MOODLE_BRANCH=MOODLE_34_STABLE DB=pgsql
-    - php: 7.1
-      env: MOODLE_BRANCH=MOODLE_34_STABLE DB=pgsql
-    - php: 7.3
-      env: MOODLE_BRANCH=MOODLE_33_STABLE DB=mysqli
-    - php: 7.2
-      env: MOODLE_BRANCH=MOODLE_33_STABLE DB=mysqli
-    - php: 7.3
-      env: MOODLE_BRANCH=MOODLE_32_STABLE DB=pgsql
-    - php: 7.2
-      env: MOODLE_BRANCH=MOODLE_32_STABLE DB=pgsql
 
 before_install:
   - phpenv config-rm xdebug.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,12 @@ matrix:
   include:
     # These are selected runs for behat, by default we don't want all combos running it
     # so just pick the lowest version supported in each of the branches.
-    - php: 7.1
-      env: BEHAT=yes MOODLE_BRANCH=master           DB=mysqli
-    - php: 7.0
-      env: BEHAT=yes MOODLE_BRANCH=MOODLE_36_STABLE DB=pgsql
-    - php: 7.0
-      env: BEHAT=yes MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli
+    #- php: 7.1
+    #  env: BEHAT=yes MOODLE_BRANCH=master           DB=mysqli
+    #- php: 7.0
+    #  env: BEHAT=yes MOODLE_BRANCH=MOODLE_36_STABLE DB=pgsql
+    #- php: 7.0
+    #  env: BEHAT=yes MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli
   exclude:
     - php: 7.2
       env: MOODLE_BRANCH=master           DB=mysqli


### PR DESCRIPTION
General cleanup (see commit messages).

Adding support for 36_STABLE, PHP 7.3. Dropping support for PHP 5.6. Changed Java runtime to OpenJDK. Added support to behat, see:

https://travis-ci.org/stronk7/moodle-mod_surveypro/builds/484994009

But finally keeping it disabled because they timeout (too long for travis). If some day we are able to reduce the times... we could easily enable them back.

Ciao :-)