### PR TITLE
Generalised the has_input_items to layout_has_item

### DIFF
--- a/classes/formbase.php
+++ b/classes/formbase.php
@@ -87,7 +87,7 @@ class mod_surveypro_formbase {
         $canaccessreserveditems = has_capability('mod/surveypro:accessreserveditems', $this->context);
 
         $utilityman = new mod_surveypro_utility($this->cm, $this->surveypro);
-        if (!$utilityman->has_input_items(0, false, false, $canaccessreserveditems)) {
+        if (!$utilityman->layout_has_items(0, SURVEYPRO_TYPEFIELD, false, $canaccessreserveditems)) {
             $canmanageitems = has_capability('mod/surveypro:manageitems', $this->context);
 
             if ($canmanageitems) {

--- a/classes/layout.php
+++ b/classes/layout.php
@@ -141,7 +141,7 @@ class mod_surveypro_layout {
         $this->surveypro = $surveypro;
 
         $utilityman = new mod_surveypro_utility($cm, $surveypro);
-        $itemcount = $utilityman->has_input_items(0, true, true, true);
+        $itemcount = $utilityman->layout_has_items(0, null, true, true, true);
         $this->set_itemcount($itemcount);
     }
 
@@ -1363,7 +1363,7 @@ class mod_surveypro_layout {
             $utilityman->items_reindex($killedsortindex);
             $this->confirm = SURVEYPRO_ACTION_EXECUTED;
 
-            $itemcount = $utilityman->has_input_items(0, true, true, true);
+            $itemcount = $utilityman->layout_has_items(0, SURVEYPRO_TYPEFIELD, true, true, true);
             $this->set_itemcount($itemcount);
 
             $this->actionfeedback = new stdClass();

--- a/classes/submission.php
+++ b/classes/submission.php
@@ -94,7 +94,7 @@ class mod_surveypro_submission {
         $canaccessreserveditems = has_capability('mod/surveypro:accessreserveditems', $this->context);
 
         $utilityman = new mod_surveypro_utility($cm, $surveypro);
-        $this->hasitems = $utilityman->has_input_items(0, false, $canmanageitems, $canaccessreserveditems);
+        $this->hasitems = $utilityman->layout_has_items(0, SURVEYPRO_TYPEFIELD, $canmanageitems, $canaccessreserveditems);
     }
 
     /**

--- a/classes/utility.php
+++ b/classes/utility.php
@@ -112,15 +112,27 @@ class mod_surveypro_utility {
      * Return if the survey has input items.
      *
      * @param int $formpage
-     * @param int $returncount
+     * @param string $type
      * @param bool $includehidden
      * @param bool $includereserved
+     * @param int $returncount
      * @return bool|int as required by $returncount
      */
-    public function has_input_items($formpage=0, $returncount=false, $includehidden=false, $includereserved=false) {
+    public function layout_has_items($formpage=0, $type=null, $includehidden=false, $includereserved=false, $returncount=false) {
         global $DB;
 
-        $whereparams = array('surveyproid' => $this->surveypro->id, 'type' => SURVEYPRO_TYPEFIELD);
+        if (!empty($type)) {
+            if (($type != SURVEYPRO_TYPEFIELD) && ($type != SURVEYPRO_TYPEFORMAT)) {
+                $message = 'Unexpected value for $type found.';
+                $message .= 'Valid values are only: '.SURVEYPRO_TYPEFIELD.' or '.SURVEYPRO_TYPEFORMAT.'.';
+                debugging('Error at line '.__LINE__.' of file '.__FILE__.'. '.$message , DEBUG_DEVELOPER);
+            }
+        }
+
+        $whereparams = array('surveyproid' => $this->surveypro->id);
+        if (!empty($type)) {
+            $whereparams['type'] = $type;
+        }
         if (!empty($formpage)) {
             $whereparams['formpage'] = $formpage;
         }
@@ -1208,7 +1220,7 @@ class mod_surveypro_utility {
         $canaccessreserveditems = has_capability('mod/surveypro:accessreserveditems', $this->context);
         $canignoremaxentries = has_capability('mod/surveypro:ignoremaxentries', $this->context);
 
-        $itemcount = $this->has_input_items(0, true, $canmanageitems, $canaccessreserveditems);
+        $itemcount = $this->layout_has_items(0, SURVEYPRO_TYPEFIELD, $canmanageitems, $canaccessreserveditems, true);
 
         $addnew = true;
         $addnew = $addnew && $cansubmit;

--- a/classes/view_cover.php
+++ b/classes/view_cover.php
@@ -88,7 +88,7 @@ class mod_surveypro_view_cover {
 
         $riskyediting = ($this->surveypro->riskyeditdeadline > time());
         $hassubmissions = $utilityman->has_submissions();
-        $itemcount = $utilityman->has_input_items(0, true, $canmanageitems, $canaccessreserveditems);
+        $itemcount = $utilityman->layout_has_items(0, SURVEYPRO_TYPEFIELD, $canmanageitems, $canaccessreserveditems, true);
 
         $messages = array();
         $timenow = time();
@@ -125,7 +125,7 @@ class mod_surveypro_view_cover {
             if ($canmanageitems) {
                 // If I $canmanageitems in $itemcount items counted were: visible + hidden.
                 $message .= ' ';
-                $visibleonly = $utilityman->has_input_items(0, true, false, $canaccessreserveditems);
+                $visibleonly = $utilityman->layout_has_items(0, SURVEYPRO_TYPEFIELD, false, $canaccessreserveditems, true);
                 $a = $itemcount - $visibleonly;
                 $message .= get_string('count_hiddenitems', 'mod_surveypro', $a);
             }

--- a/layout_itemlist.php
+++ b/layout_itemlist.php
@@ -65,7 +65,7 @@ require_capability('mod/surveypro:manageitems', $context);
 // Calculations.
 $utilityman = new mod_surveypro_utility($cm, $surveypro);
 $hassubmissions = $utilityman->has_submissions();
-$itemcount = $utilityman->has_input_items(0, true, true, true);
+$itemcount = $utilityman->layout_has_items(0, SURVEYPRO_TYPEFIELD, true, true, true);
 
 // Define the manager.
 $layoutman = new mod_surveypro_layout($cm, $context, $surveypro);


### PR DESCRIPTION
Having a layout with 1 input item and many format items, the reorder icon was not displayed in layout->elements
This was caused by the wrong count of elements. Only input items were cunted and not ALL the items.