### PR TITLE
added method to get static content

### DIFF
--- a/format/fieldset/classes/format.php
+++ b/format/fieldset/classes/format.php
@@ -120,6 +120,15 @@ class surveyproformat_fieldset_format extends mod_surveypro_itembase {
     }
 
     /**
+     * Get content.
+     *
+     * @return the content of $content property
+     */
+    public function get_content() {
+        return s($this->content);
+    }
+
+    /**
      * Item_get_pdf_template.
      *
      * @return the template to use at response report creation

--- a/format/fieldsetend/classes/format.php
+++ b/format/fieldsetend/classes/format.php
@@ -95,12 +95,21 @@ class surveyproformat_fieldsetend_format extends mod_surveypro_itembase {
         // Now execute very specific plugin level actions.
 
         // Begin of: plugin specific settings (eventually overriding general ones).
-        // Override few values.
-        $record->content = SURVEYPROFORMAT_FIELDSETEND_CONTENT;
         // End of: plugin specific settings (eventually overriding general ones).
 
         // Do parent item saving stuff here (mod_surveypro_itembase::item_save($record))).
         return parent::item_save($record);
+    }
+
+    /**
+     * Get content.
+     *
+     * @return the content of $content property
+     */
+    public function get_content() {
+        $content = SURVEYPROFORMAT_FIELDSETEND_CONTENT;
+
+        return $content;
     }
 
     /**

--- a/format/pagebreak/classes/format.php
+++ b/format/pagebreak/classes/format.php
@@ -98,12 +98,21 @@ class surveyproformat_pagebreak_format extends mod_surveypro_itembase {
         // Now execute very specific plugin level actions.
 
         // Begin of: plugin specific settings (eventually overriding general ones).
-        // Override few values.
-        $record->content = SURVEYPROFORMAT_PAGEBREAK_CONTENT;
         // End of: plugin specific settings (eventually overriding general ones).
 
         // Do parent item saving stuff here (mod_surveypro_itembase::item_save($record))).
         return parent::item_save($record);
+    }
+
+    /**
+     * Get content.
+     *
+     * @return the content of $content property
+     */
+    public function get_content() {
+        $content = SURVEYPROFORMAT_PAGEBREAK_CONTENT;
+
+        return $content;
     }
 
     /**


### PR DESCRIPTION
Pagebreak and fieldsetend don't use content at all but they must be described with some sort of content when the list of item of a layout is requested. Because of this I added a method passing the the "static" content to the methods supposed to display the list of items.