### PR TITLE
replac. $usepositionalanswer prop. with get_uses_positional_answer meth.

### DIFF
--- a/classes/itembase.php
+++ b/classes/itembase.php
@@ -119,11 +119,6 @@ class mod_surveypro_itembase {
     protected $fieldsusingformat = array('content' => SURVEYPRO_ITEMCONTENTFILEAREA);
 
     /**
-     * @var bool Possibility for this plugin to save, as user answer, the position of the user interface elements in the out form
-     */
-    protected $usespositionalanswer = null;
-
-    /**
      * List of fields properties the surveypro creator will manage in the item definition form
      * By default each item property is present in the form
      * so, in each child class, I only need to "deactivate" item property not desired/needed/handled/wanted
@@ -1101,12 +1096,12 @@ EOS;
     }
 
     /**
-     * Get usespositionalanswer.
+     * Get if the plugin uses the position of options to save user answers.
      *
-     * @return the content of $usespositionalanswer property
+     * @return bool The plugin uses the position of options to save user answers.
      */
-    public function get_usespositionalanswer() {
-        return $this->usespositionalanswer;
+    public function get_uses_positional_answer() {
+        return false;
     }
 
     /**

--- a/classes/view_import.php
+++ b/classes/view_import.php
@@ -616,7 +616,7 @@ class mod_surveypro_view_import {
     /**
      * Get item helper.
      *
-     * @return $optionscountpercol ($optionscountpercol is available only for items with $item->get_usespositionalanswer() = 1)
+     * @return $optionscountpercol ($optionscountpercol is available only for items using positional answer)
      */
     public function buil_item_helpers() {
         $optionscountpercol = array(); // Elements only for items saving position to db.
@@ -650,7 +650,7 @@ class mod_surveypro_view_import {
             $itemhelper->plugin = $item->get_plugin();
             $itemhelper->content = $item->get_content();
             $itemhelper->required = $item->get_required();
-            $itemhelper->usespositionalanswer = $item->get_usespositionalanswer();
+            $itemhelper->usespositionalanswer = $item->get_uses_positional_answer();
             $itemhelper->usesoptionother = $item->get_usesoptionother();
             $itemhelper->parentid = $item->get_parentid();
             $itemhelper->parentvalue = $item->get_parentvalue();

--- a/field/age/classes/field.php
+++ b/field/age/classes/field.php
@@ -154,7 +154,9 @@ class surveyprofield_age_field extends mod_surveypro_itembase {
         // List of properties set to static values..
         $this->type = SURVEYPRO_TYPEFIELD;
         $this->plugin = 'age';
-        $this->usespositionalanswer = false;
+
+        // Override the list of fields using format, whether needed.
+        // Nothing to override, here.
 
         // Other element specific properties.
         $maximumage = get_config('surveyprofield_age', 'maximumage');

--- a/field/autofill/classes/field.php
+++ b/field/autofill/classes/field.php
@@ -184,7 +184,9 @@ class surveyprofield_autofill_field extends mod_surveypro_itembase {
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
         $this->plugin = 'autofill';
-        $this->usespositionalanswer = false;
+
+        // Override the list of fields using format, whether needed.
+        // Nothing to override, here.
 
         // Other element specific properties.
         // No properties here.

--- a/field/boolean/classes/field.php
+++ b/field/boolean/classes/field.php
@@ -124,7 +124,9 @@ class surveyprofield_boolean_field extends mod_surveypro_itembase {
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
         $this->plugin = 'boolean';
-        $this->usespositionalanswer = false;
+
+        // Override the list of fields using format, whether needed.
+        // Nothing to override, here.
 
         // Other element specific properties.
         // No properties here.

--- a/field/character/classes/field.php
+++ b/field/character/classes/field.php
@@ -146,7 +146,9 @@ class surveyprofield_character_field extends mod_surveypro_itembase {
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
         $this->plugin = 'character';
-        $this->usespositionalanswer = false;
+
+        // Override the list of fields using format, whether needed.
+        // Nothing to override, here.
 
         // Other element specific properties.
         // No properties here.

--- a/field/checkbox/classes/field.php
+++ b/field/checkbox/classes/field.php
@@ -165,7 +165,9 @@ class surveyprofield_checkbox_field extends mod_surveypro_itembase {
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
         $this->plugin = 'checkbox';
-        $this->usespositionalanswer = true;
+
+        // Override the list of fields using format, whether needed.
+        // Nothing to override, here.
 
         // Other element specific properties.
         // No properties here.
@@ -345,6 +347,15 @@ class surveyprofield_checkbox_field extends mod_surveypro_itembase {
         $fieldlist[$this->plugin] = array('content', 'extranote', 'options', 'labelother', 'defaultvalue');
 
         return $fieldlist;
+    }
+
+    /**
+     * Get if the plugin uses the position of options to save user answers.
+     *
+     * @return bool The plugin uses the position of options to save user answers.
+     */
+    public function get_uses_positional_answer() {
+        return true;
     }
 
     /**

--- a/field/date/classes/field.php
+++ b/field/date/classes/field.php
@@ -181,7 +181,9 @@ class surveyprofield_date_field extends mod_surveypro_itembase {
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
         $this->plugin = 'date';
-        $this->usespositionalanswer = false;
+
+        // Override the list of fields using format, whether needed.
+        // Nothing to override, here.
 
         // Other element specific properties.
         // No properties here.

--- a/field/datetime/classes/field.php
+++ b/field/datetime/classes/field.php
@@ -216,7 +216,9 @@ class surveyprofield_datetime_field extends mod_surveypro_itembase {
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
         $this->plugin = 'datetime';
-        $this->usespositionalanswer = false;
+
+        // Override the list of fields using format, whether needed.
+        // Nothing to override, here.
 
         // Other element specific properties.
         // No properties here.

--- a/field/fileupload/classes/field.php
+++ b/field/fileupload/classes/field.php
@@ -119,7 +119,9 @@ class surveyprofield_fileupload_field extends mod_surveypro_itembase {
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
         $this->plugin = 'fileupload';
-        $this->usespositionalanswer = false;
+
+        // Override the list of fields using format, whether needed.
+        // Nothing to override, here.
 
         // Other element specific properties.
         // No properties here.

--- a/field/integer/classes/field.php
+++ b/field/integer/classes/field.php
@@ -124,7 +124,9 @@ class surveyprofield_integer_field extends mod_surveypro_itembase {
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
         $this->plugin = 'integer';
-        $this->usespositionalanswer = false;
+
+        // Override the list of fields using format, whether needed.
+        // Nothing to override, here.
 
         // Other element specific properties.
         $maximuminteger = get_config('surveyprofield_integer', 'maximuminteger');

--- a/field/multiselect/classes/field.php
+++ b/field/multiselect/classes/field.php
@@ -134,7 +134,9 @@ class surveyprofield_multiselect_field extends mod_surveypro_itembase {
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
         $this->plugin = 'multiselect';
-        $this->usespositionalanswer = true;
+
+        // Override the list of fields using format, whether needed.
+        // Nothing to override, here.
 
         // Other element specific properties.
         // No properties here.
@@ -296,6 +298,15 @@ class surveyprofield_multiselect_field extends mod_surveypro_itembase {
         $fieldlist[$this->plugin] = array('content', 'extranote', 'options', 'defaultvalue');
 
         return $fieldlist;
+    }
+
+    /**
+     * Get if the plugin uses the position of options to save user answers.
+     *
+     * @return bool The plugin uses the position of options to save user answers.
+     */
+    public function get_uses_positional_answer() {
+        return true;
     }
 
     /**

--- a/field/numeric/classes/field.php
+++ b/field/numeric/classes/field.php
@@ -139,7 +139,9 @@ class surveyprofield_numeric_field extends mod_surveypro_itembase {
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
         $this->plugin = 'numeric';
-        $this->usespositionalanswer = false;
+
+        // Override the list of fields using format, whether needed.
+        // Nothing to override, here.
 
         // Other element specific properties.
         $this->decimalseparator = get_string('decsep', 'langconfig');

--- a/field/radiobutton/classes/field.php
+++ b/field/radiobutton/classes/field.php
@@ -134,7 +134,9 @@ class surveyprofield_radiobutton_field extends mod_surveypro_itembase {
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
         $this->plugin = 'radiobutton';
-        $this->usespositionalanswer = true;
+
+        // Override the list of fields using format, whether needed.
+        // Nothing to override, here.
 
         // Other element specific properties.
         // No properties here.
@@ -311,6 +313,15 @@ class surveyprofield_radiobutton_field extends mod_surveypro_itembase {
         $fieldlist[$this->plugin] = array('content', 'extranote', 'options', 'labelother', 'defaultvalue');
 
         return $fieldlist;
+    }
+
+    /**
+     * Get if the plugin uses the position of options to save user answers.
+     *
+     * @return bool The plugin uses the position of options to save user answers.
+     */
+    public function get_uses_positional_answer() {
+        return true;
     }
 
     /**

--- a/field/rate/classes/field.php
+++ b/field/rate/classes/field.php
@@ -144,7 +144,9 @@ class surveyprofield_rate_field extends mod_surveypro_itembase {
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
         $this->plugin = 'rate';
-        $this->usespositionalanswer = false;
+
+        // Override the list of fields using format, whether needed.
+        // Nothing to override, here.
 
         // Other element specific properties.
         // No properties here.

--- a/field/recurrence/classes/field.php
+++ b/field/recurrence/classes/field.php
@@ -164,7 +164,9 @@ class surveyprofield_recurrence_field extends mod_surveypro_itembase {
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
         $this->plugin = 'recurrence';
-        $this->usespositionalanswer = false;
+
+        // Override the list of fields using format, whether needed.
+        // Nothing to override, here.
 
         // Other element specific properties.
         $this->lowerbound = $this->item_recurrence_to_unix_time(1, 1);

--- a/field/select/classes/field.php
+++ b/field/select/classes/field.php
@@ -129,7 +129,9 @@ class surveyprofield_select_field extends mod_surveypro_itembase {
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
         $this->plugin = 'select';
-        $this->usespositionalanswer = true;
+
+        // Override the list of fields using format, whether needed.
+        // Nothing to override, here.
 
         // Other element specific properties.
         // No properties here.
@@ -305,6 +307,15 @@ class surveyprofield_select_field extends mod_surveypro_itembase {
         $fieldlist[$this->plugin] = array('content', 'extranote', 'options', 'labelother', 'defaultvalue');
 
         return $fieldlist;
+    }
+
+    /**
+     * Get if the plugin uses the position of options to save user answers.
+     *
+     * @return bool The plugin uses the position of options to save user answers.
+     */
+    public function get_uses_positional_answer() {
+        return true;
     }
 
     /**

--- a/field/shortdate/classes/field.php
+++ b/field/shortdate/classes/field.php
@@ -166,7 +166,9 @@ class surveyprofield_shortdate_field extends mod_surveypro_itembase {
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
         $this->plugin = 'shortdate';
-        $this->usespositionalanswer = false;
+
+        // Override the list of fields using format, whether needed.
+        // Nothing to override, here.
 
         // Other element specific properties.
         // No properties here.

--- a/field/textarea/classes/field.php
+++ b/field/textarea/classes/field.php
@@ -139,7 +139,9 @@ class surveyprofield_textarea_field extends mod_surveypro_itembase {
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
         $this->plugin = 'textarea';
-        $this->usespositionalanswer = false;
+
+        // Override the list of fields using format, whether needed.
+        // Nothing to override, here.
 
         // Other element specific properties.
         // No properties here.

--- a/field/time/classes/field.php
+++ b/field/time/classes/field.php
@@ -169,7 +169,9 @@ class surveyprofield_time_field extends mod_surveypro_itembase {
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFIELD;
         $this->plugin = 'time';
-        $this->usespositionalanswer = false;
+
+        // Override the list of fields using format, whether needed.
+        // Nothing to override, here.
 
         // Other element specific properties.
         // No properties here.

--- a/format/fieldset/classes/format.php
+++ b/format/fieldset/classes/format.php
@@ -62,8 +62,9 @@ class surveyproformat_fieldset_format extends mod_surveypro_itembase {
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFORMAT;
         $this->plugin = 'fieldset';
+
+        // Override the list of fields using format, whether needed.
         $this->fieldsusingformat = array();
-        $this->usespositionalanswer = false;
 
         // Other element specific properties.
         // No properties here.

--- a/format/fieldsetend/classes/format.php
+++ b/format/fieldsetend/classes/format.php
@@ -57,8 +57,9 @@ class surveyproformat_fieldsetend_format extends mod_surveypro_itembase {
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFORMAT;
         $this->plugin = 'fieldsetend';
+
+        // Override the list of fields using format, whether needed.
         $this->fieldsusingformat = array();
-        $this->usespositionalanswer = false;
 
         // Other element specific properties.
         // No properties here.

--- a/format/label/classes/format.php
+++ b/format/label/classes/format.php
@@ -89,7 +89,9 @@ class surveyproformat_label_format extends mod_surveypro_itembase {
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFORMAT;
         $this->plugin = 'label';
-        $this->usespositionalanswer = false;
+
+        // Override the list of fields using format, whether needed.
+        // Nothing to override, here.
 
         // Other element specific properties.
         // No properties here.

--- a/format/pagebreak/classes/format.php
+++ b/format/pagebreak/classes/format.php
@@ -57,8 +57,9 @@ class surveyproformat_pagebreak_format extends mod_surveypro_itembase {
         // List of properties set to static values.
         $this->type = SURVEYPRO_TYPEFORMAT;
         $this->plugin = 'pagebreak';
+
+        // Override the list of fields using format, whether needed.
         $this->fieldsusingformat = array();
-        $this->usespositionalanswer = false;
 
         // Other element specific properties.
         // No properties here.


### PR DESCRIPTION
Following the style used in #534 (and suggested in #527) I wrote this PR. The property $usepositionalanswer is no longer used and is replaced by get_uses_positional_answer method.