### PR TITLE
Make mysqli tests back to pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: required
 
 addons:
   firefox: "47.0.1"
+  mysql: "5.6"
   postgresql: "9.4"
   apt:
     packages:


### PR DESCRIPTION
recent changes in travis infrastructure (xenial now default)
requires it to be explicitly installed (via addon or service)