### PR TITLE
Move mysql to services

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,13 @@ sudo: required
 
 addons:
   firefox: "47.0.1"
-  mysql: "5.6"
   postgresql: "9.4"
   apt:
     packages:
       - openjdk-8-jre-headless
+
+services:
+  mysql
 
 cache:
   directories:


### PR DESCRIPTION
Not sure why it worked ok in my original commit. Anyway, it seems
that's the way recommended for travis (will use mysql 5.7 by
default on xenial