### PR TITLE
Fixed folder content validation

### DIFF
--- a/classes/mastertemplate.php
+++ b/classes/mastertemplate.php
@@ -106,7 +106,7 @@ class mod_surveypro_mastertemplate extends mod_surveypro_templatebase {
             'version.php'
         );
 
-        if ($masterfilelist !== $templatemastercontent) {
+        if (array_diff($masterfilelist, $templatemastercontent) || array_diff($templatemastercontent, $masterfilelist)) {
             $message = 'The "templatemaster" folder does not match the expected one. This is a security issue. I must stop.';
             debugging($message, DEBUG_DEVELOPER);
 


### PR DESCRIPTION
I got a strange error. It is the first time I get it.
Generating a master template an error execution stopped the process.
The error arrived because
    $masterfilelist was different from $templatemastercontent
and
    if ($masterfilelist !== $templatemastercontent) {
triggered the possible security issue.

Going to investigate about the issue I found that the templatemastercontent (what I expect to have in the folder)
was:
```
Array (
    [0] => classes/privacy/provider.php
    [1] => classes/template.php
    [2] => lang/en/surveyprotemplate_pluginname.php
    [3] => pix/icon.png
    [4] => pix/icon.svg
    [5] => template.xml
    [6] => version.php
)
```

while $masterfilelist (what actually is in the folder) was:
```
Array (
    [0] => classes/privacy/provider.php
    [1] => classes/template.php
    [2] => lang/en/surveyprotemplate_pluginname.php
    [3] => pix/icon.png
    [4] => pix/icon.svg
    [6] => template.xml
    [5] => version.php
)
```

$masterfilelist comes from the moodle core method "get_directory_list" so I preferred to change my code in order to have it working fine again.