### PR TITLE
swapped params in wrong implode($array, $separator)

### DIFF
--- a/field/boolean/classes/field.php
+++ b/field/boolean/classes/field.php
@@ -243,7 +243,7 @@ class surveyprofield_boolean_field extends mod_surveypro_itembase {
         $constraints[] = $optionstr.': 0';
         $constraints[] = $optionstr.': 1';
 
-        return implode($constraints, '<br />');
+        return implode('<br />', $constraints);
     }
 
     // MARK get.

--- a/field/checkbox/classes/field.php
+++ b/field/checkbox/classes/field.php
@@ -299,7 +299,7 @@ class surveyprofield_checkbox_field extends mod_surveypro_itembase {
             $constraints[] = $labelotherstr.$labelsep.$allowedstr;
         }
 
-        return implode($constraints, '<br />');
+        return implode('<br />', $constraints);
     }
 
     // MARK get.

--- a/field/integer/classes/field.php
+++ b/field/integer/classes/field.php
@@ -246,7 +246,7 @@ class surveyprofield_integer_field extends mod_surveypro_itembase {
         $constraints[] = get_string('lowerbound', 'surveyprofield_integer').$labelsep.$this->lowerbound;
         $constraints[] = get_string('upperbound', 'surveyprofield_integer').$labelsep.$this->upperbound;
 
-        return implode($constraints, '<br />');
+        return implode('<br />', $constraints);
     }
 
     // MARK get.

--- a/field/multiselect/classes/field.php
+++ b/field/multiselect/classes/field.php
@@ -250,7 +250,7 @@ class surveyprofield_multiselect_field extends mod_surveypro_itembase {
             $constraints[] = $optionstr.$labelsep.$value;
         }
 
-        return implode($constraints, '<br />');
+        return implode('<br />', $constraints);
     }
 
     // MARK get.

--- a/field/radiobutton/classes/field.php
+++ b/field/radiobutton/classes/field.php
@@ -265,7 +265,7 @@ class surveyprofield_radiobutton_field extends mod_surveypro_itembase {
             $constraints[] = $labelotherstr.$labelsep.$allowedstr;
         }
 
-        return implode($constraints, '<br />');
+        return implode('<br />', $constraints);
     }
 
     // MARK get.

--- a/field/select/classes/field.php
+++ b/field/select/classes/field.php
@@ -259,7 +259,7 @@ class surveyprofield_select_field extends mod_surveypro_itembase {
             $constraints[] = $labelotherstr.$labelsep.$allowedstr;
         }
 
-        return implode($constraints, '<br />');
+        return implode('<br />', $constraints);
     }
 
     // MARK get.

--- a/mod_form.php
+++ b/mod_form.php
@@ -206,7 +206,7 @@ class mod_surveypro_mod_form extends moodleform_mod {
 
         // Mailroles.
         if (isset($data->mailroles)) {
-            $data->mailroles = implode($data->mailroles, ',');
+            $data->mailroles = implode(',', $data->mailroles);
         } else {
             $data->mailroles = '';
         }


### PR DESCRIPTION
running surveypro after more than an year, I found "Deprecated: implode(): Passing glue string after array is deprecated. Swap the parameters in /Applications/MAMP/htdocs/master/mod/surveypro/mod_form.php on line 209"