### PR TITLE
Update to moodle-plugin-ci v3

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -1,0 +1,129 @@
+name: Moodle Plugin CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-18.04
+
+    services:
+      postgres:
+        image: postgres:9.6
+        env:
+          POSTGRES_USER: 'postgres'
+          POSTGRES_HOST_AUTH_METHOD: 'trust'
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
+      mariadb:
+        image: mariadb:10
+        env:
+          MYSQL_USER: 'root'
+          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 3
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: '7.4'
+            moodle-branch: 'master'
+            database: pgsql
+          - php: '7.4'
+            moodle-branch: 'MOODLE_311_STABLE'
+            database: mariadb
+          - php: '7.4'
+            moodle-branch: 'MOODLE_310_STABLE'
+            database: pgsql
+          - php: '7.3'
+            moodle-branch: 'MOODLE_39_STABLE'
+            database: mariadb
+          - php: '7.2'
+            moodle-branch: 'MOODLE_38_STABLE'
+            database: pgsql
+          - php: '7.1'
+            moodle-branch: 'MOODLE_35_STABLE'
+            database: mariadb
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          path: plugin
+
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.15.0'
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Initialise moodle-plugin-ci
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
+          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
+          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
+          sudo locale-gen en_AU.UTF-8
+
+      - name: Install moodle-plugin-ci
+        run: moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
+        env:
+          DB: ${{ matrix.database }}
+          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
+          # Examples or ignore directives:
+          IGNORE_PATHS: 'ignore'
+          IGNORE_NAMES: 'ignore_name.php'
+          MUSTACHE_IGNORE_NAMES: 'broken.mustache'
+
+      - name: PHP Lint
+        if: ${{ always() }}
+        run: moodle-plugin-ci phplint
+
+      - name: PHP Copy/Paste Detector
+        continue-on-error: true # This step will show errors but will not fail
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpcpd
+
+      - name: PHP Mess Detector
+        continue-on-error: true # This step will show errors but will not fail
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpmd
+
+      - name: Moodle Code Checker
+        if: ${{ always() }}
+        run: moodle-plugin-ci codechecker
+
+      - name: Moodle PHPDoc Checker
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpdoc
+
+      - name: Validating
+        if: ${{ always() }}
+        run: moodle-plugin-ci validate
+
+      - name: Check upgrade savepoints
+        if: ${{ always() }}
+        run: moodle-plugin-ci savepoints
+
+      - name: Mustache Lint
+        if: ${{ always() }}
+        run: moodle-plugin-ci mustache
+
+      - name: Grunt
+        if: ${{ always() }}
+        run: moodle-plugin-ci grunt
+
+      - name: PHPUnit tests
+        if: ${{ always() }}
+        run: |
+          moodle-plugin-ci phpunit
+
+      - name: Behat features
+        if: ${{ always() }}
+        run: moodle-plugin-ci behat --profile chrome

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,69 +1,38 @@
 language: php
 
-sudo: required
-
-addons:
-  firefox: "47.0.1"
-  postgresql: "9.4"
-  apt:
-    packages:
-      - openjdk-8-jre-headless
+os: linux
+dist: xenial
 
 services:
-  mysql
+  - mysql
+  - postgresql
+  - docker
 
 cache:
   directories:
     - $HOME/.composer/cache
     - $HOME/.npm
+    - $HOME/.nvm
 
-php:
- - 7.3
- - 7.2
- - 7.1
- - 7.0
-
-# This section sets up the environment variables for the build.
-env:
-  - MOODLE_BRANCH=master           DB=pgsql
-  - MOODLE_BRANCH=master           DB=mysqli
-  - MOODLE_BRANCH=MOODLE_36_STABLE DB=pgsql
-  - MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli
-
-matrix:
+jobs:
   include:
-    # These are selected runs for behat, by default we don't want all combos running it
-    # so just pick the lowest version supported in each of the branches.
-    #- php: 7.1
-    #  env: BEHAT=yes MOODLE_BRANCH=master           DB=mysqli
-    #- php: 7.0
-    #  env: BEHAT=yes MOODLE_BRANCH=MOODLE_36_STABLE DB=pgsql
-    #- php: 7.0
-    #  env: BEHAT=yes MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli
-  exclude:
-    - php: 7.2
-      env: MOODLE_BRANCH=master           DB=mysqli
-    - php: 7.2
-      env: MOODLE_BRANCH=master           DB=pgsql
-    - php: 7.0
-      env: MOODLE_BRANCH=master           DB=mysqli
-    - php: 7.0
-      env: MOODLE_BRANCH=master           DB=pgsql
-    - php: 7.2
-      env: MOODLE_BRANCH=MOODLE_36_STABLE DB=pgsql
-    - php: 7.1
-      env: MOODLE_BRANCH=MOODLE_36_STABLE DB=pgsql
+    - php: 7.4
+      env: MOODLE_BRANCH=master DB=pgsql
+    - php: 7.4
+      env: MOODLE_BRANCH=MOODLE_311_STABLE DB=mysqli
+    - php: 7.4
+      env: MOODLE_BRANCH=MOODLE_310_STABLE DB=pgsql
     - php: 7.3
-      env: MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli
+      env: MOODLE_BRANCH=MOODLE_39_STABLE DB=mysqli
+    - php: 7.2
+      env: MOODLE_BRANCH=MOODLE_38_STABLE DB=pgsql
     - php: 7.1
       env: MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli
 
 before_install:
   - phpenv config-rm xdebug.ini
-  - nvm install 8.9
-  - nvm use 8.9
   - cd ../..
-  - composer create-project -n --no-dev --prefer-dist moodlerooms/moodle-plugin-ci ci ^2
+  - composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
   - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
 
 install:
@@ -71,14 +40,13 @@ install:
 
 script:
   - moodle-plugin-ci phplint
-#  - moodle-plugin-ci phpcpd
-#  - moodle-plugin-ci phpmd
+  - moodle-plugin-ci phpcpd
+  - moodle-plugin-ci phpmd
   - moodle-plugin-ci codechecker
   - moodle-plugin-ci validate
   - moodle-plugin-ci savepoints
   - moodle-plugin-ci mustache
   - moodle-plugin-ci grunt
-#  - moodle-plugin-ci phpunit
-  - if [ $BEHAT == 'yes' ]; then
-        moodle-plugin-ci behat || travis_terminate 1;
-    fi
+  - moodle-plugin-ci phpdoc
+  - moodle-plugin-ci phpunit
+  - moodle-plugin-ci behat


### PR DESCRIPTION
Update to moodle-plugin-ci v3

This just updates to current moodle-plugin-ci v3 and renew
the combinations tested to current ones, matching the GHA ones.

Note this is built on top of #557 and needs to be merged AFTER it.