### PR TITLE
replaced curly braces with brackets

### DIFF
--- a/classes/utility_mform.php
+++ b/classes/utility_mform.php
@@ -51,7 +51,7 @@ class mod_surveypro_utility_mform {
                 if (file_exists($filepath) && is_dir($filepath)) {
                     $classfiles = scandir($filepath);
                     foreach ($classfiles as $classfile) {
-                        if ($classfile{0} == '.') { // Hidden files, '.' and '..'.
+                        if ($classfile[0] == '.') { // Hidden files, '.' and '..'.
                             continue;
                         }
                         $basename = basename($classfile, '.php');


### PR DESCRIPTION
Running behat test I found: 
Deprecated: Array and string offset access syntax with curly braces is deprecated in /Applications/MAMP/htdocs/master/mod/surveypro/classes/utility_mform.php on line 54