### PR TITLE
Get nodejs correct version installed

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -70,6 +70,7 @@ jobs:
           echo $(cd ci/bin; pwd) >> $GITHUB_PATH
           echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
           sudo locale-gen en_AU.UTF-8
+          echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
 
       - name: Install moodle-plugin-ci
         run: moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1


### PR DESCRIPTION
Following the 3.0.5 release of moodle-plugin-ci, where a bug
was fixed and requires to add a new line to the install script.

See ACTION REQUIRED:
  https://github.com/moodlehq/moodle-plugin-ci/releases/tag/3.0.5