### PR TITLE
Replaced `inline` with  `subform`

### DIFF
--- a/form/mtemplates/apply_form.php
+++ b/form/mtemplates/apply_form.php
@@ -45,7 +45,7 @@ class mod_surveypro_applymtemplateform extends moodleform {
 
         // Get _customdata.
         // Useless: $mtemplateman = $this->_customdata->mtemplateman;.
-        $inline = $this->_customdata->inline;
+        $subform = $this->_customdata->subform;
 
         if ($mtemplatepluginlist = get_plugin_list('surveyprotemplate')) {
             $mtemplates = array();
@@ -61,7 +61,7 @@ class mod_surveypro_applymtemplateform extends moodleform {
         // Applymtemplate: mastertemplate.
         if (count($mtemplates)) {
             $fieldname = 'mastertemplate';
-            if ($inline) {
+            if ($subform) {
                 $elementgroup = array();
                 $elementgroup[] = $mform->createElement('select', $fieldname, get_string($fieldname, 'mod_surveypro'), $mtemplates);
                 $elementgroup[] = $mform->createElement('submit', $fieldname.'_button', get_string('apply', 'mod_surveypro'));
@@ -96,7 +96,7 @@ class mod_surveypro_applymtemplateform extends moodleform {
 
         // Get _customdata.
         $mtemplateman = $this->_customdata->mtemplateman;
-        // Useless: $inline = $this->_customdata->inline;.
+        // Useless: $subform = $this->_customdata->subform;.
 
         $errors = parent::validation($data, $files);
 

--- a/layout_itemlist.php
+++ b/layout_itemlist.php
@@ -104,7 +104,7 @@ if (!$itemcount) { // The surveypro is empty.
 
     $formparams = new stdClass();
     $formparams->mtemplateman = $mtemplateman;
-    $formparams->inline = true;
+    $formparams->subform = true;
 
     // Init mtemplateform form.
     $mtemplateform = new mod_surveypro_applymtemplateform($formurl, $formparams);

--- a/mtemplate_apply.php
+++ b/mtemplate_apply.php
@@ -56,7 +56,7 @@ $formparams = new stdClass();
 $formparams->cmid = $cm->id;
 $formparams->surveypro = $surveypro;
 $formparams->mtemplateman = $mtemplateman;
-$formparams->inline = false;
+$formparams->subform = false;
 
 $applymtemplate = new mod_surveypro_applymtemplateform($formurl, $formparams);
 // End of: prepare params for the form.


### PR DESCRIPTION
Replaced `inline` variable name with a simpler to understand `subform` variable name