### PR TITLE
Changed regex to include questions without <p>

### DIFF
--- a/classes/itembase.php
+++ b/classes/itembase.php
@@ -892,7 +892,7 @@ class mod_surveypro_itembase {
      * @return string
      */
     public function include_customnumber_in_content() {
-        return preg_replace('~^(<p[^>]*)>~', '\1>'.$this->customnumber.': ', $this->get_content());
+        return preg_replace('~^(<p[^>]*>)?~', '\1'.$this->customnumber.': ', $this->get_content());
     }
 
     /**


### PR DESCRIPTION
Questions without \<p\> are not frequent but...
- they are the most common case into behat test
- I can not exclude users decide to use a plain text without using html editor