### PR TITLE
Changed the error message supposed to appear in the page

### DIFF
--- a/field/numeric/tests/behat/multiformat.feature
+++ b/field/numeric/tests/behat/multiformat.feature
@@ -49,7 +49,7 @@ Feature: verify the input with different number format
     And I press "Nuova risposta"
     And I set the field "Write the best approximation of π you can remember" to "3.14"
     And I press "Invia"
-    Then I should see "Provided value is not a number"
+    Then I should see "Il valore fornito non è un numero"
 
     And I set the field "Write the best approximation of π you can remember" to "3,14"
     And I press "Invia"


### PR DESCRIPTION
Few days ago I changed some italian string. It was a silly task and I did not run behat because the change was really silly.
In spite of this, I forget to update the scenario: 'submit the numeric field using two different formats' with the expected
italian sting.