### PR TITLE
Rewritten the regex to include customnumber

### DIFF
--- a/classes/itembase.php
+++ b/classes/itembase.php
@@ -892,7 +892,11 @@ class mod_surveypro_itembase {
      * @return string
      */
     public function include_customnumber_in_content() {
-        return preg_replace('~^(<p[^>]*>)?~', '\1'.$this->customnumber.': ', $this->get_content());
+        // $regex = '~^((<p[^>]*>)*)~'; // To get <p>1: <p>Question</p></p>.
+        $regex = '~^(<p[^>]*>)*~';
+        $replacement = '\0 '.$this->customnumber.': ';
+
+        return preg_replace($regex, $replacement, $this->get_content());
     }
 
     /**

--- a/field/boolean/tests/behat/customnumebr_inclusion.feature
+++ b/field/boolean/tests/behat/customnumebr_inclusion.feature
@@ -1,0 +1,46 @@
+@mod @mod_surveypro
+Feature: include custom numbers into element question/content
+  In order to verify the correct inclusion of the custom number at the beginning of the question
+  As a teacher
+  I create a surveypro with few boolean items, I assign a custom number to each item and I verify the text displays correctly.
+
+  @javascript
+  Scenario Outline: verify that custom numbers are correctly included
+    Given the following "courses" exist:
+      | fullname              | shortname | category | groupmode |
+      | Verify custom numbers | VerifyCN  | 0        | 0         |
+    And the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | 1        | teacher1@nowhere.net |
+    And the following "course enrolments" exist:
+      | user     | course   | role           |
+      | teacher1 | VerifyCN | editingteacher |
+    And the following "activities" exist:
+      | activity  | name            | intro                        | course   | idnumber   |
+      | surveypro | VerifyCN survey | Verify custom numbers survey | VerifyCN | surveypro1 |
+    And surveypro "VerifyCN survey" contains the following items:
+      | type  | plugin  |
+      | field | boolean |
+    And I log in as "teacher1"
+    And I am on "Verify custom numbers" course homepage
+    And I follow "Verify custom numbers"
+    And I follow "VerifyCN survey"
+    And I follow "Layout"
+    And I follow "edit_item_1"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Content        | <content>      |
+      | Element number | <customnumber> |
+    And I press "Save changes"
+    And I follow "Preview"
+    Then I should see "<output>"
+
+    Examples:
+      | content                                                              | customnumber  | output              |
+      | Is it true?                                                          | 1             | 1: Is it true?      |
+      | <p>Is it true?</p>                                                   | 2a            | 2a: Is it true?     |
+      | <p dir="ltr">Is it true?</p>                                         | III           | III: Is it true?    |
+      | <p dir="ltr"><em>Is it true?</em></p>                                | 4th           | 4th: Is it true?    |
+      | <p><p dir="ltr">Is it true?</p></p>                                  | 5)            | 5): Is it true?     |
+      | <p><p dir="ltr"><p class="lookatme">Is it true?</p></p></p>          | 6.a           | 6.a: Is it true?    |
+      | <p><p dir="ltr"><h3><p class="lookatme">Is it true?</p></h3></p></p> | 7.3-II        | 7.3-II: Is it true? |


### PR DESCRIPTION
I was addressed to find a way to include the question custom numer into the question content putting it close to the displayed text and not before the html tag <p>

Some examples:

Given
```'Is it true?'```
I want to get
```$customnumber.': '.'Is it true?'```

Given
```'<p>Is it true?</p>'```
I want to get
```'<p>'.$customnumber.': '.'Is it true?</p>'```

Given
```'<p dir="ltr">Is it true?</p>'```
I want to get
```'<p dir="ltr">'.$customnumber.': '.'Is it true?</p>'```

Given
```'<p dir="ltr"><em>Is it true?</em></p>'```
I want to get
```'<p dir="ltr">'.$customnumber.': '.'<em>Is it true?</em></p>'```

Given
```'<p><p dir="ltr">Is it true?<br></p></p>'```
I want to get
```'<p><p dir="ltr">'.$customnumber.': '.'Is it true?<br></p></p>'```
