### PR TITLE
Upgrades report to parent TAB

### DIFF
--- a/classes/reportbase.php
+++ b/classes/reportbase.php
@@ -74,8 +74,8 @@ class mod_surveypro_reportbase {
      *
      * @return array
      */
-    public function allowed_templates() {
-        return array();
+    public function report_applies_to() {
+        return array('each');
     }
 
     /**

--- a/classes/tabs.php
+++ b/classes/tabs.php
@@ -147,6 +147,14 @@ class mod_surveypro_tabs {
             }
         }
 
+        // TAB REPORTS.
+        if ($this->tabtab == SURVEYPRO_TABREPORTS) {
+            if ($this->tabpagesurl['tab_reports']['container']) {
+                $tabreportsname = get_string('tabreportsname', 'mod_surveypro');
+                $row[] = new tabobject($tabreportsname, null, $tabreportsname);
+            }
+        }
+
         // Array of tabs. Closes the tab row element definition.
         // Next tabs element is going to define the pages row.
         $this->tabs[] = $row;
@@ -319,6 +327,38 @@ class mod_surveypro_tabs {
                 if ($elementurl = $this->tabpagesurl['tab_mtemplate']['apply']) {
                     $strlabel = get_string('tabmtemplatepage2', 'mod_surveypro');
                     $row[] = new tabobject('idpage2', $elementurl->out(), $strlabel);
+                }
+
+                $this->tabs[] = $row;
+
+                break;
+            case SURVEYPRO_TABREPORTS:
+                $canaccessreports = has_capability('mod/surveypro:accessreports', $this->context);
+                $canaccessownreports = has_capability('mod/surveypro:accessownreports', $this->context);
+
+                $tabreportsname = get_string('tabreportsname', 'mod_surveypro');
+
+                $inactive = array($tabreportsname);
+                $activetwo = array($tabreportsname);
+
+                if ($surveyproreportlist = get_plugin_list('surveyproreport')) {
+                    $counter = 0;
+                    foreach ($surveyproreportlist as $reportname => $reportpath) {
+                        $classname = 'surveyproreport_'.$reportname.'_report';
+                        $reportman = new $classname($this->cm, $this->context, $this->surveypro);
+                        $report_applies_to = $reportman->report_applies_to();
+                        if (($report_applies_to == ['each']) || in_array($this->surveypro->template, $report_applies_to)) {
+                            if ($canaccessreports || ($reportman->has_student_report() && $canaccessownreports)) {
+                                if ($reportman->report_apply()) {
+                                    $counter++;
+                                    if ($elementurl = $this->tabpagesurl['tab_reports'][$reportname]) {
+                                        $strlabel = get_string('pluginname', 'surveyproreport_'.$reportname);
+                                        $row[] = new tabobject('idpage'.$counter, $elementurl->out(), $strlabel);
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
 
                 $this->tabs[] = $row;

--- a/classes/view_cover.php
+++ b/classes/view_cover.php
@@ -201,9 +201,8 @@ class mod_surveypro_view_cover {
             $classname = 'surveyproreport_'.$pluginname.'_report';
             $reportman = new $classname($this->cm, $this->context, $this->surveypro);
 
-            $allowedtemplates = $reportman->allowed_templates();
-
-            if ((!$allowedtemplates) || in_array($this->surveypro->template, $allowedtemplates)) {
+            $report_applies_to = $reportman->report_applies_to();
+            if (($report_applies_to == ['each']) || in_array($this->surveypro->template, $report_applies_to)) {
                 if ($canaccessreports || ($reportman->has_student_report() && $canaccessownreports)) {
                     if ($reportman->report_apply()) {
                         if ($childreports = $reportman->has_childreports($canaccessreports)) {

--- a/lang/en/surveypro.php
+++ b/lang/en/surveypro.php
@@ -58,6 +58,7 @@ $string['tabutemplatename'] = 'User templates';
 $string['tabmtemplatename'] = 'Master templates';
     $string['tabmtemplatepage1'] = 'Save';
     $string['tabmtemplatepage2'] = 'Apply';
+$string['tabreportsname'] = 'Reports';
 
 $string['action_help'] = 'Operate on elements already present in the survey with the following action.';
 $string['action'] = 'Preexisting elements';

--- a/lib.php
+++ b/lib.php
@@ -43,6 +43,7 @@ define('SURVEYPRO_TABLAYOUT'     , 1);
 define('SURVEYPRO_TABSUBMISSIONS', 2);
 define('SURVEYPRO_TABUTEMPLATES' , 3);
 define('SURVEYPRO_TABMTEMPLATES' , 4);
+define('SURVEYPRO_TABREPORTS'    , 5);
 
 /**
  * PAGES
@@ -73,6 +74,9 @@ define('SURVEYPRO_UTEMPLATES_APPLY' , 4);
 // PAGES in tab MASTER TEMPLATES.
 define('SURVEYPRO_MTEMPLATES_BUILD', 1);
 define('SURVEYPRO_MTEMPLATES_APPLY', 2);
+
+// PAGES in tab REPORTS.
+// I can not define constants for report pages because they are a subplugin and can be integrated with additional reports.
 
 /**
  * ITEM TYPES
@@ -889,9 +893,8 @@ function surveypro_extend_settings_navigation(settings_navigation $settings, nav
             $classname = 'surveyproreport_'.$reportname.'_report';
             $reportman = new $classname($cm, $context, $surveypro);
 
-            $allowedtemplates = $reportman->allowed_templates();
-
-            if ((!$allowedtemplates) || in_array($surveypro->template, $allowedtemplates)) {
+            $report_applies_to = $reportman->report_applies_to();
+            if (($report_applies_to == ['each']) || in_array($surveypro->template, $report_applies_to)) {
                 if ($canaccessreports || ($reportman->has_student_report() && $canaccessownreports)) {
                     if ($reportman->report_apply()) {
                         if (!isset($reportnode)) {

--- a/report/attachments/view.php
+++ b/report/attachments/view.php
@@ -84,7 +84,9 @@ $PAGE->set_heading($course->shortname);
 
 echo $OUTPUT->header();
 
-new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABSUBMISSIONS, SURVEYPRO_SUBMISSION_REPORT);
+$surveyproreportlist = get_plugin_list('surveyproreport');
+$reportkey = array_search('attachments', $surveyproreportlist);
+new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABREPORTS, $reportkey);
 
 $reportman->prevent_direct_user_input();
 $reportman->check_attachmentitems();

--- a/report/colles/classes/report.php
+++ b/report/colles/classes/report.php
@@ -145,7 +145,7 @@ class surveyproreport_colles_report extends mod_surveypro_reportbase {
      *
      * @return void
      */
-    public function allowed_templates() {
+    public function report_applies_to() {
         return array('collesactual', 'collespreferred', 'collesactualpreferred');
     }
 

--- a/report/colles/view.php
+++ b/report/colles/view.php
@@ -99,7 +99,9 @@ $PAGE->set_heading($course->shortname);
 
 echo $OUTPUT->header();
 
-new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABSUBMISSIONS, SURVEYPRO_SUBMISSION_REPORT);
+$surveyproreportlist = get_plugin_list('surveyproreport');
+$reportkey = array_search('colles', $surveyproreportlist);
+new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABREPORTS, $reportkey);
 
 $reportman->nosubmissions_stop();
 

--- a/report/delayedusers/view.php
+++ b/report/delayedusers/view.php
@@ -97,7 +97,10 @@ $PAGE->set_heading($course->shortname);
 
 echo $OUTPUT->header();
 
-new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABSUBMISSIONS, SURVEYPRO_SUBMISSION_REPORT);
+$surveyproreportlist = get_plugin_list('surveyproreport');
+$reportkey = array_search('delayedusers', $surveyproreportlist);
+new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABREPORTS, $reportkey);
+
 
 if ($showjumper) {
     $groupfilterform->set_data(array('groupid' => $groupid));

--- a/report/frequency/view.php
+++ b/report/frequency/view.php
@@ -77,7 +77,9 @@ $PAGE->set_heading($course->shortname);
 
 echo $OUTPUT->header();
 
-new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABSUBMISSIONS, SURVEYPRO_SUBMISSION_REPORT);
+$surveyproreportlist = get_plugin_list('surveyproreport');
+$reportkey = array_search('frequency', $surveyproreportlist);
+new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABREPORTS, $reportkey);
 
 $reportman->stop_if_textareas_only();
 

--- a/report/responsesperuser/view.php
+++ b/report/responsesperuser/view.php
@@ -84,7 +84,9 @@ $PAGE->set_heading($course->shortname);
 
 echo $OUTPUT->header();
 
-new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABSUBMISSIONS, SURVEYPRO_SUBMISSION_REPORT);
+$surveyproreportlist = get_plugin_list('surveyproreport');
+$reportkey = array_search('responsesperuser', $surveyproreportlist);
+new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABREPORTS, $reportkey);
 
 if ($showjumper) {
     $groupfilterform->set_data(array('groupid' => $groupid));

--- a/report/userspercount/view.php
+++ b/report/userspercount/view.php
@@ -84,7 +84,9 @@ $PAGE->set_heading($course->shortname);
 
 echo $OUTPUT->header();
 
-new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABSUBMISSIONS, SURVEYPRO_SUBMISSION_REPORT);
+$surveyproreportlist = get_plugin_list('surveyproreport');
+$reportkey = array_search('userspercount', $surveyproreportlist);
+new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABREPORTS, $reportkey);
 
 if ($showjumper) {
     $groupfilterform->set_data(array('groupid' => $groupid));

--- a/tests/behat/navigation.feature
+++ b/tests/behat/navigation.feature
@@ -77,22 +77,27 @@ Feature: verify urls really redirect to existing pages
     # Survey -> Dashboard: Reports section
     And I follow "Run Attachments overview report"
     # return home
+    And I follow "Survey" page in tab bar
     And I follow "Dashboard" page in tab bar
 
     And I follow "Run Delayed users report"
     # return home
+    And I follow "Survey" page in tab bar
     And I follow "Dashboard" page in tab bar
 
     And I follow "Run Frequency distribution report"
     # return home
+    And I follow "Survey" page in tab bar
     And I follow "Dashboard" page in tab bar
 
     And I follow "Run Responses per user report"
     # return home
+    And I follow "Survey" page in tab bar
     And I follow "Dashboard" page in tab bar
 
     And I follow "Run Users per count of responses report"
     # return home
+    And I follow "Survey" page in tab bar
     And I follow "Dashboard" page in tab bar
 
     # Survey -> Dashboard: User templates section


### PR DESCRIPTION
After a so long time far from surveypro I found that reports had the same dignity of usertemplate or mastertemplates but were sublocated in the child tab as a page of survey TAB.
This sounds not correct to my eyes today so I created the parent TAB_REPORT and I moved reports as its pages.