### PR TITLE
Swap view view cover

### DIFF
--- a/classes/event/all_submissions_viewed.php
+++ b/classes/event/all_submissions_viewed.php
@@ -70,7 +70,7 @@ class all_submissions_viewed extends \core\event\base {
     public function get_url() {
         $paramurl = array();
         $paramurl['id'] = $this->contextinstanceid;
-        return new \moodle_url('/mod/surveypro/view.php', $paramurl);
+        return new \moodle_url('/mod/surveypro/view_submissions.php', $paramurl);
     }
 
     /**

--- a/classes/event/submission_deleted.php
+++ b/classes/event/submission_deleted.php
@@ -70,7 +70,7 @@ class submission_deleted extends \core\event\base {
     public function get_url() {
         $paramurl = array();
         $paramurl['id'] = $this->contextinstanceid;
-        return new \moodle_url('/mod/surveypro/view.php', $paramurl);
+        return new \moodle_url('/mod/surveypro/view_submissions.php', $paramurl);
     }
 
     /**

--- a/classes/event/submission_duplicated.php
+++ b/classes/event/submission_duplicated.php
@@ -70,7 +70,7 @@ class submission_duplicated extends \core\event\base {
     public function get_url() {
         $paramurl = array();
         $paramurl['id'] = $this->contextinstanceid;
-        return new \moodle_url('/mod/surveypro/view.php', $paramurl);
+        return new \moodle_url('/mod/surveypro/view_submissions.php', $paramurl);
     }
 
     /**

--- a/classes/event/submissioninpdf_downloaded.php
+++ b/classes/event/submissioninpdf_downloaded.php
@@ -72,7 +72,7 @@ class submissioninpdf_downloaded extends \core\event\base {
         $paramurl['id'] = $this->contextinstanceid;
         $paramurl['submissionid'] = $this->objectid;
         $paramurl['view'] = $this->other['view'];
-        return new \moodle_url('/mod/surveypro/view.php', $paramurl);
+        return new \moodle_url('/mod/surveypro/view_submissions.php', $paramurl);
     }
 
     /**

--- a/classes/itembase.php
+++ b/classes/itembase.php
@@ -611,7 +611,7 @@ class mod_surveypro_itembase {
             if ($oldhidden != $newhidden) {
                 $action = ($oldhidden) ? SURVEYPRO_SHOWITEM : SURVEYPRO_HIDEITEM;
 
-                $layoutman = new mod_surveypro_layout($this->cm, $context, $this->surveypro);
+                $layoutman = new mod_surveypro_layout_itemsetup($this->cm, $context, $this->surveypro);
                 $layoutman->set_type($this->type);
                 $layoutman->set_plugin($this->plugin);
                 $layoutman->set_itemid($itemid);
@@ -637,7 +637,7 @@ class mod_surveypro_itembase {
             if ($oldreserved != $newreserved) {
                 $action = ($oldreserved) ? SURVEYPRO_MAKEAVAILABLE : SURVEYPRO_MAKERESERVED;
 
-                $layoutman = new mod_surveypro_layout($this->cm, $context, $this->surveypro);
+                $layoutman = new mod_surveypro_layout_itemsetup($this->cm, $context, $this->surveypro);
                 $layoutman->set_type($this->type);
                 $layoutman->set_plugin($this->plugin);
                 $layoutman->set_itemid($itemid);
@@ -902,7 +902,7 @@ class mod_surveypro_itembase {
     /**
      * This method defines if an item can be switched to mandatory or not.
      *
-     * Used by mod_surveypro_layout->display_items_table() to define the icon to show
+     * Used by mod_surveypro_layout_itemsetup->display_items_table() to define the icon to show
      *
      * @return boolean
      */

--- a/classes/layout_itemsetup.php
+++ b/classes/layout_itemsetup.php
@@ -31,7 +31,7 @@ defined('MOODLE_INTERNAL') || die();
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_surveypro_layout {
+class mod_surveypro_layout_itemsetup {
 
     /**
      * @var object Course module object

--- a/classes/mastertemplate.php
+++ b/classes/mastertemplate.php
@@ -508,7 +508,7 @@ class mod_surveypro_mastertemplate extends mod_surveypro_templatebase {
 
         if ($hassubmissions && (!$riskyediting)) {
             echo $OUTPUT->notification(get_string('applyusertemplatedenied01', 'mod_surveypro'), 'notifyproblem');
-            $url = new moodle_url('/mod/surveypro/view.php', array('s' => $this->surveypro->id));
+            $url = new moodle_url('/mod/surveypro/view_submissions.php', array('s' => $this->surveypro->id));
             echo $OUTPUT->continue_button($url);
             echo $OUTPUT->footer();
             die();

--- a/classes/tabs.php
+++ b/classes/tabs.php
@@ -350,7 +350,6 @@ class mod_surveypro_tabs {
                         if (($reportappliesto == ['each']) || in_array($this->surveypro->template, $reportappliesto)) {
                             if ($canaccessreports || ($reportman->has_student_report() && $canaccessownreports)) {
                                 if ($reportman->report_apply()) {
-                                    $counter++;
                                     if ($elementurl = $this->tabpagesurl['tab_reports'][$reportname]) {
                                         $strlabel = get_string('pluginname', 'surveyproreport_'.$reportname);
                                         $row[] = new tabobject('idpage'.$counter, $elementurl->out(), $strlabel);
@@ -358,6 +357,7 @@ class mod_surveypro_tabs {
                                 }
                             }
                         }
+                        $counter++;
                     }
                 }
 

--- a/classes/usertemplate.php
+++ b/classes/usertemplate.php
@@ -501,7 +501,7 @@ class mod_surveypro_usertemplate extends mod_surveypro_templatebase {
 
         if ($hassubmissions && (!$riskyediting)) {
             echo $OUTPUT->notification(get_string('applyusertemplatedenied01', 'mod_surveypro'), 'notifyproblem');
-            $url = new moodle_url('/mod/surveypro/view.php', array('s' => $this->surveypro->id));
+            $url = new moodle_url('/mod/surveypro/view_submissions.php', array('s' => $this->surveypro->id));
             echo $OUTPUT->continue_button($url);
             echo $OUTPUT->footer();
             die();

--- a/classes/view_form.php
+++ b/classes/view_form.php
@@ -995,7 +995,7 @@ class mod_surveypro_view_form extends mod_surveypro_formbase {
         if (!empty($this->surveypro->mailcontent)) {
             $fullname = fullname($USER);
             $surveyproname = $this->surveypro->name;
-            $url = $CFG->wwwroot.'/mod/surveypro/view.php?s='.$this->surveypro->id;
+            $url = $CFG->wwwroot.'/mod/surveypro/view_submissions.php?s='.$this->surveypro->id;
 
             $content = $this->surveypro->mailcontent;
             $originals = array('{FIRSTNAME}', '{LASTNAME}', '{FULLNAME}', '{COURSENAME}', '{SURVEYPRONAME}', '{SURVEYPROURL}');
@@ -1007,7 +1007,7 @@ class mod_surveypro_view_form extends mod_surveypro_formbase {
             $a->username = fullname($USER);
             $a->surveyproname = $this->surveypro->name;
             $a->title = get_string('reviewsubmissions', 'mod_surveypro');
-            $a->href = $CFG->wwwroot.'/mod/surveypro/view.php?s='.$this->surveypro->id;
+            $a->href = $CFG->wwwroot.'/mod/surveypro/view_submissions.php?s='.$this->surveypro->id;
 
             $content = get_string('newsubmissionbody', 'mod_surveypro', $a);
         }
@@ -1042,7 +1042,7 @@ class mod_surveypro_view_form extends mod_surveypro_formbase {
                 echo $OUTPUT->notification($message, 'notifyproblem');
 
                 $whereparams = array('id' => $this->cm->id);
-                $continueurl = new moodle_url('/mod/surveypro/view.php', $whereparams);
+                $continueurl = new moodle_url('/mod/surveypro/view_submissions.php', $whereparams);
 
                 echo $OUTPUT->continue_button($continueurl);
                 echo $OUTPUT->footer();

--- a/classes/view_search.php
+++ b/classes/view_search.php
@@ -69,7 +69,7 @@ class mod_surveypro_view_search {
     /**
      * Get the searchparamurl.
      *
-     * At the submission time of the seach form, define the $searchparamurl to send to view.php
+     * At the submission time of the seach form, define the $searchparamurl to send to view_submissions.php
      *
      * @return mixed $searchquery if a search was requested, void otherwise
      */

--- a/db/access.php
+++ b/db/access.php
@@ -86,7 +86,7 @@
  *      mod/surveypro:ignoremaxentries
  *
  *  SUB-TAB == SURVEYPRO_SUBMISSION_MANAGE
- *      $elementurl = new moodle_url('/mod/surveypro/view.php', $paramurl);
+ *      $elementurl = new moodle_url('/mod/surveypro/view_submissions.php', $paramurl);
  *
  *      mod/surveypro:alwaysseeowner
  *

--- a/field/age/tests/behat/use_advanced_elements.feature
+++ b/field/age/tests/behat/use_advanced_elements.feature
@@ -65,7 +65,9 @@ Feature: test the use of reserved elements
     When I log in as "student1"
     And I am on "Reserved elements" course homepage
     And I follow "Reserved element test"
+    And I follow "Responses"
     And I press "New response"
+
     Then I should see "1: First age item"
     Then I should not see "2: Second age item"
 
@@ -81,6 +83,7 @@ Feature: test the use of reserved elements
     When I log in as "teacher1"
     And I am on "Reserved elements" course homepage
     And I follow "Reserved element test"
+    And I follow "Responses" page in tab bar
     And I follow "edit_submission_row_1"
     Then I should see "1: First age item"
     Then I should see "2: Second age item"

--- a/index.php
+++ b/index.php
@@ -102,7 +102,7 @@ foreach ($surveypros as $surveypro) {
         $cellclass = array('class' => 'dimmed');
     }
 
-    $url = new moodle_url('/mod/surveypro/view.php', array('id' => $surveypro->coursemodule));
+    $url = new moodle_url('/mod/surveypro/view_submissions.php', array('id' => $surveypro->coursemodule));
     $inprogressresp = isset($inprogresssubmissions[$surveypro->id]) ? $inprogresssubmissions[$surveypro->id] : 0;
     $closedresp = isset($closedsubmissions[$surveypro->id]) ? $closedsubmissions[$surveypro->id] : 0;
 

--- a/layout_itemlist.php
+++ b/layout_itemlist.php
@@ -72,7 +72,7 @@ $hassubmissions = $utilitylayoutman->has_submissions();
 $itemcount = $utilitylayoutman->layout_has_items(0, SURVEYPRO_TYPEFIELD, true, true, true);
 
 // Define the manager.
-$layoutman = new mod_surveypro_layout($cm, $context, $surveypro);
+$layoutman = new mod_surveypro_layout_itemsetup($cm, $context, $surveypro);
 $layoutman->set_type($type);
 $layoutman->set_plugin($plugin);
 $layoutman->set_itemid($itemid);

--- a/layout_itemsetup.php
+++ b/layout_itemsetup.php
@@ -58,7 +58,7 @@ if ($action != SURVEYPRO_NOACTION) {
 $utilitylayoutman = new mod_surveypro_utility_layout($cm, $surveypro);
 $hassubmissions = $utilitylayoutman->has_submissions();
 
-$layoutman = new mod_surveypro_layout($cm, $context, $surveypro);
+$layoutman = new mod_surveypro_layout_itemsetup($cm, $context, $surveypro);
 if (!empty($typeplugin)) {
     $layoutman->set_typeplugin($typeplugin);
 } else {

--- a/layout_preview.php
+++ b/layout_preview.php
@@ -27,7 +27,6 @@ require_once($CFG->dirroot.'/mod/surveypro/form/outform/fill_form.php');
 
 $id = optional_param('id', 0, PARAM_INT); // Course_module id.
 $s = optional_param('s', 0, PARAM_INT);   // Surveypro instance id.
-$edit = optional_param('edit', -1, PARAM_BOOL);
 
 if (!empty($id)) {
     $cm = get_coursemodule_from_id('surveypro', $id, 0, false, MUST_EXIST);
@@ -38,12 +37,14 @@ if (!empty($id)) {
     $course = $DB->get_record('course', array('id' => $surveypro->course), '*', MUST_EXIST);
     $cm = get_coursemodule_from_instance('surveypro', $surveypro->id, $course->id, false, MUST_EXIST);
 }
+$cm = cm_info::create($cm);
 
-require_course_login($course, true, $cm);
-
-$context = context_module::instance($cm->id);
 $formpage = optional_param('formpage', 0, PARAM_INT); // Form page number.
 $submissionid = optional_param('submissionid', 0, PARAM_INT);
+$edit = optional_param('edit', -1, PARAM_BOOL);
+
+require_course_login($course, false, $cm);
+$context = context_module::instance($cm->id);
 
 // Calculations.
 mod_surveypro_utility_mform::register_form_elements();
@@ -124,6 +125,12 @@ if ($PAGE->user_allowed_editing()) {
 }
 
 echo $OUTPUT->header();
+echo $OUTPUT->heading(format_string($surveypro->name), 2, null);
+
+// Render the activity information.
+$completiondetails = \core_completion\cm_completion_details::get_instance($cm, $USER->id);
+$activitydates = \core\activity_dates::get_dates_for_module($cm, $USER->id);
+echo $OUTPUT->activity_information($cm, $completiondetails, $activitydates);
 
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABLAYOUT, SURVEYPRO_LAYOUT_PREVIEW);
 

--- a/layout_validation.php
+++ b/layout_validation.php
@@ -35,10 +35,12 @@ if (!empty($id)) {
     $course = $DB->get_record('course', array('id' => $surveypro->course), '*', MUST_EXIST);
     $cm = get_coursemodule_from_instance('surveypro', $surveypro->id, $course->id, false, MUST_EXIST);
 }
+$cm = cm_info::create($cm);
 
-require_course_login($course, true, $cm);
-
+require_course_login($course, false, $cm);
 $context = context_module::instance($cm->id);
+
+// Required capability.
 require_capability('mod/surveypro:additems', $context);
 
 // Calculations.
@@ -93,6 +95,12 @@ $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
 echo $OUTPUT->header();
+echo $OUTPUT->heading(format_string($surveypro->name), 2, null);
+
+// Render the activity information.
+$completiondetails = \core_completion\cm_completion_details::get_instance($cm, $USER->id);
+$activitydates = \core\activity_dates::get_dates_for_module($cm, $USER->id);
+echo $OUTPUT->activity_information($cm, $completiondetails, $activitydates);
 
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABLAYOUT, SURVEYPRO_LAYOUT_VALIDATE);
 

--- a/layout_validation.php
+++ b/layout_validation.php
@@ -45,7 +45,7 @@ require_capability('mod/surveypro:additems', $context);
 
 // Calculations.
 
-$layoutman = new mod_surveypro_layout($cm, $context, $surveypro);
+$layoutman = new mod_surveypro_layout_itemsetup($cm, $context, $surveypro);
 
 // Property type is useless, do not set it.
 // $layoutman->set_type('');

--- a/mtemplate_apply.php
+++ b/mtemplate_apply.php
@@ -37,10 +37,12 @@ if (!empty($id)) {
     $course = $DB->get_record('course', array('id' => $surveypro->course), '*', MUST_EXIST);
     $cm = get_coursemodule_from_instance('surveypro', $surveypro->id, $course->id, false, MUST_EXIST);
 }
+$cm = cm_info::create($cm);
 
-require_course_login($course, true, $cm);
-
+require_course_login($course, false, $cm);
 $context = context_module::instance($cm->id);
+
+// Required capability.
 require_capability('mod/surveypro:applymastertemplates', $context);
 
 // Calculations.
@@ -81,6 +83,12 @@ $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
 echo $OUTPUT->header();
+echo $OUTPUT->heading(format_string($surveypro->name), 2, null);
+
+// Render the activity information.
+$completiondetails = \core_completion\cm_completion_details::get_instance($cm, $USER->id);
+$activitydates = \core\activity_dates::get_dates_for_module($cm, $USER->id);
+echo $OUTPUT->activity_information($cm, $completiondetails, $activitydates);
 
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABMTEMPLATES, SURVEYPRO_MTEMPLATES_APPLY);
 

--- a/mtemplate_save.php
+++ b/mtemplate_save.php
@@ -37,10 +37,12 @@ if (!empty($id)) {
     $course = $DB->get_record('course', array('id' => $surveypro->course), '*', MUST_EXIST);
     $cm = get_coursemodule_from_instance('surveypro', $surveypro->id, $course->id, false, MUST_EXIST);
 }
+$cm = cm_info::create($cm);
 
-require_course_login($course, true, $cm);
-
+require_course_login($course, false, $cm);
 $context = context_module::instance($cm->id);
+
+// Required capability.
 require_capability('mod/surveypro:savemastertemplates', $context);
 
 // Calculations.
@@ -69,6 +71,12 @@ $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
 echo $OUTPUT->header();
+echo $OUTPUT->heading(format_string($surveypro->name), 2, null);
+
+// Render the activity information.
+$completiondetails = \core_completion\cm_completion_details::get_instance($cm, $USER->id);
+$activitydates = \core\activity_dates::get_dates_for_module($cm, $USER->id);
+echo $OUTPUT->activity_information($cm, $completiondetails, $activitydates);
 
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABMTEMPLATES, SURVEYPRO_MTEMPLATES_BUILD);
 

--- a/report/attachments/classes/report.php
+++ b/report/attachments/classes/report.php
@@ -191,9 +191,6 @@ class surveyproreport_attachments_report extends mod_surveypro_reportbase {
      * @return void
      */
     public function output_data() {
-        global $OUTPUT;
-
-        echo $OUTPUT->heading(get_string('pluginname', 'surveyproreport_attachments'));
         $this->outputtable->print_html();
     }
 

--- a/report/attachments/view.php
+++ b/report/attachments/view.php
@@ -28,6 +28,7 @@ require_once($CFG->libdir.'/tablelib.php');
 
 $id = optional_param('id', 0, PARAM_INT);
 $s = optional_param('s', 0, PARAM_INT);
+
 if (!empty($id)) {
     $cm = get_coursemodule_from_id('surveypro', $id, 0, false, MUST_EXIST);
     $course = $DB->get_record('course', array('id' => $cm->course), '*', MUST_EXIST);
@@ -37,11 +38,14 @@ if (!empty($id)) {
     $course = $DB->get_record('course', array('id' => $surveypro->course), '*', MUST_EXIST);
     $cm = get_coursemodule_from_instance('surveypro', $surveypro->id, $course->id, false, MUST_EXIST);
 }
+$cm = cm_info::create($cm);
+
 $groupid = optional_param('groupid', 0, PARAM_INT);
 
-require_course_login($course, true, $cm);
-
+require_course_login($course, false, $cm);
 $context = context_module::instance($cm->id);
+
+// Required capability.
 require_capability('mod/surveypro:accessreports', $context);
 
 $reportman = new surveyproreport_attachments_report($cm, $context, $surveypro);
@@ -83,9 +87,15 @@ $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
 echo $OUTPUT->header();
+echo $OUTPUT->heading(format_string($surveypro->name), 2, null);
+
+// Render the activity information.
+$completiondetails = \core_completion\cm_completion_details::get_instance($cm, $USER->id);
+$activitydates = \core\activity_dates::get_dates_for_module($cm, $USER->id);
+echo $OUTPUT->activity_information($cm, $completiondetails, $activitydates);
 
 $surveyproreportlist = get_plugin_list('surveyproreport');
-$reportkey = array_search('attachments', $surveyproreportlist);
+$reportkey = array_search('attachments', array_keys($surveyproreportlist));
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABREPORTS, $reportkey);
 
 $reportman->prevent_direct_user_input();

--- a/report/colles/graph.php
+++ b/report/colles/graph.php
@@ -28,17 +28,18 @@ require_once($CFG->dirroot.'/mod/surveypro/report/colles/lib.php');
 
 $id = required_param('id', PARAM_INT); // Course Module ID.
 $type = required_param('type', PARAM_ALPHA); // Report type.
-$groupid = optional_param('groupid', 0, PARAM_INT); // Group ID.
-$area = optional_param('area', 0, PARAM_INT);  // Report area.
-$qid = optional_param('qid', 0, PARAM_INT);  // Question ID.
 
 $cm = get_coursemodule_from_id('surveypro', $id, 0, false, MUST_EXIST);
 $course = $DB->get_record('course', array('id' => $cm->course), '*', MUST_EXIST);
 $surveypro = $DB->get_record('surveypro', array('id' => $cm->instance), '*', MUST_EXIST);
 
-$context = context_module::instance($cm->id);
+$groupid = optional_param('groupid', 0, PARAM_INT); // Group ID.
+$area = optional_param('area', 0, PARAM_INT);  // Report area.
+$qid = optional_param('qid', 0, PARAM_INT);  // Question ID.
 
 require_login($course, false, $cm);
+
+$context = context_module::instance($cm->id);
 
 if ($type == 'summary') {
     if (!has_capability('mod/surveypro:accessreports', $context)) {

--- a/report/colles/view.php
+++ b/report/colles/view.php
@@ -28,6 +28,7 @@ require_once($CFG->libdir.'/tablelib.php');
 
 $id = optional_param('id', 0, PARAM_INT);
 $s = optional_param('s', 0, PARAM_INT);
+
 if (!empty($id)) {
     $cm = get_coursemodule_from_id('surveypro', $id, 0, false, MUST_EXIST);
     $course = $DB->get_record('course', array('id' => $cm->course), '*', MUST_EXIST);
@@ -37,13 +38,14 @@ if (!empty($id)) {
     $course = $DB->get_record('course', array('id' => $surveypro->course), '*', MUST_EXIST);
     $cm = get_coursemodule_from_instance('surveypro', $surveypro->id, $course->id, false, MUST_EXIST);
 }
+$cm = cm_info::create($cm);
 
 $type = optional_param('type', 'summary', PARAM_ALPHA);  // Type of graph.
 $area = optional_param('area', false, PARAM_INT);  // Area ID.
 
-require_course_login($course, true, $cm);
-
+require_course_login($course, false, $cm);
 $context = context_module::instance($cm->id);
+
 if ($type == 'summary') {
     if (!has_capability('mod/surveypro:accessreports', $context)) {
         require_capability('mod/surveypro:accessownreports', $context);
@@ -97,9 +99,15 @@ $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
 echo $OUTPUT->header();
+echo $OUTPUT->heading(format_string($surveypro->name), 2, null);
+
+// Render the activity information.
+$completiondetails = \core_completion\cm_completion_details::get_instance($cm, $USER->id);
+$activitydates = \core\activity_dates::get_dates_for_module($cm, $USER->id);
+echo $OUTPUT->activity_information($cm, $completiondetails, $activitydates);
 
 $surveyproreportlist = get_plugin_list('surveyproreport');
-$reportkey = array_search('colles', $surveyproreportlist);
+$reportkey = array_search('colles', array_keys($surveyproreportlist));
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABREPORTS, $reportkey);
 
 $reportman->nosubmissions_stop();

--- a/report/frequency/classes/report.php
+++ b/report/frequency/classes/report.php
@@ -107,7 +107,7 @@ class surveyproreport_frequency_report extends mod_surveypro_reportbase {
         $countfields = $DB->count_records_select('surveypro_item', $where, $params);
         if (!$countfields) {
             echo $OUTPUT->box(get_string('textareasarenotallowed', 'surveyproreport_frequency'));
-            $url = new moodle_url('/mod/surveypro/view.php', array('s' => $this->surveypro->id));
+            $url = new moodle_url('/mod/surveypro/view_submissions.php', array('s' => $this->surveypro->id));
             echo $OUTPUT->continue_button($url);
             echo $OUTPUT->footer();
             die();

--- a/report/frequency/graph.php
+++ b/report/frequency/graph.php
@@ -28,15 +28,17 @@ require_once($CFG->dirroot.'/mod/surveypro/report/frequency/lib.php');
 
 $id = required_param('id', PARAM_INT); // Course Module ID.
 $itemid = required_param('itemid', PARAM_INT); // Item ID.
-$groupid = optional_param('groupid', 0, PARAM_INT); // Group ID.
 
 $cm = get_coursemodule_from_id('surveypro', $id, 0, false, MUST_EXIST);
 $course = $DB->get_record('course', array('id' => $cm->course), '*', MUST_EXIST);
 $surveypro = $DB->get_record('surveypro', array('id' => $cm->instance), '*', MUST_EXIST);
 
-$context = context_module::instance($cm->id);
+$groupid = optional_param('groupid', 0, PARAM_INT); // Group ID.
 
 require_login($course, false, $cm);
+$context = context_module::instance($cm->id);
+
+// Required capability.
 require_capability('mod/surveypro:accessreports', $context);
 
 $reportman = new surveyproreport_frequency_report($cm, $context, $surveypro);

--- a/report/lateusers/classes/report.php
+++ b/report/lateusers/classes/report.php
@@ -161,9 +161,6 @@ class surveyproreport_lateusers_report extends mod_surveypro_reportbase {
      * Output_data
      */
     public function output_data() {
-        global $OUTPUT;
-
-        echo $OUTPUT->heading(get_string('pluginname', 'surveyproreport_lateusers'));
         $this->outputtable->print_html();
     }
 }

--- a/report/lateusers/view.php
+++ b/report/lateusers/view.php
@@ -28,6 +28,7 @@ require_once($CFG->libdir.'/tablelib.php');
 
 $id = optional_param('id', 0, PARAM_INT);
 $s = optional_param('s', 0, PARAM_INT);
+
 if (!empty($id)) {
     $cm = get_coursemodule_from_id('surveypro', $id, 0, false, MUST_EXIST);
     $course = $DB->get_record('course', array('id' => $cm->course), '*', MUST_EXIST);
@@ -37,11 +38,14 @@ if (!empty($id)) {
     $course = $DB->get_record('course', array('id' => $surveypro->course), '*', MUST_EXIST);
     $cm = get_coursemodule_from_instance('surveypro', $surveypro->id, $course->id, false, MUST_EXIST);
 }
+$cm = cm_info::create($cm);
+
 $groupid = optional_param('groupid', 0, PARAM_INT);
 
-require_course_login($course, true, $cm);
-
+require_course_login($course, false, $cm);
 $context = context_module::instance($cm->id);
+
+// Required capability.
 require_capability('mod/surveypro:accessreports', $context);
 
 $reportman = new surveyproreport_lateusers_report($cm, $context, $surveypro);
@@ -96,11 +100,16 @@ $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
 echo $OUTPUT->header();
+echo $OUTPUT->heading(format_string($surveypro->name), 2, null);
+
+// Render the activity information.
+$completiondetails = \core_completion\cm_completion_details::get_instance($cm, $USER->id);
+$activitydates = \core\activity_dates::get_dates_for_module($cm, $USER->id);
+echo $OUTPUT->activity_information($cm, $completiondetails, $activitydates);
 
 $surveyproreportlist = get_plugin_list('surveyproreport');
-$reportkey = array_search('delayedusers', $surveyproreportlist);
+$reportkey = array_search('lateusers', array_keys($surveyproreportlist));
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABREPORTS, $reportkey);
-
 
 if ($showjumper) {
     $groupfilterform->set_data(array('groupid' => $groupid));

--- a/report/responsesperuser/classes/report.php
+++ b/report/responsesperuser/classes/report.php
@@ -161,9 +161,6 @@ class surveyproreport_responsesperuser_report extends mod_surveypro_reportbase {
      * Output_data
      */
     public function output_data() {
-        global $OUTPUT;
-
-        echo $OUTPUT->heading(get_string('pluginname', 'surveyproreport_responsesperuser'));
         $this->outputtable->print_html();
     }
 }

--- a/report/responsesperuser/view.php
+++ b/report/responsesperuser/view.php
@@ -28,6 +28,7 @@ require_once($CFG->libdir.'/tablelib.php');
 
 $id = optional_param('id', 0, PARAM_INT);
 $s = optional_param('s', 0, PARAM_INT);
+
 if (!empty($id)) {
     $cm = get_coursemodule_from_id('surveypro', $id, 0, false, MUST_EXIST);
     $course = $DB->get_record('course', array('id' => $cm->course), '*', MUST_EXIST);
@@ -37,11 +38,14 @@ if (!empty($id)) {
     $course = $DB->get_record('course', array('id' => $surveypro->course), '*', MUST_EXIST);
     $cm = get_coursemodule_from_instance('surveypro', $surveypro->id, $course->id, false, MUST_EXIST);
 }
+$cm = cm_info::create($cm);
+
 $groupid = optional_param('groupid', 0, PARAM_INT);
 
-require_course_login($course, true, $cm);
-
+require_course_login($course, false, $cm);
 $context = context_module::instance($cm->id);
+
+// Required capability.
 require_capability('mod/surveypro:accessreports', $context);
 
 $reportman = new surveyproreport_responsesperuser_report($cm, $context, $surveypro);
@@ -83,9 +87,15 @@ $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
 echo $OUTPUT->header();
+echo $OUTPUT->heading(format_string($surveypro->name), 2, null);
+
+// Render the activity information.
+$completiondetails = \core_completion\cm_completion_details::get_instance($cm, $USER->id);
+$activitydates = \core\activity_dates::get_dates_for_module($cm, $USER->id);
+echo $OUTPUT->activity_information($cm, $completiondetails, $activitydates);
 
 $surveyproreportlist = get_plugin_list('surveyproreport');
-$reportkey = array_search('responsesperuser', $surveyproreportlist);
+$reportkey = array_search('responsesperuser', array_keys($surveyproreportlist));
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABREPORTS, $reportkey);
 
 if ($showjumper) {

--- a/report/userspercount/classes/report.php
+++ b/report/userspercount/classes/report.php
@@ -151,9 +151,6 @@ class surveyproreport_userspercount_report extends mod_surveypro_reportbase {
      * Output_data
      */
     public function output_data() {
-        global $OUTPUT;
-
-        echo $OUTPUT->heading(get_string('pluginname', 'surveyproreport_userspercount'));
         $this->outputtable->print_html();
     }
 }

--- a/report/userspercount/view.php
+++ b/report/userspercount/view.php
@@ -28,6 +28,7 @@ require_once($CFG->libdir.'/tablelib.php');
 
 $id = optional_param('id', 0, PARAM_INT);
 $s = optional_param('s', 0, PARAM_INT);
+
 if (!empty($id)) {
     $cm = get_coursemodule_from_id('surveypro', $id, 0, false, MUST_EXIST);
     $course = $DB->get_record('course', array('id' => $cm->course), '*', MUST_EXIST);
@@ -37,11 +38,14 @@ if (!empty($id)) {
     $course = $DB->get_record('course', array('id' => $surveypro->course), '*', MUST_EXIST);
     $cm = get_coursemodule_from_instance('surveypro', $surveypro->id, $course->id, false, MUST_EXIST);
 }
+$cm = cm_info::create($cm);
+
 $groupid = optional_param('groupid', 0, PARAM_INT);
 
-require_course_login($course, true, $cm);
-
+require_course_login($course, false, $cm);
 $context = context_module::instance($cm->id);
+
+// Required capability.
 require_capability('mod/surveypro:accessreports', $context);
 
 $reportman = new surveyproreport_userspercount_report($cm, $context, $surveypro);
@@ -83,9 +87,15 @@ $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
 echo $OUTPUT->header();
+echo $OUTPUT->heading(format_string($surveypro->name), 2, null);
+
+// Render the activity information.
+$completiondetails = \core_completion\cm_completion_details::get_instance($cm, $USER->id);
+$activitydates = \core\activity_dates::get_dates_for_module($cm, $USER->id);
+echo $OUTPUT->activity_information($cm, $completiondetails, $activitydates);
 
 $surveyproreportlist = get_plugin_list('surveyproreport');
-$reportkey = array_search('userspercount', $surveyproreportlist);
+$reportkey = array_search('userspercount', array_keys($surveyproreportlist));
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABREPORTS, $reportkey);
 
 if ($showjumper) {

--- a/tests/behat/preserve_autofillpersonaldata.feature
+++ b/tests/behat/preserve_autofillpersonaldata.feature
@@ -111,7 +111,7 @@ Feature: editing a submission, autofill userID is not overwritten
     When I log in as "student2"
     And I am on "Course divided into groups" course homepage
     And I follow "Preserve autofill"
-
+    And I follow "Responses"
     And I follow "edit_submission_row_1"
     Then the field "Your first name" matches value "student1"
     Then the field "Your last name" matches value "user1"
@@ -126,6 +126,7 @@ Feature: editing a submission, autofill userID is not overwritten
     When I log in as "student1"
     And I am on "Course divided into groups" course homepage
     And I follow "Preserve autofill"
+    And I follow "Responses"
 
     And I follow "edit_submission_row_1"
     Then the field "Your first name" matches value "student1"
@@ -138,6 +139,7 @@ Feature: editing a submission, autofill userID is not overwritten
     When I log in as "teacher1"
     And I am on "Course divided into groups" course homepage
     And I follow "Preserve autofill"
+    And I follow "Responses" page in tab bar
 
     And I follow "edit_submission_row_1"
     Then the field "Your first name" matches value "student1"
@@ -152,6 +154,7 @@ Feature: editing a submission, autofill userID is not overwritten
     When I log in as "student1"
     And I am on "Course divided into groups" course homepage
     And I follow "Preserve autofill"
+    And I follow "Responses"
 
     And I follow "edit_submission_row_1"
     Then the field "Your first name" matches value "student1"

--- a/tests/behat/see_onlygroupsubmissions.feature
+++ b/tests/behat/see_onlygroupsubmissions.feature
@@ -75,6 +75,7 @@ Feature: test students can see submissions from their groupmates
     When I log in as "student1"
     And I am on "Course divided into groups" course homepage
     And I follow "Get only my group submission"
+    And I follow "Responses"
 
     Then I should see "Nothing to display"
 
@@ -103,6 +104,7 @@ Feature: test students can see submissions from their groupmates
     When I log in as "student2"
     And I am on "Course divided into groups" course homepage
     And I follow "Get only my group submission"
+    And I follow "Responses"
 
     And I should see "Never" in the "student1 user1" "table_row"
     Then I should see "2" submissions
@@ -126,6 +128,7 @@ Feature: test students can see submissions from their groupmates
     When I log in as "student3"
     And I am on "Course divided into groups" course homepage
     And I follow "Get only my group submission"
+    And I follow "Responses"
 
     Then I should see "Nothing to display"
 
@@ -149,6 +152,7 @@ Feature: test students can see submissions from their groupmates
     When I log in as "student1"
     And I am on "Course divided into groups" course homepage
     And I follow "Get only my group submission"
+    And I follow "Responses"
 
     Then I should see "Never" in the "student1 user1" "table_row"
     Then I should see "Never" in the "student2 user2" "table_row"

--- a/tests/behat/see_onlypersonalsubmissions.feature
+++ b/tests/behat/see_onlypersonalsubmissions.feature
@@ -80,7 +80,10 @@ Feature: test each student sees only personal submissions
     When I log in as "student2"
     And I am on "See only personal submissions" course homepage
     And I follow "Get only my own submissions"
+    And I follow "Responses"
+
     Then I should see "Nothing to display"
+
     And I press "New response"
 
     # student2 submits a response
@@ -100,6 +103,7 @@ Feature: test each student sees only personal submissions
     When I log in as "student1"
     And I am on "See only personal submissions" course homepage
     And I follow "Get only my own submissions"
+    And I follow "Responses"
 
     Then I should see "Never" in the "Student1 user1" "table_row"
     Then I should not see "Student2" in the "submissions" "table"

--- a/tests/behat/submission_test.feature
+++ b/tests/behat/submission_test.feature
@@ -62,6 +62,7 @@ Feature: make a submission test for each available item
     When I log in as "student1"
     And I am on "Test submission for each available item" course homepage
     And I follow "Each item submission"
+    And I follow "Responses"
     And I press "New response"
 
     # student1 submits his first response
@@ -127,6 +128,7 @@ Feature: make a submission test for each available item
 
     And I am on "Test submission for each available item" course homepage
     And I follow "Each item submission"
+    And I follow "Responses" page in tab bar
     And I follow "edit_submission_row_1"
     And I press "Next page >>"
     And I set the field "id_surveypro_field_multiselect_11" to "sugar, jam"

--- a/utemplate_apply.php
+++ b/utemplate_apply.php
@@ -37,14 +37,16 @@ if (!empty($id)) {
     $course = $DB->get_record('course', array('id' => $surveypro->course), '*', MUST_EXIST);
     $cm = get_coursemodule_from_instance('surveypro', $surveypro->id, $course->id, false, MUST_EXIST);
 }
-
-require_course_login($course, true, $cm);
+$cm = cm_info::create($cm);
 
 $utemplateid = optional_param('fid', 0, PARAM_INT);
 $action = optional_param('act', SURVEYPRO_NOACTION, PARAM_INT);
 $confirm = optional_param('cnf', SURVEYPRO_UNCONFIRMED, PARAM_INT);
 
+require_course_login($course, false, $cm);
 $context = context_module::instance($cm->id);
+
+// Required capability.
 require_capability('mod/surveypro:applyusertemplates', $context);
 
 // Calculations.
@@ -85,6 +87,12 @@ $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
 echo $OUTPUT->header();
+echo $OUTPUT->heading(format_string($surveypro->name), 2, null);
+
+// Render the activity information.
+$completiondetails = \core_completion\cm_completion_details::get_instance($cm, $USER->id);
+$activitydates = \core\activity_dates::get_dates_for_module($cm, $USER->id);
+echo $OUTPUT->activity_information($cm, $completiondetails, $activitydates);
 
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABUTEMPLATES, SURVEYPRO_UTEMPLATES_APPLY);
 

--- a/utemplate_import.php
+++ b/utemplate_import.php
@@ -37,17 +37,19 @@ if (!empty($id)) {
     $course = $DB->get_record('course', array('id' => $surveypro->course), '*', MUST_EXIST);
     $cm = get_coursemodule_from_instance('surveypro', $surveypro->id, $course->id, false, MUST_EXIST);
 }
-
-require_course_login($course, true, $cm);
+$cm = cm_info::create($cm);
 
 $utemplateid = optional_param('fid', 0, PARAM_INT);
+
+require_course_login($course, false, $cm);
+$context = context_module::instance($cm->id);
+
+// Required capability.
+require_capability('mod/surveypro:importusertemplates', $context);
 
 // Params never passed but needed by called class.
 $action = SURVEYPRO_NOACTION;
 $confirm = SURVEYPRO_UNCONFIRMED;
-
-$context = context_module::instance($cm->id);
-require_capability('mod/surveypro:importusertemplates', $context);
 
 // Calculations.
 $utemplateman = new mod_surveypro_usertemplate($cm, $context, $surveypro);
@@ -87,6 +89,12 @@ $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
 echo $OUTPUT->header();
+echo $OUTPUT->heading(format_string($surveypro->name), 2, null);
+
+// Render the activity information.
+$completiondetails = \core_completion\cm_completion_details::get_instance($cm, $USER->id);
+$activitydates = \core\activity_dates::get_dates_for_module($cm, $USER->id);
+echo $OUTPUT->activity_information($cm, $completiondetails, $activitydates);
 
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABUTEMPLATES, SURVEYPRO_UTEMPLATES_IMPORT);
 

--- a/utemplate_manage.php
+++ b/utemplate_manage.php
@@ -35,14 +35,16 @@ if (!empty($id)) {
     $course = $DB->get_record('course', array('id' => $surveypro->course), '*', MUST_EXIST);
     $cm = get_coursemodule_from_instance('surveypro', $surveypro->id, $course->id, false, MUST_EXIST);
 }
-
-require_course_login($course, true, $cm);
+$cm = cm_info::create($cm);
 
 $utemplateid = optional_param('fid', 0, PARAM_INT);
 $action = optional_param('act', SURVEYPRO_NOACTION, PARAM_INT);
 $confirm = optional_param('cnf', SURVEYPRO_UNCONFIRMED, PARAM_INT);
 
+require_course_login($course, false, $cm);
 $context = context_module::instance($cm->id);
+
+// Required capability.
 require_capability('mod/surveypro:manageusertemplates', $context);
 
 // Calculations.
@@ -65,6 +67,12 @@ $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
 echo $OUTPUT->header();
+echo $OUTPUT->heading(format_string($surveypro->name), 2, null);
+
+// Render the activity information.
+$completiondetails = \core_completion\cm_completion_details::get_instance($cm, $USER->id);
+$activitydates = \core\activity_dates::get_dates_for_module($cm, $USER->id);
+echo $OUTPUT->activity_information($cm, $completiondetails, $activitydates);
 
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABUTEMPLATES, SURVEYPRO_UTEMPLATES_MANAGE);
 

--- a/utemplate_save.php
+++ b/utemplate_save.php
@@ -37,17 +37,19 @@ if (!empty($id)) {
     $course = $DB->get_record('course', array('id' => $surveypro->course), '*', MUST_EXIST);
     $cm = get_coursemodule_from_instance('surveypro', $surveypro->id, $course->id, false, MUST_EXIST);
 }
-
-require_course_login($course, true, $cm);
+$cm = cm_info::create($cm);
 
 $utemplateid = optional_param('fid', 0, PARAM_INT);
+
+require_course_login($course, false, $cm);
+$context = context_module::instance($cm->id);
+
+// Required capability.
+require_capability('mod/surveypro:saveusertemplates', $context);
 
 // Params never passed but needed by called class.
 $action = SURVEYPRO_NOACTION;
 $confirm = SURVEYPRO_UNCONFIRMED;
-
-$context = context_module::instance($cm->id);
-require_capability('mod/surveypro:saveusertemplates', $context);
 
 // Calculations.
 $utemplateman = new mod_surveypro_usertemplate($cm, $context, $surveypro);
@@ -86,6 +88,12 @@ $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
 echo $OUTPUT->header();
+echo $OUTPUT->heading(format_string($surveypro->name), 2, null);
+
+// Render the activity information.
+$completiondetails = \core_completion\cm_completion_details::get_instance($cm, $USER->id);
+$activitydates = \core\activity_dates::get_dates_for_module($cm, $USER->id);
+echo $OUTPUT->activity_information($cm, $completiondetails, $activitydates);
 
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABUTEMPLATES, SURVEYPRO_UTEMPLATES_BUILD);
 

--- a/view.php
+++ b/view.php
@@ -15,7 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Starting page of the module.
+ * Starting page to display the surveypro cover page.
  *
  * @package   mod_surveypro
  * @copyright 2013 onwards kordan <kordan@mclink.it>
@@ -37,49 +37,21 @@ if (!empty($id)) {
 }
 $cm = cm_info::create($cm);
 
-$tifirst = optional_param('tifirst', '', PARAM_ALPHA); // First letter of the name.
-$tilast = optional_param('tilast', '', PARAM_ALPHA);   // First letter of the surname.
-// $tsort = optional_param('tsort', '', PARAM_ALPHA);     // Field asked to sort the table for.
 $edit = optional_param('edit', -1, PARAM_BOOL);
 
-// A response was submitted.
-$justsubmitted = optional_param('justsubmitted', 0, PARAM_INT);
-$formview = optional_param('formview', 0, PARAM_INT);
-$responsestatus = optional_param('responsestatus', 0, PARAM_INT);
-
-// The list is managed.
-$submissionid = optional_param('submissionid', 0, PARAM_INT);
-$action = optional_param('act', SURVEYPRO_NOACTION, PARAM_INT);
-$view = optional_param('view', SURVEYPRO_NOVIEW, PARAM_INT);
-$confirm = optional_param('cnf', SURVEYPRO_UNCONFIRMED, PARAM_INT);
-$searchquery = optional_param('searchquery', '', PARAM_RAW);
-$force = optional_param('force', 0, PARAM_INT);
-
 require_course_login($course, false, $cm);
+
 $context = context_module::instance($cm->id);
 
-if ($action != SURVEYPRO_NOACTION) {
-    require_sesskey();
-}
-
 // Calculations.
-$submissionman = new mod_surveypro_submission($cm, $context, $surveypro);
-$submissionman->setup($submissionid, $action, $view, $confirm, $searchquery);
+$utilitylayoutman = new mod_surveypro_utility_layout($cm, $surveypro);
+$utilitylayoutman->noitem_redirect();
 
-if ($view == SURVEYPRO_RESPONSETOPDF) {
-    $submissionman->submission_to_pdf();
-    die();
-}
-
-if (empty($force)) {
-    $submissionman->noitem_redirect();
-}
-
-// Perform action before PAGE. (The content of the admin block depends on the output of these actions).
-$submissionman->actions_execution();
+$coverman = new mod_surveypro_view_cover($cm, $context, $surveypro);
 
 // Output starts here.
-$PAGE->set_url('/mod/surveypro/view.php', array('s' => $surveypro->id));
+$url = new moodle_url('/mod/surveypro/view.php', array('s' => $surveypro->id));
+$PAGE->set_url($url);
 $PAGE->set_context($context);
 $PAGE->set_cm($cm);
 $PAGE->set_title($surveypro->name);
@@ -108,17 +80,9 @@ $completiondetails = \core_completion\cm_completion_details::get_instance($cm, $
 $activitydates = \core\activity_dates::get_dates_for_module($cm, $USER->id);
 echo $OUTPUT->activity_information($cm, $completiondetails, $activitydates);
 
-new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABSUBMISSIONS, SURVEYPRO_SUBMISSION_MANAGE);
+new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABSUBMISSIONS, SURVEYPRO_SUBMISSION_CPANEL);
 
-if (!empty($justsubmitted)) {
-    $submissionman->show_thanks_page($responsestatus, $formview, $justsubmitted);
-} else {
-    $submissionman->actions_feedback(); // Action feedback after PAGE.
-
-    $submissionman->show_action_buttons($tifirst, $tilast);
-    $submissionman->display_submissions_table();
-    $submissionman->trigger_event(); // Event: all_submissions_viewed.
-}
+$coverman->display_cover();
 
 // Finish the page.
 echo $OUTPUT->footer();

--- a/view_cover.php
+++ b/view_cover.php
@@ -25,7 +25,6 @@
 require_once(dirname(dirname(dirname(__FILE__))).'/config.php');
 $id = optional_param('id', 0, PARAM_INT); // Course_module id.
 $s = optional_param('s', 0, PARAM_INT);   // Surveypro instance id.
-$edit = optional_param('edit', -1, PARAM_BOOL);
 
 if (!empty($id)) {
     $cm = get_coursemodule_from_id('surveypro', $id, 0, false, MUST_EXIST);
@@ -36,9 +35,11 @@ if (!empty($id)) {
     $course = $DB->get_record('course', array('id' => $surveypro->course), '*', MUST_EXIST);
     $cm = get_coursemodule_from_instance('surveypro', $surveypro->id, $course->id, false, MUST_EXIST);
 }
+$cm = cm_info::create($cm);
 
-require_course_login($course, true, $cm);
+$edit = optional_param('edit', -1, PARAM_BOOL);
 
+require_course_login($course, false, $cm);
 $context = context_module::instance($cm->id);
 
 // Calculations.
@@ -68,6 +69,12 @@ if ($PAGE->user_allowed_editing()) {
 }
 
 echo $OUTPUT->header();
+echo $OUTPUT->heading(format_string($surveypro->name), 2, null);
+
+// Render the activity information.
+$completiondetails = \core_completion\cm_completion_details::get_instance($cm, $USER->id);
+$activitydates = \core\activity_dates::get_dates_for_module($cm, $USER->id);
+echo $OUTPUT->activity_information($cm, $completiondetails, $activitydates);
 
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABSUBMISSIONS, SURVEYPRO_SUBMISSION_CPANEL);
 

--- a/view_export.php
+++ b/view_export.php
@@ -37,10 +37,12 @@ if (!empty($id)) {
     $course = $DB->get_record('course', array('id' => $surveypro->course), '*', MUST_EXIST);
     $cm = get_coursemodule_from_instance('surveypro', $surveypro->id, $course->id, false, MUST_EXIST);
 }
+$cm = cm_info::create($cm);
 
-require_course_login($course, true, $cm);
-
+require_course_login($course, false, $cm);
 $context = context_module::instance($cm->id);
+
+// Required capability.
 require_capability('mod/surveypro:exportdata', $context);
 
 // Calculations.
@@ -81,6 +83,12 @@ $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
 echo $OUTPUT->header();
+echo $OUTPUT->heading(format_string($surveypro->name), 2, null);
+
+// Render the activity information.
+$completiondetails = \core_completion\cm_completion_details::get_instance($cm, $USER->id);
+$activitydates = \core\activity_dates::get_dates_for_module($cm, $USER->id);
+echo $OUTPUT->activity_information($cm, $completiondetails, $activitydates);
 
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABSUBMISSIONS, SURVEYPRO_SUBMISSION_EXPORT);
 

--- a/view_form.php
+++ b/view_form.php
@@ -79,7 +79,7 @@ $outform = new mod_surveypro_outform($formurl, $formparams, 'post', '', array('i
 // Begin of: manage form submission.
 if ($outform->is_cancelled()) {
     $localparamurl = array('id' => $cm->id, 'view' => $view);
-    $redirecturl = new moodle_url('/mod/surveypro/view.php', $localparamurl);
+    $redirecturl = new moodle_url('/mod/surveypro/view_submissions.php', $localparamurl);
     redirect($redirecturl, get_string('usercanceled', 'mod_surveypro'));
 }
 
@@ -91,7 +91,7 @@ if ($userformman->formdata = $outform->get_data()) {
     $pausebutton = isset($userformman->formdata->pausebutton);
     if ($pausebutton) {
         $localparamurl = array('id' => $cm->id, 'view' => $view);
-        $redirecturl = new moodle_url('/mod/surveypro/view.php', $localparamurl);
+        $redirecturl = new moodle_url('/mod/surveypro/view_submissions.php', $localparamurl);
         redirect($redirecturl); // Go somewhere.
     }
 
@@ -136,7 +136,7 @@ if ($userformman->formdata = $outform->get_data()) {
     // This is necessary otherwise if the user switches language using the corresponding menu
     // just after a new response is submitted
     // the browser redirects to http://localhost/head_behat/mod/surveypro/view_form.php?s=xxx&view=1&lang=it
-    // and not               to http://localhost/head_behat/mod/surveypro/view.php?s=xxx&lang=it
+    // and not               to http://localhost/head_behat/mod/surveypro/view_submissions.php?s=xxx&lang=it
     // alias it goes to the page to get one more response
     // instead of remaining in the view submissions page.
     $paramurl = array();
@@ -144,7 +144,7 @@ if ($userformman->formdata = $outform->get_data()) {
     $paramurl['responsestatus'] = $userformman->get_responsestatus();
     $paramurl['justsubmitted'] = 1 + $userformman->get_userdeservesthanks();
     $paramurl['formview'] = $userformman->get_view(); // What was I viewing in the form?
-    $redirecturl = new moodle_url('/mod/surveypro/view.php', $paramurl);
+    $redirecturl = new moodle_url('/mod/surveypro/view_submissions.php', $paramurl);
     redirect($redirecturl); // Redirect to the first non empty page.
 }
 // End of: manage form submission.

--- a/view_form.php
+++ b/view_form.php
@@ -37,13 +37,14 @@ if (!empty($id)) {
     $course = $DB->get_record('course', array('id' => $surveypro->course), '*', MUST_EXIST);
     $cm = get_coursemodule_from_instance('surveypro', $surveypro->id, $course->id, false, MUST_EXIST);
 }
+$cm = cm_info::create($cm);
 
-require_course_login($course, true, $cm);
-
-$context = context_module::instance($cm->id);
 $submissionid = optional_param('submissionid', 0, PARAM_INT);
 $formpage = optional_param('formpage', 0, PARAM_INT); // Form page number.
 $view = optional_param('view', SURVEYPRO_NOVIEW, PARAM_INT);
+
+require_course_login($course, false, $cm);
+$context = context_module::instance($cm->id);
 
 // Calculations.
 mod_surveypro_utility_mform::register_form_elements();
@@ -161,6 +162,12 @@ $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
 echo $OUTPUT->header();
+echo $OUTPUT->heading(format_string($surveypro->name), 2, null);
+
+// Render the activity information.
+$completiondetails = \core_completion\cm_completion_details::get_instance($cm, $USER->id);
+$activitydates = \core\activity_dates::get_dates_for_module($cm, $USER->id);
+echo $OUTPUT->activity_information($cm, $completiondetails, $activitydates);
 
 new mod_surveypro_tabs($cm, $context, $surveypro, $userformman->get_tabtab(), $userformman->get_tabpage());
 

--- a/view_import.php
+++ b/view_import.php
@@ -37,10 +37,12 @@ if (!empty($id)) {
     $course = $DB->get_record('course', array('id' => $surveypro->course), '*', MUST_EXIST);
     $cm = get_coursemodule_from_instance('surveypro', $surveypro->id, $course->id, false, MUST_EXIST);
 }
+$cm = cm_info::create($cm);
 
-require_course_login($course, true, $cm);
-
+require_course_login($course, false, $cm);
 $context = context_module::instance($cm->id);
+
+// Required capability.
 require_capability('mod/surveypro:importdata', $context);
 
 // Calculations.
@@ -74,6 +76,12 @@ $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
 echo $OUTPUT->header();
+echo $OUTPUT->heading(format_string($surveypro->name), 2, null);
+
+// Render the activity information.
+$completiondetails = \core_completion\cm_completion_details::get_instance($cm, $USER->id);
+$activitydates = \core\activity_dates::get_dates_for_module($cm, $USER->id);
+echo $OUTPUT->activity_information($cm, $completiondetails, $activitydates);
 
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABSUBMISSIONS, SURVEYPRO_SUBMISSION_IMPORT);
 

--- a/view_import.php
+++ b/view_import.php
@@ -62,7 +62,7 @@ if ($importman->formdata = $importform->get_data()) {
     $err = $importman->validate_csvcontent();
     if (empty($err)) {
         $importman->import_csv();
-        $redirecturl = new moodle_url('/mod/surveypro/view.php', array('s' => $surveypro->id));
+        $redirecturl = new moodle_url('/mod/surveypro/view_submissions.php', array('s' => $surveypro->id));
         redirect($redirecturl);
     }
 }

--- a/view_search.php
+++ b/view_search.php
@@ -68,7 +68,7 @@ $searchform = new mod_surveypro_searchform($formurl, $formparams, 'post', '', ar
 // Begin of: manage form submission.
 if ($searchform->is_cancelled()) {
     $paramurl = array('id' => $cm->id);
-    $returnurl = new moodle_url('/mod/surveypro/view.php', $paramurl);
+    $returnurl = new moodle_url('/mod/surveypro/view_submissions.php', $paramurl);
     redirect($returnurl);
 }
 
@@ -79,7 +79,7 @@ if ($searchman->formdata = $searchform->get_data()) {
     if ($searchquery = $searchman->get_searchparamurl()) {
         $paramurl['searchquery'] = $searchquery;
     }
-    $returnurl = new moodle_url('/mod/surveypro/view.php', $paramurl);
+    $returnurl = new moodle_url('/mod/surveypro/view_submissions.php', $paramurl);
     redirect($returnurl);
 }
 // End of: manage form submission.

--- a/view_search.php
+++ b/view_search.php
@@ -37,12 +37,14 @@ if (!empty($id)) {
     $course = $DB->get_record('course', array('id' => $surveypro->course), '*', MUST_EXIST);
     $cm = get_coursemodule_from_instance('surveypro', $surveypro->id, $course->id, false, MUST_EXIST);
 }
-
-require_course_login($course, true, $cm);
+$cm = cm_info::create($cm);
 
 $formpage = optional_param('formpage', 1, PARAM_INT); // Form page number.
 
+require_course_login($course, false, $cm);
 $context = context_module::instance($cm->id);
+
+// Required capability.
 require_capability('mod/surveypro:searchsubmissions', $context);
 
 // Calculations.
@@ -90,6 +92,12 @@ $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 
 echo $OUTPUT->header();
+echo $OUTPUT->heading(format_string($surveypro->name), 2, null);
+
+// Render the activity information.
+$completiondetails = \core_completion\cm_completion_details::get_instance($cm, $USER->id);
+$activitydates = \core\activity_dates::get_dates_for_module($cm, $USER->id);
+echo $OUTPUT->activity_information($cm, $completiondetails, $activitydates);
 
 new mod_surveypro_tabs($cm, $context, $surveypro, SURVEYPRO_TABSUBMISSIONS, SURVEYPRO_SUBMISSION_SEARCH);
 


### PR DESCRIPTION
In this PR I "simply" changed few file names to reflect the structure of the TABS shown on top of the web pages.

TABS structure is this:
Layout
    Preview
    Elements
    Element setup (generally hidden)
    Branching validation (visible only if parent-child items exist)
Survey
    Dashboard
    Responses
    Import (generally hidden)
    Export (generally hidden)
User templates (generally hidden)
    Manage (available only if the parent TAB is visible)
    Save (available only if the parent TAB is visible)
    Import (available only if the parent TAB is visible)
    Apply (available only if the parent TAB is visible)
Master templates (generally hidden)
    Save (available only if the parent TAB is visible)
    Apply (available only if the parent TAB is visible)
Reports (generally hidden)
    Attachments overview (available only if the parent TAB is visible)
    Colles (available only if the parent TAB is visible and the surveypro was build from a colles master templates)
    Frequency distribution (available only if the parent TAB is visible)
    Late users (available only if the parent TAB is visible)
    Responses per user (available only if the parent TAB is visible)
    Users per count of responses (available only if the parent TAB is visible)

With swap_view_view_cover I swapped the names of view.php and view_cover.php
Now, for instance, the content of the web page
Survey -> Responses
comes from the "landing page" view_submissions.php (view stands for surveypro)
that uses the class mod_surveypro_view_submissions
that lives in classes/view_submissions.php

One more example:
Layout -> Preview
comes from the "landing page" layout_preview.php
that uses the class mod_surveypro_layout_preview
that lives in classes/layout_preview.php

If I am not wrong this is true for all the pages.

This is the output of behat test executed without --suite

https://pastebin.com/aYzvxaXZ
