### PR TITLE
Changed standing report query

### DIFF
--- a/report/lateusers/classes/report.php
+++ b/report/lateusers/classes/report.php
@@ -133,11 +133,17 @@ class surveyproreport_lateusers_report extends mod_surveypro_reportbase {
         $whereparams = array();
         $userfieldsapi = \core_user\fields::for_userpic()->get_sql('u');
 
-        $submissiontable = 'SELECT userid, surveyproid
+        $submissiontable = 'SELECT userid, surveyproid, count(*) as submissioncount
                             FROM {surveypro_submission}
                             WHERE surveyproid = :subsurveyproid
-                            GROUP BY userid, surveyproid';
+                            AND status = :status
+                            GROUP BY userid, surveyproid
+                            HAVING submissioncount >= :completionsubmit';
+
+        $whereparams = [];
         $whereparams['subsurveyproid'] = $this->surveypro->id;
+        $whereparams['status'] = SURVEYPRO_STATUSCLOSED;
+        $whereparams['completionsubmit'] = $this->surveypro->completionsubmit;
 
         $sql = 'SELECT s.surveyproid'.$userfieldsapi->selects.'
                 FROM {user} u


### PR DESCRIPTION
The idea is: if the user is allowed to pause/resume the survey he has to be counted among late users if he didn't submit its answer OR if he submitted only IN PROGRESS responses.
Further more... if the required conditions are defined as "The user has to sumbit at least x responses" the user has to be considered "late user" if he submitted AS CLOSED less than x responses.