### PR TITLE
Deleted redundand info from cover

### DIFF
--- a/classes/view_cover.php
+++ b/classes/view_cover.php
@@ -102,20 +102,8 @@ class mod_surveypro_view_cover {
         $addnew = $utilitylayoutman->is_newresponse_allowed($next);
         // End of: is the button to add one more response going to be displayed?
 
-        echo $OUTPUT->heading(get_string('coverpage_welcome', 'mod_surveypro', $this->surveypro->name));
         if ($this->surveypro->intro) {
             echo $OUTPUT->box(format_module_intro('surveypro', $this->surveypro, $this->cm->id), 'generalbox description', 'intro');
-        }
-
-        // Begin of: general info.
-        if ($this->surveypro->timeopen) { // Opening time.
-            $langkey = ($this->surveypro->timeopen > $timenow) ? 'willopen' : 'opened';
-            $messages[] = get_string($langkey, 'mod_surveypro').$labelsep.userdate($this->surveypro->timeopen);
-        }
-
-        if ($this->surveypro->timeclose) { // Closing time.
-            $langkey = ($this->surveypro->timeclose > $timenow) ? 'willclose' : 'closed';
-            $messages[] = get_string($langkey, 'mod_surveypro').$labelsep.userdate($this->surveypro->timeclose);
         }
 
         // Number of elements.

--- a/lang/en/surveypro.php
+++ b/lang/en/surveypro.php
@@ -140,7 +140,6 @@ $string['count_allitems'] = 'Survey built on {$a} elements.';
 $string['count_hiddenitems'] = '({$a} hidden)';
 $string['count_pages'] = 'Divided into {$a} pages.';
 $string['course'] = 'Course';
-$string['coverpage_welcome'] = 'Welcome to {$a}';
 $string['crontask'] = 'Surveypro maintenance jobs';
 $string['currenttotemplate'] = 'Save current survey as master template in zip format.<br />To install a master template, unzip it to mod/surveypro/template/ and visit the notification page.';
 $string['customnumber_header'] = '#';

--- a/lang/es/surveypro.php
+++ b/lang/es/surveypro.php
@@ -137,7 +137,6 @@ $string['count_allitems'] = 'Encuesta construida en {$a} elementos.';
 $string['count_hiddenitems'] = '({$a} ocultos)';
 $string['count_pages'] = 'Dividida en {$a} páginas.';
 $string['course'] = 'Curso';
-$string['coverpage_welcome'] = 'Bienvenido a {$a}';
 $string['crontask'] = 'Trabajos de mantenimiento de Surveypro';
 $string['currenttotemplate'] = 'Guardar encuesta actual como plantilla maestra en formato ZIP.<br />Para instalar una plantilla maestra, descomprímala a mod/surveypro/template/ y visite la página de notificaciones.';
 $string['customnumber_header'] = '#';

--- a/lang/es_mx/surveypro.php
+++ b/lang/es_mx/surveypro.php
@@ -137,7 +137,6 @@ $string['count_allitems'] = 'Encuesta construida en {$a} elementos.';
 $string['count_hiddenitems'] = '({$a} ocultos)';
 $string['count_pages'] = 'Dividida en {$a} páginas.';
 $string['course'] = 'Curso';
-$string['coverpage_welcome'] = 'Bienvenido a {$a}';
 $string['crontask'] = 'Trabajos de mantenimiento de Surveypro';
 $string['currenttotemplate'] = 'Guardar encuesta actual como plantilla maestra en formato ZIP.<br />Para instalar una plantilla maestra, descomprímala a mod/surveypro/template/ y visite la página de notificaciones.';
 $string['customnumber_header'] = '#';

--- a/lang/it/surveypro.php
+++ b/lang/it/surveypro.php
@@ -71,7 +71,6 @@ $string['completiondetail:entries'] = 'Risposte da inviare: {$a}';
 $string['count_allitems'] = 'Questionario costituito da {$a} elementi.';
 $string['count_hiddenitems'] = '({$a} nascosti)';
 $string['count_pages'] = 'Distribuito su {$a} pagine.';
-$string['coverpage_welcome'] = 'Benvenuto in: {$a}';
 $string['customnumber_help'] = 'Definisce un numero personalizzato per l\'elemento. Può essere un numero intero come "1" o una qualunque altra scelta come, per esempio: 1a, A, 1.1.a, #1, A, A.1... Si consideri la coerenza della numerazione è lasciata alla tua responsabilità. Per questo, si faccia sempre una doppia verifica qualora si scegliesse di modificare l\'ordine delle domande.';
 $string['customnumber'] = 'Numero dell\'elemento';
 $string['deleteallitems'] = 'Elimina tutti gli elementi';


### PR DESCRIPTION
Since the inclusion of completion detail (#617) into surveypro the specification of opening and closing dates and few more details in surveypro cover page has become redundant.