### PR TITLE
Attachment report wrong tab

### DIFF
--- a/classes/tabs.php
+++ b/classes/tabs.php
@@ -348,7 +348,7 @@ class tabs {
                 if ($surveyproreportlist = get_plugin_list('surveyproreport')) {
                     $counter = 0;
                     foreach ($surveyproreportlist as $reportname => $reportpath) {
-                        $classname = 'surveyproreport_'.$reportname.'_report';
+                        $classname = 'surveyproreport_'.$reportname.'\report';
                         $reportman = new $classname($this->cm, $this->context, $this->surveypro);
                         $reportappliesto = $reportman->report_applies_to();
                         if (($reportappliesto == ['each']) || in_array($this->surveypro->template, $reportappliesto)) {

--- a/classes/utility_layout.php
+++ b/classes/utility_layout.php
@@ -974,7 +974,7 @@ class utility_layout {
 
         if ($surveyproreportlist = get_plugin_list('surveyproreport')) {
             foreach ($surveyproreportlist as $reportname => $reportpath) {
-                $classname = 'surveyproreport_'.$reportname.'_report';
+                $classname = 'surveyproreport_'.$reportname.'\report';
                 $reportman = new $classname($this->cm, $this->context, $this->surveypro);
                 $reportappliesto = $reportman->report_applies_to();
                 if (($reportappliesto == ['each']) || in_array($this->surveypro->template, $reportappliesto)) {

--- a/classes/view_cover.php
+++ b/classes/view_cover.php
@@ -190,7 +190,7 @@ class view_cover {
         $surveyproreportlist = get_plugin_list('surveyproreport');
         $paramurlbase = array('id' => $this->cm->id);
         foreach ($surveyproreportlist as $pluginname => $pluginpath) {
-            $classname = 'surveyproreport_'.$pluginname.'_report';
+            $classname = 'surveyproreport_'.$pluginname.'\report';
             $reportman = new $classname($this->cm, $this->context, $this->surveypro);
 
             $reportappliesto = $reportman->report_applies_to();
@@ -260,7 +260,7 @@ class view_cover {
     /**
      * Recursive function to populate the $messages array for reports nested as much times as wanted
      *
-     * Uncomment lines of has_childreports method in surveyproreport_colles_report class of report/colles/classes/report.php file
+     * Uncomment lines of has_childreports method in surveyproreport_colles\report class of report/colles/classes/report.php file
      * to see this function in action.
      *
      * @param string $childreports

--- a/lib.php
+++ b/lib.php
@@ -893,7 +893,7 @@ function surveypro_extend_settings_navigation(settings_navigation $settings, nav
 
         $icon = new \pix_icon('i/report', '', 'moodle');
         foreach ($surveyproreportlist as $reportname => $reportpath) {
-            $classname = 'surveyproreport_'.$reportname.'_report';
+            $classname = 'surveyproreport_'.$reportname.'\report';
             $reportman = new $classname($cm, $context, $surveypro);
 
             $reportappliesto = $reportman->report_applies_to();
@@ -923,7 +923,7 @@ function surveypro_extend_settings_navigation(settings_navigation $settings, nav
 /**
  * Recursive function to add links for reports nested as much times as wanted
  *
- * Uncomment lines of has_childreports method in the surveyproreport_colles_report class of report/colles/classes/report.php file
+ * Uncomment lines of has_childreports method in the surveyproreport_colles\report class of report/colles/classes/report.php file
  * to see this function in action.
  *
  * @param string $templatename

--- a/report/attachments/classes/filterform.php
+++ b/report/attachments/classes/filterform.php
@@ -22,6 +22,8 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace surveyproreport_attachments;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot.'/lib/formslib.php');
@@ -33,7 +35,7 @@ require_once($CFG->dirroot.'/lib/formslib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class surveyproreport_attachmentfilterform extends \moodleform {
+class filterform extends \moodleform {
 
     /**
      * Definition.

--- a/report/attachments/classes/form.php
+++ b/report/attachments/classes/form.php
@@ -22,6 +22,8 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace surveyproreport_attachments;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot.'/mod/surveypro/field/fileupload/lib.php');
@@ -33,7 +35,7 @@ require_once($CFG->dirroot.'/mod/surveypro/field/fileupload/lib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class surveyproreport_attachments_form {
+class form {
 
     /**
      * @var object Course module object

--- a/report/attachments/classes/groupjumperform.php
+++ b/report/attachments/classes/groupjumperform.php
@@ -15,25 +15,27 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Class to filter output by group
+ * Class to filter the attachment item to overview
  *
- * @package   surveyproreport_responsesperuser
+ * @package   surveyproreport_attachments
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+
+namespace surveyproreport_attachments;
 
 defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot.'/lib/formslib.php');
 
 /**
- * The class to filter the attachment item to overview
+ * Class to filter output by group
  *
- * @package   surveyproreport_responsesperuser
+ * @package   surveyproreport_attachments
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_surveypro_responsesperuser_groupjumper extends \moodleform {
+class groupjumperform extends \moodleform {
 
     /**
      * Definition.

--- a/report/attachments/classes/report.php
+++ b/report/attachments/classes/report.php
@@ -22,6 +22,8 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace surveyproreport_attachments;
+
 defined('MOODLE_INTERNAL') || die();
 
 use mod_surveypro\reportbase;
@@ -35,7 +37,7 @@ require_once($CFG->libdir.'/tablelib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class surveyproreport_attachments_report extends reportbase {
+class report extends reportbase {
 
     /**
      * @var flexible_table $outputtable

--- a/report/attachments/uploads.php
+++ b/report/attachments/uploads.php
@@ -23,9 +23,10 @@
  */
 
 use mod_surveypro\tabs;
+use surveyproreport_attachments\filterform;
+use surveyproreport_attachments\form;
 
 require_once(dirname(dirname(dirname(dirname(dirname(__FILE__))))).'/config.php');
-require_once($CFG->dirroot.'/mod/surveypro/report/attachments/form/attachmentfilter_form.php');
 
 $id = optional_param('id', 0, PARAM_INT); // Course_module id.
 $s = optional_param('s', 0, PARAM_INT);   // Surveypro instance id.
@@ -64,7 +65,7 @@ if (count($parts) == 2) {
 }
 
 // Calculations.
-$uploadsformman = new surveyproreport_attachments_form($cm, $context, $surveypro);
+$uploadsformman = new form($cm, $context, $surveypro);
 $uploadsformman->prevent_direct_user_input();
 $uploadsformman->set_userid($userid);
 $uploadsformman->set_itemid($itemid);
@@ -85,7 +86,7 @@ $formparams->canaccessreserveditems = $canaccessreserveditems;
 $formparams->canviewhiddenactivities = $canviewhiddenactivities;
 // End of: prepare params for the form.
 
-$filterform = new surveyproreport_attachmentfilterform($formurl, $formparams, 'post', '', array('id' => 'userentry'));
+$filterform = new filterform($formurl, $formparams, 'post', '', array('id' => 'userentry'));
 
 // Output starts here.
 $paramurl = array('s' => $surveypro->id, 'userid' => $userid, 'submissionid' => $submissionid);

--- a/report/attachments/uploads.php
+++ b/report/attachments/uploads.php
@@ -109,7 +109,9 @@ $completiondetails = \core_completion\cm_completion_details::get_instance($cm, $
 $activitydates = \core\activity_dates::get_dates_for_module($cm, $USER->id);
 echo $OUTPUT->activity_information($cm, $completiondetails, $activitydates);
 
-new tabs($cm, $context, $surveypro, SURVEYPRO_TABSUBMISSIONS, SURVEYPRO_SUBMISSION_REPORT);
+$surveyproreportlist = get_plugin_list('surveyproreport');
+$reportkey = array_search('attachments', array_keys($surveyproreportlist));
+new tabs($cm, $context, $surveypro, SURVEYPRO_TABREPORTS, $reportkey);
 
 $filterform->display();
 

--- a/report/attachments/view.php
+++ b/report/attachments/view.php
@@ -23,9 +23,10 @@
  */
 
 use mod_surveypro\tabs;
+use surveyproreport_attachments\groupjumperform;
+use surveyproreport_attachments\report;
 
 require_once(dirname(dirname(dirname(dirname(dirname(__FILE__))))).'/config.php');
-require_once($CFG->dirroot.'/mod/surveypro/report/attachments/classes/groupjumper_form.php');
 require_once($CFG->libdir.'/tablelib.php');
 
 $id = optional_param('id', 0, PARAM_INT);
@@ -51,7 +52,7 @@ $context = \context_module::instance($cm->id);
 // Required capability.
 require_capability('mod/surveypro:accessreports', $context);
 
-$reportman = new surveyproreport_attachments_report($cm, $context, $surveypro);
+$reportman = new report($cm, $context, $surveypro);
 $reportman->set_groupid($groupid);
 $reportman->setup_outputtable();
 
@@ -70,7 +71,7 @@ if ($showjumper) {
     $formparams->addnotinanygroup = $reportman->add_notinanygroup();
     $formparams->jumpercontent = $jumpercontent;
     $attributes = array('id' => 'surveypro_jumperform');
-    $groupfilterform = new mod_surveypro_attachments_groupjumper($formurl, $formparams, null, null, $attributes);
+    $groupfilterform = new groupjumperform($formurl, $formparams, null, null, $attributes);
 
     $PAGE->requires->js_amd_inline("
     require(['jquery'], function($) {

--- a/report/colles/classes/groupjumperform.php
+++ b/report/colles/classes/groupjumperform.php
@@ -17,10 +17,12 @@
 /**
  * Class to filter output by group
  *
- * @package   surveyproreport_userspercount
+ * @package   surveyproreport_colles
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+
+namespace surveyproreport_colles;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -29,11 +31,11 @@ require_once($CFG->dirroot.'/lib/formslib.php');
 /**
  * The class to filter the attachment item to overview
  *
- * @package   surveyproreport_userspercount
+ * @package   surveyproreport_colles
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_surveypro_userspercount_groupjumper extends \moodleform {
+class groupjumperform extends \moodleform {
 
     /**
      * Definition.

--- a/report/colles/classes/report.php
+++ b/report/colles/classes/report.php
@@ -22,6 +22,8 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace surveyproreport_colles;
+
 defined('MOODLE_INTERNAL') || die();
 
 use mod_surveypro\reportbase;
@@ -33,7 +35,7 @@ use mod_surveypro\reportbase;
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class surveyproreport_colles_report extends reportbase {
+class report extends reportbase {
 
     /**
      * @var string $template

--- a/report/colles/graph.php
+++ b/report/colles/graph.php
@@ -22,6 +22,8 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use surveyproreport_colles\report;
+
 require_once('../../../../config.php');
 require_once($CFG->libdir.'/graphlib.php');
 require_once($CFG->dirroot.'/mod/surveypro/report/colles/lib.php');
@@ -49,7 +51,7 @@ if ($type == 'summary') {
     require_capability('mod/surveypro:accessreports', $context);
 }
 
-$reportman = new surveyproreport_colles_report($cm, $context, $surveypro);
+$reportman = new report($cm, $context, $surveypro);
 $reportman->set_area($area);
 $reportman->set_groupid($groupid);
 

--- a/report/colles/view.php
+++ b/report/colles/view.php
@@ -23,6 +23,7 @@
  */
 
 use mod_surveypro\tabs;
+use surveyproreport_colles\report;
 
 require_once(dirname(dirname(dirname(dirname(dirname(__FILE__))))).'/config.php');
 require_once($CFG->dirroot.'/mod/surveypro/report/colles/lib.php');
@@ -57,7 +58,7 @@ if ($type == 'summary') {
     require_capability('mod/surveypro:accessreports', $context);
 }
 
-$reportman = new surveyproreport_colles_report($cm, $context, $surveypro);
+$reportman = new report($cm, $context, $surveypro);
 $reportman->set_area($area);
 
 // Begin of: define $mform return url.

--- a/report/frequency/classes/filterform.php
+++ b/report/frequency/classes/filterform.php
@@ -22,9 +22,12 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace surveyproreport_frequency;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot.'/lib/formslib.php');
+
 /**
  * Class to filter output by group
  *
@@ -32,7 +35,7 @@ require_once($CFG->dirroot.'/lib/formslib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_surveypro_itemfilterform extends \moodleform {
+class filterform extends \moodleform {
 
     /**
      * Definition.

--- a/report/frequency/classes/report.php
+++ b/report/frequency/classes/report.php
@@ -22,6 +22,8 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace surveyproreport_frequency;
+
 defined('MOODLE_INTERNAL') || die();
 
 use mod_surveypro\reportbase;
@@ -35,7 +37,7 @@ require_once($CFG->libdir.'/tablelib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class surveyproreport_frequency_report extends reportbase {
+class report extends reportbase {
 
     /**
      * @var flexible_table $outputtable

--- a/report/frequency/graph.php
+++ b/report/frequency/graph.php
@@ -22,6 +22,8 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use surveyproreport_frequency\report;
+
 require_once('../../../../config.php');
 require_once($CFG->libdir.'/graphlib.php');
 require_once($CFG->dirroot.'/mod/surveypro/report/frequency/lib.php');
@@ -41,7 +43,7 @@ $context = \context_module::instance($cm->id);
 // Required capability.
 require_capability('mod/surveypro:accessreports', $context);
 
-$reportman = new surveyproreport_frequency_report($cm, $context, $surveypro);
+$reportman = new report($cm, $context, $surveypro);
 $reportman->set_groupid($groupid);
 
 list($sql, $whereparams) = $reportman->get_submissions_sql($itemid);

--- a/report/frequency/view.php
+++ b/report/frequency/view.php
@@ -24,9 +24,10 @@
 
 use mod_surveypro\utility_layout;
 use mod_surveypro\tabs;
+use surveyproreport_frequency\filterform;
+use surveyproreport_frequency\report;
 
 require_once(dirname(dirname(dirname(dirname(dirname(__FILE__))))).'/config.php');
-require_once($CFG->dirroot.'/mod/surveypro/report/frequency/classes/itemfilter_form.php');
 require_once($CFG->dirroot.'/mod/surveypro/report/frequency/lib.php');
 require_once($CFG->libdir.'/tablelib.php');
 
@@ -53,7 +54,7 @@ $context = \context_module::instance($cm->id);
 require_capability('mod/surveypro:accessreports', $context);
 
 $utilitylayoutman = new utility_layout($cm, $surveypro);
-$reportman = new surveyproreport_frequency_report($cm, $context, $surveypro);
+$reportman = new report($cm, $context, $surveypro);
 
 // Begin of: instance filterform.
 $showjumper = $reportman->is_groupjumper_needed();
@@ -72,7 +73,7 @@ if ($showjumper) {
     $formparams->addnotinanygroup = $reportman->add_notinanygroup();
     $formparams->jumpercontent = $jumpercontent;
 }
-$filterform = new mod_surveypro_itemfilterform($formurl, $formparams); // No autosubmit, here.
+$filterform = new filterform($formurl, $formparams); // No autosubmit, here.
 // End of: instance filterform.
 
 // Output starts here.

--- a/report/lateusers/classes/groupjumperform.php
+++ b/report/lateusers/classes/groupjumperform.php
@@ -22,6 +22,8 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace surveyproreport_lateusers;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot.'/lib/formslib.php');
@@ -33,7 +35,7 @@ require_once($CFG->dirroot.'/lib/formslib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_surveypro_lateusers_groupjumper extends \moodleform {
+class groupjumperform extends \moodleform {
 
     /**
      * Definition.

--- a/report/lateusers/classes/report.php
+++ b/report/lateusers/classes/report.php
@@ -22,6 +22,8 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace surveyproreport_lateusers;
+
 defined('MOODLE_INTERNAL') || die();
 
 use mod_surveypro\reportbase;
@@ -35,7 +37,7 @@ require_once($CFG->libdir.'/tablelib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class surveyproreport_lateusers_report extends reportbase {
+class report extends reportbase {
 
     /**
      * @var flexible_table $outputtable

--- a/report/lateusers/view.php
+++ b/report/lateusers/view.php
@@ -23,9 +23,10 @@
  */
 
 use mod_surveypro\tabs;
+use surveyproreport_lateusers\groupjumperform;
+use surveyproreport_lateusers\report;
 
 require_once(dirname(dirname(dirname(dirname(dirname(__FILE__))))).'/config.php');
-require_once($CFG->dirroot.'/mod/surveypro/report/lateusers/classes/groupjumper_form.php');
 require_once($CFG->libdir.'/tablelib.php');
 
 $id = optional_param('id', 0, PARAM_INT);
@@ -51,7 +52,7 @@ $context = \context_module::instance($cm->id);
 // Required capability.
 require_capability('mod/surveypro:accessreports', $context);
 
-$reportman = new surveyproreport_lateusers_report($cm, $context, $surveypro);
+$reportman = new report($cm, $context, $surveypro);
 $reportman->set_groupid($groupid);
 $reportman->setup_outputtable();
 
@@ -83,7 +84,7 @@ if ($showjumper) {
     $formparams->addnotinanygroup = false;
     $formparams->jumpercontent = $jumpercontent;
     $attributes = array('id' => 'surveypro_jumperform');
-    $groupfilterform = new mod_surveypro_lateusers_groupjumper($formurl, $formparams, null, null, $attributes);
+    $groupfilterform = new groupjumperform($formurl, $formparams, null, null, $attributes);
 
     $PAGE->requires->js_amd_inline("
     require(['jquery'], function($) {

--- a/report/responsesperuser/classes/groupjumperform.php
+++ b/report/responsesperuser/classes/groupjumperform.php
@@ -17,10 +17,12 @@
 /**
  * Class to filter output by group
  *
- * @package   surveyproreport_colles
+ * @package   surveyproreport_responsesperuser
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+
+namespace surveyproreport_responsesperuser;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -29,11 +31,11 @@ require_once($CFG->dirroot.'/lib/formslib.php');
 /**
  * The class to filter the attachment item to overview
  *
- * @package   surveyproreport_colles
+ * @package   surveyproreport_responsesperuser
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_surveypro_colles_groupjumper extends \moodleform {
+class groupjumperform extends \moodleform {
 
     /**
      * Definition.

--- a/report/responsesperuser/classes/report.php
+++ b/report/responsesperuser/classes/report.php
@@ -22,6 +22,8 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace surveyproreport_responsesperuser;
+
 defined('MOODLE_INTERNAL') || die();
 
 use mod_surveypro\reportbase;
@@ -35,7 +37,7 @@ require_once($CFG->libdir.'/tablelib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class surveyproreport_responsesperuser_report extends reportbase {
+class report extends reportbase {
 
     /**
      * @var flexible_table $outputtable

--- a/report/responsesperuser/view.php
+++ b/report/responsesperuser/view.php
@@ -23,9 +23,10 @@
  */
 
 use mod_surveypro\tabs;
+use surveyproreport_responsesperuser\groupjumperform;
+use surveyproreport_responsesperuser\report;
 
 require_once(dirname(dirname(dirname(dirname(dirname(__FILE__))))).'/config.php');
-require_once($CFG->dirroot.'/mod/surveypro/report/responsesperuser/classes/groupjumper_form.php');
 require_once($CFG->libdir.'/tablelib.php');
 
 $id = optional_param('id', 0, PARAM_INT);
@@ -51,7 +52,7 @@ $context = \context_module::instance($cm->id);
 // Required capability.
 require_capability('mod/surveypro:accessreports', $context);
 
-$reportman = new surveyproreport_responsesperuser_report($cm, $context, $surveypro);
+$reportman = new report($cm, $context, $surveypro);
 $reportman->set_groupid($groupid);
 $reportman->setup_outputtable();
 
@@ -70,7 +71,7 @@ if ($showjumper) {
     $formparams->addnotinanygroup = $reportman->add_notinanygroup();
     $formparams->jumpercontent = $jumpercontent;
     $attributes = array('id' => 'surveypro_jumperform');
-    $groupfilterform = new mod_surveypro_responsesperuser_groupjumper($formurl, $formparams, null, null, $attributes);
+    $groupfilterform = new groupjumperform($formurl, $formparams, null, null, $attributes);
 
     $PAGE->requires->js_amd_inline("
     require(['jquery'], function($) {

--- a/report/userspercount/classes/groupjumperform.php
+++ b/report/userspercount/classes/groupjumperform.php
@@ -15,25 +15,27 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Class to filter the attachment item to overview
+ * Class to filter output by group
  *
- * @package   surveyproreport_attachments
+ * @package   surveyproreport_userspercount
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+
+namespace surveyproreport_userspercount;
 
 defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot.'/lib/formslib.php');
 
 /**
- * Class to filter output by group
+ * The class to filter the attachment item to overview
  *
- * @package   surveyproreport_attachments
+ * @package   surveyproreport_userspercount
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_surveypro_attachments_groupjumper extends \moodleform {
+class groupjumperform extends \moodleform {
 
     /**
      * Definition.

--- a/report/userspercount/classes/report.php
+++ b/report/userspercount/classes/report.php
@@ -22,6 +22,8 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace surveyproreport_userspercount;
+
 defined('MOODLE_INTERNAL') || die();
 
 use mod_surveypro\reportbase;
@@ -35,7 +37,7 @@ require_once($CFG->libdir.'/tablelib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class surveyproreport_userspercount_report extends reportbase {
+class report extends reportbase {
 
     /**
      * @var flexible_table $outputtable

--- a/report/userspercount/view.php
+++ b/report/userspercount/view.php
@@ -23,9 +23,10 @@
  */
 
 use mod_surveypro\tabs;
+use surveyproreport_userspercount\groupjumperform;
+use surveyproreport_userspercount\report;
 
 require_once(dirname(dirname(dirname(dirname(dirname(__FILE__))))).'/config.php');
-require_once($CFG->dirroot.'/mod/surveypro/report/userspercount/classes/groupjumper_form.php');
 require_once($CFG->libdir.'/tablelib.php');
 
 $id = optional_param('id', 0, PARAM_INT);
@@ -51,7 +52,7 @@ $context = \context_module::instance($cm->id);
 // Required capability.
 require_capability('mod/surveypro:accessreports', $context);
 
-$reportman = new surveyproreport_userspercount_report($cm, $context, $surveypro);
+$reportman = new report($cm, $context, $surveypro);
 $reportman->set_groupid($groupid);
 $reportman->setup_outputtable();
 
@@ -70,7 +71,7 @@ if ($showjumper) {
     $formparams->addnotinanygroup = $reportman->add_notinanygroup();
     $formparams->jumpercontent = $jumpercontent;
     $attributes = array('id' => 'surveypro_jumperform');
-    $groupfilterform = new mod_surveypro_userspercount_groupjumper($formurl, $formparams, null, null, $attributes);
+    $groupfilterform = new groupjumperform($formurl, $formparams, null, null, $attributes);
 
     $PAGE->requires->js_amd_inline("
     require(['jquery'], function($) {

--- a/tests/behat/submission_test.feature
+++ b/tests/behat/submission_test.feature
@@ -5,7 +5,7 @@ Feature: make a submission test for each available item
   I fill a surveypro and go to see responses
 
   @javascript @_file_upload
-  Scenario: test a submission works fine for each available core item
+  Scenario: test a submission with each core item
     Given the following "courses" exist:
       | fullname                                | shortname       | category | groupmode |
       | Test submission for each available item | Submission test | 0        | 0         |


### PR DESCRIPTION
Running the attachment report it is possible to ask for details of each attachment. If they are requested the page diplaying them uses "Report" as page and not as TAB.

Branch build on top of "namespace added to reports too" (#637)