### PR TITLE
Dropped "return true" to keep the button enabled

### DIFF
--- a/classes/view_export.php
+++ b/classes/view_export.php
@@ -388,7 +388,6 @@ class view_export {
         $this->export_write_xlsrecord($rowcounter, $recordtoexport, $worksheet);
 
         $workbook->close();
-        return true;
     }
 
     /**


### PR DESCRIPTION
At the end of the export to excel of saved responses the "Continue" form button was unexpectedly disabled.
This is an issue if people ask to download to excel twice (for instance for "closed" and "in progress" responses separately).
It seems that dropping "return true" or changing it with exit; fixes the issue.
