### PR TITLE
Refined issue id 652

### DIFF
--- a/classes/view_export.php
+++ b/classes/view_export.php
@@ -396,6 +396,7 @@ class view_export {
         $this->export_write_xlsrecord($rowcounter, $recordtoexport, $worksheet);
 
         $workbook->close();
+        exit;
     }
 
     /**


### PR DESCRIPTION
The 'Continue' button is still disabled after a download to excel of responses so the user is not allowed to download twice.
The workaround is simple: just reload the page but if I can fix it, this is even better.