### PR TITLE
Fixed few  minor details of the relation table

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -42,7 +42,6 @@ table#validaterelations {
 table#manageitems .plugin,
 table#sortitems .plugin,
 table#validaterelations .plugin {
-    padding: 0.5em;
     text-align: center;
 }
 
@@ -85,7 +84,8 @@ table#validaterelations td.parentitem {
 }
 
 table#manageitems td.parentitem span.branch .icon,
-table#sortitems td.parentitem span.branch .icon {
+table#sortitems td.parentitem span.branch .icon,
+table#validaterelations td.parentitem span.branch .icon {
     padding: 0 .1em 0 .1em;
     margin: 0 .1em 0 .1em;
 }


### PR DESCRIPTION
- Relation table sorting is useless as each child must be after the parent
- The best place for parent constraints are in the frame of the parent item
- Relation icons are not well separated as in the item table
- Header of the plugin column is not well vertically aligned