### PR TITLE
removed starting underscore

### DIFF
--- a/field/age/classes/privacy/provider.php
+++ b/field/age/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/field/autofill/classes/privacy/provider.php
+++ b/field/autofill/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/field/boolean/classes/privacy/provider.php
+++ b/field/boolean/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/field/character/classes/privacy/provider.php
+++ b/field/character/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/field/checkbox/classes/privacy/provider.php
+++ b/field/checkbox/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/field/date/classes/privacy/provider.php
+++ b/field/date/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/field/datetime/classes/privacy/provider.php
+++ b/field/datetime/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/field/fileupload/classes/privacy/provider.php
+++ b/field/fileupload/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/field/integer/classes/privacy/provider.php
+++ b/field/integer/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/field/multiselect/classes/privacy/provider.php
+++ b/field/multiselect/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/field/numeric/classes/privacy/provider.php
+++ b/field/numeric/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/field/radiobutton/classes/privacy/provider.php
+++ b/field/radiobutton/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/field/rate/classes/privacy/provider.php
+++ b/field/rate/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/field/recurrence/classes/privacy/provider.php
+++ b/field/recurrence/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/field/select/classes/privacy/provider.php
+++ b/field/select/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/field/shortdate/classes/privacy/provider.php
+++ b/field/shortdate/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/field/textarea/classes/privacy/provider.php
+++ b/field/textarea/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/field/time/classes/privacy/provider.php
+++ b/field/time/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/format/fieldset/classes/privacy/provider.php
+++ b/format/fieldset/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/format/fieldsetend/classes/privacy/provider.php
+++ b/format/fieldsetend/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/format/label/classes/privacy/provider.php
+++ b/format/label/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/format/pagebreak/classes/privacy/provider.php
+++ b/format/pagebreak/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/report/attachments/classes/privacy/provider.php
+++ b/report/attachments/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/report/colles/classes/privacy/provider.php
+++ b/report/colles/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/report/frequency/classes/privacy/provider.php
+++ b/report/frequency/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/report/lateusers/classes/privacy/provider.php
+++ b/report/lateusers/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/report/responsesperuser/classes/privacy/provider.php
+++ b/report/responsesperuser/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/report/userspercount/classes/privacy/provider.php
+++ b/report/userspercount/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/template/attls/classes/privacy/provider.php
+++ b/template/attls/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/template/collesactual/classes/privacy/provider.php
+++ b/template/collesactual/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/template/collesactualpreferred/classes/privacy/provider.php
+++ b/template/collesactualpreferred/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/template/collespreferred/classes/privacy/provider.php
+++ b/template/collespreferred/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/template/criticalincidents/classes/privacy/provider.php
+++ b/template/criticalincidents/classes/privacy/provider.php
@@ -34,16 +34,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/templatemaster/classes/privacy/provider.php
+++ b/templatemaster/classes/privacy/provider.php
@@ -29,14 +29,10 @@ defined('MOODLE_INTERNAL') || die();
 /**
  * Privacy Subsystem for template_templatemaster implementing null_provider.
  *
- * @package   mod_surveypro
  * @copyright 2018 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class provider implements \core_privacy\local\metadata\null_provider {
-
-    // To provide php 5.6 (33_STABLE) and up support.
-    use \core_privacy\local\legacy_polyfill;
 
     /**
      * Get the language string identifier with the component's language
@@ -44,7 +40,7 @@ class provider implements \core_privacy\local\metadata\null_provider {
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }


### PR DESCRIPTION
Following code ckecker report,
each instance of public static function _get_reason() {
has been replaced by
public static function get_reason() : string {

In the frame of the same intervention
    // To provide php 5.6 (33_STABLE) and up support.
    use \core_privacy\local\legacy_polyfill;
has been dropped too.