### PR TITLE
replaced print_error with throw new moodle_exception

### DIFF
--- a/classes/layout_itemsetup.php
+++ b/classes/layout_itemsetup.php
@@ -847,7 +847,7 @@ class layout_itemsetup {
 
         if (!is_array($where)) {
             $a = 'get_children';
-            print_error('arrayexpected', 'mod_surveypro', null, $a);
+            throw new moodle_exception('arrayexpected', 'mod_surveypro', null, $a);
         }
 
         $idscontainer = array($baseitemid);
@@ -885,7 +885,7 @@ class layout_itemsetup {
 
         if (!is_array($additionalcondition)) {
             $a = 'add_parent_node';
-            print_error('arrayexpected', 'mod_surveypro', null, $a);
+            throw new moodle_exception('arrayexpected', 'mod_surveypro', null, $a);
         }
 
         $nodelist = array($this->sortindex => $this->rootitemid);
@@ -1039,7 +1039,7 @@ class layout_itemsetup {
      */
     public function prevent_direct_user_input() {
         if ($this->surveypro->template) {
-            print_error('incorrectaccessdetected', 'mod_surveypro');
+            throw new moodle_exception('incorrectaccessdetected', 'mod_surveypro');
         }
     }
 

--- a/classes/layout_preview.php
+++ b/classes/layout_preview.php
@@ -83,7 +83,7 @@ class layout_preview extends formbase {
      */
     private function prevent_direct_user_input() {
         if (!has_capability('mod/surveypro:preview', $this->context)) {
-            print_error('incorrectaccessdetected', 'mod_surveypro');
+            throw new moodle_exception('incorrectaccessdetected', 'mod_surveypro');
         }
     }
 

--- a/classes/tabs.php
+++ b/classes/tabs.php
@@ -369,7 +369,7 @@ class tabs {
 
                 break;
             default:
-                print_error('incorrectaccessdetected', 'mod_surveypro');
+                throw new moodle_exception('incorrectaccessdetected', 'mod_surveypro');
         }
 
         print_tabs($this->tabs, $pageid, $inactive, $activetwo);

--- a/classes/usertemplate.php
+++ b/classes/usertemplate.php
@@ -142,7 +142,7 @@ class usertemplate extends templatebase {
             $a = new \stdClass();
             $a->sharinglevel = $sharinglevel;
             $a->methodname = 'get_contextid_from_sharinglevel';
-            print_error('wrong_sharinglevel_found', 'mod_surveypro', null, $a);
+            throw new moodle_exception('wrong_sharinglevel_found', 'mod_surveypro', null, $a);
         }
 
         switch ($contextlevel) {

--- a/classes/view_form.php
+++ b/classes/view_form.php
@@ -286,7 +286,7 @@ class view_form extends formbase {
                 $a->startingpage = 'SURVEYPRO_LEFT_OVERFLOW';
             }
             $a->methodname = 'next_not_empty_page';
-            print_error('wrong_direction_found', 'mod_surveypro', null, $a);
+            throw new moodle_exception('wrong_direction_found', 'mod_surveypro', null, $a);
         }
 
         if ($startingpage == SURVEYPRO_RIGHT_OVERFLOW) {
@@ -718,7 +718,7 @@ class view_form extends formbase {
             $item->userform_save_preprocessing($iteminfo->contentperelement, $useranswer, false);
 
             if ($useranswer->content === SURVEYPRO_DUMMYCONTENT) {
-                print_error('wrong_userdatarec_found', 'mod_surveypro', null, SURVEYPRO_DUMMYCONTENT);
+                throw new moodle_exception('wrong_userdatarec_found', 'mod_surveypro', null, SURVEYPRO_DUMMYCONTENT);
             } else {
                 $DB->update_record('surveypro_answer', $useranswer);
             }
@@ -1231,7 +1231,7 @@ class view_form extends formbase {
         if (($this->view == SURVEYPRO_READONLYRESPONSE) || ($this->view == SURVEYPRO_EDITRESPONSE)) {
             $where = array('id' => $this->get_submissionid());
             if (!$submission = $DB->get_record('surveypro_submission', $where, '*', IGNORE_MISSING)) {
-                print_error('incorrectaccessdetected', 'mod_surveypro');
+                throw new moodle_exception('incorrectaccessdetected', 'mod_surveypro');
             }
             if ($submission->userid != $USER->id) {
                 $groupmode = groups_get_activity_groupmode($this->cm, $COURSE);
@@ -1306,7 +1306,7 @@ class view_form extends formbase {
                 $allowed = false;
         }
         if (!$allowed) {
-            print_error('incorrectaccessdetected', 'mod_surveypro');
+            throw new moodle_exception('incorrectaccessdetected', 'mod_surveypro');
         }
     }
 

--- a/classes/view_submissions.php
+++ b/classes/view_submissions.php
@@ -1326,7 +1326,7 @@ class view_submissions {
         if ($this->action != SURVEYPRO_DELETEALLRESPONSES) { // If a specific submission is involved.
             $ownerid = $DB->get_field('surveypro_submission', 'userid', array('id' => $this->submissionid), IGNORE_MISSING);
             if (!$ownerid) {
-                print_error('incorrectaccessdetected', 'mod_surveypro');
+                throw new moodle_exception('incorrectaccessdetected', 'mod_surveypro');
             }
 
             $ismine = ($ownerid == $USER->id);
@@ -1405,7 +1405,7 @@ class view_submissions {
         }
 
         if (!$allowed) {
-            print_error('incorrectaccessdetected', 'mod_surveypro');
+            throw new moodle_exception('incorrectaccessdetected', 'mod_surveypro');
         }
     }
 

--- a/field/autofill/classes/item.php
+++ b/field/autofill/classes/item.php
@@ -520,7 +520,7 @@ EOS;
                     $olduseranswer->content = $answer['mainelement'];
                 } else {
                     $a = '$answer = '.$answer;
-                    print_error('unhandledvalue', 'mod_surveypro', null, $a);
+                    throw new moodle_exception('unhandledvalue', 'mod_surveypro', null, $a);
                 }
             }
             return;

--- a/field/radiobutton/classes/item.php
+++ b/field/radiobutton/classes/item.php
@@ -757,7 +757,7 @@ EOS;
         }
 
         $a = '$answer = '.$answer;
-        print_error('unhandledvalue', 'mod_surveypro', null, $a);
+        throw new moodle_exception('unhandledvalue', 'mod_surveypro', null, $a);
     }
 
     /**

--- a/report/attachments/classes/form.php
+++ b/report/attachments/classes/form.php
@@ -116,7 +116,7 @@ class form {
         $allowed = has_capability('mod/surveypro:accessreports', $this->context);
 
         if (!$allowed) {
-            print_error('incorrectaccessdetected', 'mod_surveypro');
+            throw new moodle_exception('incorrectaccessdetected', 'mod_surveypro');
         }
     }
 

--- a/report/attachments/classes/report.php
+++ b/report/attachments/classes/report.php
@@ -226,7 +226,7 @@ class report extends reportbase {
      */
     public function prevent_direct_user_input() {
         if (!empty($this->surveypro->anonymous)) {
-            print_error('incorrectaccessdetected', 'mod_surveypro');
+            throw new moodle_exception('incorrectaccessdetected', 'mod_surveypro');
         }
     }
 }


### PR DESCRIPTION
Following the Code Checker report
each instance of print_error has been replaced with new moodle_exception leaving passed parameters untouched.