### PR TITLE
Added logs for reminder emails

### DIFF
--- a/classes/event/abandoned_submission_deleted.php
+++ b/classes/event/abandoned_submission_deleted.php
@@ -1,0 +1,62 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * mod_surveypro submission modified event.
+ *
+ * @package   mod_surveypro
+ * @copyright 2013 onwards kordan <kordan@mclink.it>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_surveypro\event;
+
+/**
+ * The mod_surveypro submission modified event class.
+ *
+ * @package   mod_surveypro
+ * @copyright 2013 onwards kordan <kordan@mclink.it>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class abandoned_submission_deleted extends \core\event\base {
+
+    /**
+     * Set basic properties for the event
+     */
+    protected function init() {
+        $this->data['crud'] = 'r'; // One of these: c(reate), r(ead), u(pdate), d(elete).
+        $this->data['edulevel'] = self::LEVEL_PARTICIPATING;
+        $this->data['objecttable'] = 'surveypro_submission';
+    }
+
+    /**
+     * Return localised event name.
+     *
+     * @return string
+     */
+    public static function get_name() {
+        return get_string('abandoned_submission_deleted', 'mod_surveypro');
+    }
+
+    /**
+     * Returns description of what happened.
+     *
+     * @return string
+     */
+    public function get_description() {
+        return "Response has been deleted as abandoned in surveypro id {$this->objectid}.";
+    }
+}

--- a/classes/event/mail_neverstarted_sent.php
+++ b/classes/event/mail_neverstarted_sent.php
@@ -1,0 +1,62 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * mod_surveypro submission modified event.
+ *
+ * @package   mod_surveypro
+ * @copyright 2013 onwards kordan <kordan@mclink.it>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_surveypro\event;
+
+/**
+ * The mod_surveypro submission modified event class.
+ *
+ * @package   mod_surveypro
+ * @copyright 2013 onwards kordan <kordan@mclink.it>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class mail_neverstarted_sent extends \core\event\base {
+
+    /**
+     * Set basic properties for the event
+     */
+    protected function init() {
+        $this->data['crud'] = 'r'; // One of these: c(reate), r(ead), u(pdate), d(elete).
+        $this->data['edulevel'] = self::LEVEL_PARTICIPATING;
+        $this->data['objecttable'] = 'surveypro_submission';
+    }
+
+    /**
+     * Return localised event name.
+     *
+     * @return string
+     */
+    public static function get_name() {
+        return get_string('event_mailneverstarted_sent', 'mod_surveypro');
+    }
+
+    /**
+     * Returns description of what happened.
+     *
+     * @return string
+     */
+    public function get_description() {
+        return "Email was sent due to never started surveypro id {$this->objectid}.";
+    }
+}

--- a/classes/event/mail_oneshotmp_sent.php
+++ b/classes/event/mail_oneshotmp_sent.php
@@ -1,0 +1,62 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * mod_surveypro submission modified event.
+ *
+ * @package   mod_surveypro
+ * @copyright 2013 onwards kordan <kordan@mclink.it>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_surveypro\event;
+
+/**
+ * The mod_surveypro submission modified event class.
+ *
+ * @package   mod_surveypro
+ * @copyright 2013 onwards kordan <kordan@mclink.it>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class mail_oneshotmp_sent extends \core\event\base {
+
+    /**
+     * Set basic properties for the event
+     */
+    protected function init() {
+        $this->data['crud'] = 'r'; // One of these: c(reate), r(ead), u(pdate), d(elete).
+        $this->data['edulevel'] = self::LEVEL_PARTICIPATING;
+        $this->data['objecttable'] = 'surveypro_submission';
+    }
+
+    /**
+     * Return localised event name.
+     *
+     * @return string
+     */
+    public static function get_name() {
+        return get_string('event_mailoneshotmp_sent', 'mod_surveypro');
+    }
+
+    /**
+     * Returns description of what happened.
+     *
+     * @return string
+     */
+    public function get_description() {
+        return "Email was sent to remind interrupted one shot surveypro id {$this->objectid}.";
+    }
+}

--- a/classes/event/mail_pauseresume_sent.php
+++ b/classes/event/mail_pauseresume_sent.php
@@ -1,0 +1,62 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * mod_surveypro submission modified event.
+ *
+ * @package   mod_surveypro
+ * @copyright 2013 onwards kordan <kordan@mclink.it>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_surveypro\event;
+
+/**
+ * The mod_surveypro submission modified event class.
+ *
+ * @package   mod_surveypro
+ * @copyright 2013 onwards kordan <kordan@mclink.it>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class mail_pauseresume_sent extends \core\event\base {
+
+    /**
+     * Set basic properties for the event
+     */
+    protected function init() {
+        $this->data['crud'] = 'r'; // One of these: c(reate), r(ead), u(pdate), d(elete).
+        $this->data['edulevel'] = self::LEVEL_PARTICIPATING;
+        $this->data['objecttable'] = 'surveypro_submission';
+    }
+
+    /**
+     * Return localised event name.
+     *
+     * @return string
+     */
+    public static function get_name() {
+        return get_string('event_mailpauseresume_sent', 'mod_surveypro');
+    }
+
+    /**
+     * Returns description of what happened.
+     *
+     * @return string
+     */
+    public function get_description() {
+        return "Email was sent to remind paused surveypro id {$this->objectid}.";
+    }
+}

--- a/classes/task/mail_neverstarted.php
+++ b/classes/task/mail_neverstarted.php
@@ -64,7 +64,6 @@ class mail_neverstarted extends crontaskbase {
             $subject = get_string('reminder_subject', 'surveypro', $SITE->fullname);
 
             foreach ($surveypros as $surveypro) {
-                // Search for users with unstarted submissions.
                 $cm = get_coursemodule_from_instance('surveypro', $surveypro->id, $surveypro->course, false, MUST_EXIST);
                 $context = \context_module::instance($cm->id);
 
@@ -92,6 +91,11 @@ class mail_neverstarted extends crontaskbase {
                     $message = get_string('remindneverstarted_content', 'surveypro', $a);
                     // Direct email.
                     email_to_user($user, $from, $subject, $message);
+
+                    // Event: mail_neverstarted_sent.
+                    $eventdata = ['context' => $context, 'objectid' => $surveypro->id, 'relateduserid' => $user->id];
+                    $event = \mod_surveypro\event\mail_neverstarted_sent::create($eventdata);
+                    $event->trigger();
                 }
             }
         }

--- a/classes/task/mail_oneshotmp.php
+++ b/classes/task/mail_oneshotmp.php
@@ -75,6 +75,9 @@ class mail_oneshotmp extends crontaskbase {
             $subject = get_string('reminder_subject', 'surveypro', $SITE->fullname);
 
             foreach ($surveypros as $surveypro) {
+                $cm = get_coursemodule_from_instance('surveypro', $surveypro->id, $surveypro->course, false, MUST_EXIST);
+                $context = \context_module::instance($cm->id);
+
                 // Search for users with in progress surveypro.
                 $whereparams = array();
                 $submissiontable = 'SELECT userid, surveyproid
@@ -118,6 +121,11 @@ class mail_oneshotmp extends crontaskbase {
                     $message .= get_string('reminderoneshot_content3', 'surveypro', $a->surveyprourl);
                     // Direct email.
                     email_to_user($user, $from, $subject, $message);
+
+                    // Event: mail_oneshotmp_sent.
+                    $eventdata = ['context' => $context, 'objectid' => $surveypro->id, 'relateduserid' => $user->id];
+                    $event = \mod_surveypro\event\mail_oneshotmp_sent::create($eventdata);
+                    $event->trigger();
                 }
             }
         }

--- a/classes/task/mail_pauseresume.php
+++ b/classes/task/mail_pauseresume.php
@@ -75,6 +75,9 @@ class mail_pauseresume extends crontaskbase {
             $subject = get_string('reminder_subject', 'surveypro', $SITE->fullname);
 
             foreach ($surveypros as $surveypro) {
+                $cm = get_coursemodule_from_instance('surveypro', $surveypro->id, $surveypro->course, false, MUST_EXIST);
+                $context = \context_module::instance($cm->id);
+
                 // Search for users with in progress surveypro.
                 $whereparams = array();
                 $submissiontable = 'SELECT userid, surveyproid
@@ -117,6 +120,11 @@ class mail_pauseresume extends crontaskbase {
                     $message .= get_string('reminderpaused_content3', 'surveypro', $a->surveyprourl);
                     // Direct email.
                     email_to_user($user, $from, $subject, $message);
+
+                    // Event: mail_pauseresume_sent.
+                    $eventdata = ['context' => $context, 'objectid' => $surveypro->id, 'relateduserid' => $user->id];
+                    $event = \mod_surveypro\event\mail_pauseresume_sent::create($eventdata);
+                    $event->trigger();
                 }
             }
         }

--- a/lang/en/surveypro.php
+++ b/lang/en/surveypro.php
@@ -60,6 +60,7 @@ $string['tabmtemplatename'] = 'Master templates';
     $string['tabmtemplatepage2'] = 'Apply';
 $string['tabreportsname'] = 'Reports';
 
+$string['abandoned_submission_deleted'] = 'Deleted abandoned response';
 $string['action_help'] = 'Operate on elements already present in the survey with the following action.';
 $string['action'] = 'Preexisting elements';
 $string['addnewsubmission'] = 'New response';
@@ -174,6 +175,9 @@ $string['event_item_deleted'] = 'An item has been deleted';
 $string['event_item_hidden'] = 'An item has been hidden';
 $string['event_item_modified'] = 'An item has been modified';
 $string['event_item_shown'] = 'An item has been shown';
+$string['event_mailneverstarted_sent'] = 'Email sent for never started survey';
+$string['event_mailoneshotmp_sent'] = 'Email sent for abandoned one shot multi page survey';
+$string['event_mailpauseresume_sent'] = 'Email sent for abandoned paused survey';
 $string['event_mastertemplate_applied'] = 'A master template has been applied';
 $string['event_mastertemplate_saved'] = 'A master template has been saved';
 $string['event_submission_created'] = 'A response has been created';

--- a/lang/it/surveypro.php
+++ b/lang/it/surveypro.php
@@ -59,6 +59,7 @@ $string['tabmtemplatename'] = 'Template sistema';
     $string['tabmtemplatepage1'] = 'Genera';
     $string['tabmtemplatepage2'] = 'Applica';
 
+$string['abandoned_submission_deleted'] = 'Eliminata risposta abbandonata';
 $string['addnewsubmission'] = 'Nuova risposta';
 $string['answerisnoanswer'] = 'Risposta rifiutata';
 $string['answernotsubmitted'] = 'Risposta omessa';
@@ -94,6 +95,9 @@ $string['event_item_deleted'] = 'Cancellato item';
 $string['event_item_hidden'] = 'Nascosto item';
 $string['event_item_modified'] = 'Modificato item';
 $string['event_item_shown'] = 'Visualizzato item';
+$string['event_mailneverstarted_sent'] = 'Sollecitata l\'indagine mai avviata';
+$string['event_mailoneshotmp_sent'] = 'Sollecitata l\'indagine su più pagine';
+$string['event_mailpauseresume_sent'] = 'Sollecitata l\'indagine in pausa';
 $string['event_mastertemplate_applied'] = 'Applicato "template di sistema"';
 $string['event_mastertemplate_saved'] = 'Salvato "template di sistema"';
 $string['event_submission_created'] = 'Inviata nuova risposta';

--- a/version.php
+++ b/version.php
@@ -26,6 +26,6 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_surveypro';
 $plugin->maturity = MATURITY_ALPHA;
-$plugin->version = 2022042600;
+$plugin->version = 2022051900;
 $plugin->release = '1.0';
 $plugin->requires = 2021051700;


### PR DESCRIPTION
Three logs were added:
1) logs for email sent because of never started surveys
2) logs for email sent because of abandoned one page surveys
3) logs for email sent because of abandoned survey where pause/resume is allowed.

Classes in surveypro/classes/event were purged of unused methods.
The message is so simple that there is non need of $this->other[] params.
The function validate_data() was conseguently dropped.
Tested only for never started surveys.