### PR TITLE
Added 'page in tab bar' to 'And I follow "Responses"'

### DIFF
--- a/tests/behat/duplicate_response.feature
+++ b/tests/behat/duplicate_response.feature
@@ -58,7 +58,7 @@ Feature: duplicate response
     When I log in as "admin"
     And I am on "Duplicate response" course homepage
     And I follow "Duplicate response sp"
-    And I follow "Responses"
+    And I follow "Responses" page in tab bar
     # Duplicate other original response
     And I click on "//a[contains(@id,'duplicate_submission_row_1')]" "xpath_element"
     Then I should see "Are you sure you want duplicate the response owned by student1 user1, created on"


### PR DESCRIPTION
Fixed the only survived issue (only using suite=default):

001 Scenario: Duplicate a response # /Applications/MAMP/htdocs/stable/mod/surveypro/tests/behat/duplicate_response.feature:8
      And I follow "Responses"     # /Applications/MAMP/htdocs/stable/mod/surveypro/tests/behat/duplicate_response.feature:61
        The "(//html/.//a
        [./@href][((./@id = 'Responses' or contains(normalize-space(string(.)), 'Responses') or contains(./@title, 'Responses') or contains(./@rel, 'Responses')) or .//*[(contains(concat(' ', @class, ' '), ' icon ') or self::img) and (contains(./@alt, 'Responses') or contains(./@title, 'Responses'))])] | //html/.//*
        [translate(./@role, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz') = 'link'][((./@id = 'Responses' or contains(./@value, 'Responses')) or contains(./@title, 'Responses') or contains(normalize-space(string(.)), 'Responses'))])[1]" xpath node is not visible and it should be visible (Behat\Mink\Exception\ExpectationException)

Now the outcome is:

/Applications/MAMP/htdocs/stable[MOODLE_311_STABLE|●1✚1] % vendor/bin/behat --config /Applications/MAMP/data/behat$instance/behatrun/behat/behat.yml --suite=classic --name="Duplicate a response"

Moodle 3.11.7+ (Build: 20220624), 1f6ab2b67640ce4f5038c100fbd626f9b4954f7a
Php: 7.4.2, mysqli: 5.7.26, OS: Darwin 21.5.0 x86_64
Run optional tests:
- Accessibility: No
Server OS "Darwin", Browser: "firefox"
Started at 28-06-2022, 18:08
.......................................

1 scenario (1 superato)
39 passaggi (39 superati)
0m23.59s (27.95Mb)
/Applications/MAMP/htdocs/stable[MOODLE_311_STABLE|●1✚1] % vendor/bin/behat --config /Applications/MAMP/data/behat$instance/behatrun/behat/behat.yml --suite=default --name="Duplicate a response"

Moodle 3.11.7+ (Build: 20220624), 1f6ab2b67640ce4f5038c100fbd626f9b4954f7a
Php: 7.4.2, mysqli: 5.7.26, OS: Darwin 21.5.0 x86_64
Run optional tests:
- Accessibility: No
Server OS "Darwin", Browser: "firefox"
Started at 28-06-2022, 18:08
.......................................

1 scenario (1 superato)
39 passaggi (39 superati)
0m31.28s (27.86Mb)