### PR TITLE
Fixed the routine to drop no longer allowed answers (Do not merge. #706 is better.)

### DIFF
--- a/tests/behat/regular_submission_on_change_of_mid.feature
+++ b/tests/behat/regular_submission_on_change_of_mid.feature
@@ -1,0 +1,84 @@
+@mod @mod_surveypro @surveyprofield
+Feature: delete no longer allowed answers on user change of mind
+  In order to test the deletion of no longer allowed answers in a parent-child relation over two pages when user changes his answer
+  As a teacher
+  I create a parent-child relation and as a student I fill, return back, change my answer and continue.
+
+  @javascript
+  Scenario: test change my mind
+    Given the following "courses" exist:
+      | fullname       | shortname      | category | groupmode |
+      | Change my mind | Change my mind | 0        | 0         |
+    And the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | teacher  | teacher1@nowhere.net |
+      | student1 | Student   | student  | student1@nowhere.net |
+    And the following "course enrolments" exist:
+      | user     | course            | role           |
+      | teacher1 | Change my mind | editingteacher |
+      | student1 | Change my mind | student        |
+    And the following "activities" exist:
+      | activity  | name                | intro               | newpageforchild | course         |
+      | surveypro | Test change my mind | Test change my mind | 1               | Change my mind |
+    And surveypro "Test change my mind" contains the following items:
+      | type   | plugin      |
+      | field  | character   |
+      | field  | boolean     |
+      | format | pagebreak   |
+      | field  | select      |
+      | field  | numeric     |
+    And I log in as "teacher1"
+    And I am on "Change my mind" course homepage
+    And I follow "Test change my mind"
+    And I follow "Layout"
+
+    And I follow "edit_item_1"
+    And I expand all fieldsets
+    And I set the field "Content" to "Useless question"
+    And I set the field "id_pattern" to "free pattern"
+    And I press "Save changes"
+
+    And I follow "edit_item_2"
+    And I set the field "Content" to "Switching boolean"
+    And I press "Save changes"
+
+    And I follow "edit_item_4"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Content        | Choose a direction             |
+      | Parent element | Boolean [2]: Switching boolean |
+      | Parent content | 0                              |
+    And I set the multiline field "Options" to "North\nEast\nSouth\nWest"
+    And I press "Save changes"
+
+    And I follow "edit_item_5"
+    And I set the field "Content" to "Question without parent"
+    And I press "Save changes"
+
+    And I log out
+
+    # Let the student start to fill the surveypro
+    When I log in as "student1"
+    And I am on "Change my mind" course homepage
+    And I follow "Test change my mind"
+
+    And I press "New response"
+    And I set the field "Useless question" to "Useless answers"
+    And I set the field "Switching boolean" to "0"
+    And I press "Next page >>"
+    Then I should see "Choose a direction"
+    Then I should see "Question without parent"
+
+    And I set the field "Choose a direction" to "South"
+    And I set the field "Question without parent" to "This should remain"
+    And I press "<< Previous page"
+
+    And I set the field "Switching boolean" to "1"
+    And I press "Next page >>"
+    Then I should not see "Choose a direction"
+    Then I should see "Question without parent"
+
+    And I press "Submit"
+    And I press "Continue to responses list"
+    Then I should see "1" submissions
+    Then I should not see "Some answers of this response have been found as unverified."

--- a/tests/behat/submission_test.feature
+++ b/tests/behat/submission_test.feature
@@ -125,7 +125,6 @@ Feature: make a submission test for each available item
     And I log out
 
     When I log in as "teacher1"
-
     And I am on "Test submission for each available item" course homepage
     And I follow "Each item submission"
     And I follow "Responses" page in tab bar


### PR DESCRIPTION
The context of this fix is this: let's suppose I have a surveypro with parent child relation spanning multiple  pages.
On page 1 I have a branching item.
On page 2 I have the child of the branching item AND a question without parent.
I fill the surveypro.
I add an answer for the parent item and I move to page 2.
Here I add an answer for the child item and the free item.
At the end I return back to page 1.
I change my answer to the parent item.
I return to page 2, I fill the free item and I submit.
The submission HAS TO BE CLOSED and not marked as "in progress" because some item has answer not verified.

The original answer to the child item should, actually, be dropped when the student returns to page 2 for the seconf time.
This path corrects the routine to drop answers to this kind of items.