### PR TITLE
Fixed the routine to drop no longer allowed answers (rev 02) (Do not merge. #707 is better.)

### DIFF
--- a/tests/behat/change_of_mind_advanced.feature
+++ b/tests/behat/change_of_mind_advanced.feature
@@ -1,0 +1,122 @@
+@mod @mod_surveypro @surveyprofield
+Feature: advanced deletion of no longer allowed answers on user change of mind
+  Test the deletion of no longer allowed answers in a parent-child relation over three pages when user changes his answer
+  As a teacher
+  I create a parent-child relation and as a student I fill, return back, change my answer and continue.
+
+  @javascript
+  Scenario: Test advanced change of mind
+    Given the following "courses" exist:
+      | fullname       | shortname      | category | groupmode |
+      | Advanced change of mind | Advanced change of mind | 0        | 0         |
+    And the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | teacher  | teacher1@nowhere.net |
+      | student1 | Student   | student  | student1@nowhere.net |
+    And the following "course enrolments" exist:
+      | user     | course                  | role           |
+      | teacher1 | Advanced change of mind | editingteacher |
+      | student1 | Advanced change of mind | student        |
+    And the following "activities" exist:
+      | activity  | name                         | intro                        | newpageforchild | course                  |
+      | surveypro | Test advanced change of mind | Test advanced change of mind | 1               | Advanced change of mind |
+    And surveypro "Test advanced change of mind" contains the following items:
+      | type   | plugin      |
+      | field  | character   |
+      | field  | boolean     |
+      | format | pagebreak   |
+      | field  | radiobutton |
+      | format | pagebreak   |
+      | field  | select      |
+      | field  | checkbox    |
+      | field  | character   |
+    And I log in as "teacher1"
+    And I am on "Advanced change of mind" course homepage
+    And I follow "Test advanced change of mind"
+    And I follow "Layout"
+
+    And I follow "edit_item_1"
+    And I set the field "Required" to "1"
+    And I press "Save changes"
+
+    And I follow "edit_item_2"
+    And I set the field "Required" to "1"
+    And I press "Save changes"
+
+    And I follow "edit_item_4"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Content        | Which pet do you like more? |
+      | Required       | 1                        |
+      | Parent element | Boolean [2]: Is it true?    |
+      | Parent content | 1                           |
+    And I set the multiline field "Options" to "dog\ncat\nbird\ncrocodile"
+    And I press "Save changes"
+
+    And I follow "edit_item_6"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Content        | Choose a direction       |
+      | Required       | 1                        |
+      | Parent element | Boolean [2]: Is it true? |
+      | Parent content | 0                        |
+    And I set the multiline field "Options" to "North\nEast\nSouth\nWest"
+    And I press "Save changes"
+
+    And I follow "edit_item_7"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Required       | 1                        |
+      | Parent element | Boolean [2]: Is it true? |
+      | Parent content | 1                        |
+    And I press "Save changes"
+
+    And I follow "edit_item_8"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Content    | Question without parent |
+      | Required   | 1                       |
+      | id_pattern | free pattern            |
+    And I press "Save changes"
+
+    And I log out
+
+    # Let the student start to fill the surveypro
+    When I log in as "student1"
+    And I am on "Advanced change of mind" course homepage
+    And I follow "Test advanced change of mind"
+
+    And I press "New response"
+    And I set the field "Write down your email" to "su@nowhere.net"
+    And I set the field "Is it true?" to "1"
+    And I press "Next page >>"
+    Then I should see "Which pet do you like more?"
+
+    And I set the following fields to these values:
+      | id_surveypro_field_radiobutton_4_2 | 1 |
+    And I press "Next page >>"
+    Then I should not see "Choose a direction"
+
+    And I set the following fields to these values:
+      | id_surveypro_field_checkbox_7_1 | 1 |
+    And I set the field "Question without parent" to "This should remain"
+    And I press "<< Previous page"
+
+    And I set the following fields to these values:
+      | id_surveypro_field_radiobutton_4_3 | 1 |
+    And I press "<< Previous page"
+
+    And I set the field "Is it true?" to "0"
+    And I press "Next page >>"
+    Then I should see "Page 3 of 3"
+    Then I should not see "Which pet do you like more?"
+    Then I should not see "What do you usually get for breakfast?"
+    Then I should see "Choose a direction"
+    Then I should see "Question without parent"
+
+    And I set the field "Choose a direction" to "South"
+    And I press "Submit"
+
+    And I press "Continue to responses list"
+    Then I should see "1" submissions
+    Then I should not see "Some answers of this response have been found as unverified."

--- a/tests/behat/change_of_mind_simple.feature
+++ b/tests/behat/change_of_mind_simple.feature
@@ -1,0 +1,87 @@
+@mod @mod_surveypro @surveyprofield
+Feature: simple deletion of no longer allowed answers on user change of mind
+  Test the deletion of no longer allowed answers in a parent-child relation over two pages when user changes his answer
+  As a teacher
+  I create a parent-child relation and as a student I fill, return back, change my answer and continue.
+
+  @javascript
+  Scenario: Test simple change of mind
+    Given the following "courses" exist:
+      | fullname              | shortname             | category | groupmode |
+      | Simple change of mind | Simple change of mind | 0        | 0         |
+    And the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | teacher  | teacher1@nowhere.net |
+      | student1 | Student   | student  | student1@nowhere.net |
+    And the following "course enrolments" exist:
+      | user     | course            | role           |
+      | teacher1 | Simple change of mind | editingteacher |
+      | student1 | Simple change of mind | student        |
+    And the following "activities" exist:
+      | activity  | name                       | intro                      | newpageforchild | course                |
+      | surveypro | Test simple change of mind | Test simple change of mind | 1               | Simple change of mind |
+    And surveypro "Test simple change of mind" contains the following items:
+      | type   | plugin      |
+      | field  | character   |
+      | field  | boolean     |
+      | format | pagebreak   |
+      | field  | select      |
+      | field  | character   |
+    And I log in as "teacher1"
+    And I am on "Simple change of mind" course homepage
+    And I follow "Test simple change of mind"
+    And I follow "Layout"
+
+    And I follow "edit_item_1"
+    And I set the field "Required" to "1"
+    And I press "Save changes"
+
+    And I follow "edit_item_2"
+    And I set the field "Required" to "1"
+    And I press "Save changes"
+
+    And I follow "edit_item_4"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Content        | Choose a direction       |
+      | Required       | 1                        |
+      | Parent element | Boolean [2]: Is it true? |
+      | Parent content | 0                        |
+    And I set the multiline field "Options" to "North\nEast\nSouth\nWest"
+    And I press "Save changes"
+
+    And I follow "edit_item_5"
+    And I set the following fields to these values:
+      | Content  | Question without parent |
+      | Required | 1                       |
+      | id_pattern | free pattern            |
+
+    And I press "Save changes"
+
+    And I log out
+
+    # Let the student start to fill the surveypro
+    When I log in as "student1"
+    And I am on "Simple change of mind" course homepage
+    And I follow "Test simple change of mind"
+
+    And I press "New response"
+    And I set the field "Write down your email" to "su@nowhere.net"
+    And I set the field "Is it true?" to "0"
+    And I press "Next page >>"
+    Then I should see "Choose a direction"
+    Then I should see "Question without parent"
+
+    And I set the field "Choose a direction" to "South"
+    And I set the field "Question without parent" to "This should remain"
+    And I press "<< Previous page"
+
+    And I set the field "Is it true?" to "1"
+    And I press "Next page >>"
+    Then I should not see "Choose a direction"
+    Then I should see "Question without parent"
+
+    And I press "Submit"
+    And I press "Continue to responses list"
+    Then I should see "1" submissions
+    Then I should not see "Some answers of this response have been found as unverified."


### PR DESCRIPTION
The context of this fix is this: let's suppose I have a surveypro with parent child relation spanning multiple pages.

Simple scenario
On page 1 I have a branching item.
On page 2 I have the child of the branching item AND a question without parent.
I fill the surveypro.
I add an answer for the parent item and I move to page 2.
Here I add an answer for the child item and for  he free item.
At the end I return back to page 1.
I change my mind and the answer to the parent item.
I return to page 2, I fill the free item and I submit.
The submission HAS TO BE CLOSED and not marked as "in progress" because some item has answer not verified.

The original answer to the child item should, actually, be dropped when the student returns to page 2 for the seconf time.
This patch corrects the routine to drop answers to this kind of items.

Advanced scenario
On page 1 I have a branching item.
On page 2 I have an item depending from branching item when answer is 1.
On page 3 I have an item depending from branching item when answer is 0, one more item depending from branching item when answer is 1 AND one free item (without dependencies).
I fill the surveypro.
I answer 1 to the parent item and I move forward.
I find ai intem in page 2 and I provide an answer.
I move forward and, in page 3, I find the item depending from branching item when answer is 1 AND the free item.
I provide an answer to both of them and I move backward.
I land in page 2. I am free to leave the item untouched or to change the answer.
I move backward once more and I change (in page 1) the answer to branching item (from 1 to 0) and I move forward.
I land in page 3 and I see only the item depending from branching item when answer is 0 and the free item (without dependencies).
I fill the page and I submit.
The submission HAS TO BE CLOSED and not marked as "in progress" because some item has answer not verified.