### PR TITLE
Fixed the routine to drop no longer allowed answers (rev 03) Do not merge. #713 is better.

### DIFF
--- a/classes/view_form.php
+++ b/classes/view_form.php
@@ -852,8 +852,14 @@ class view_form extends formbase {
      * Drop old answers into pages no longer valid.
      *
      * Ok, I am moving from $userformman->formpage to page $userformman->nextpageright.
-     * I need to delete all the answer that were (maybe) written during last input session in this surveypro.
-     * Answers to each item in a page between ($this->formpage + 1) and ($this->nextpageright - 1) included, must be deleted.
+     * I need to verify all the answers that were (maybe) saved during last input session and saved with verified = 0.
+     * I divide this process into two steps.
+     * First step:
+     *     if there are answers to this surveypro saved with verified = 0 and corresponding to items belonging to pages
+     *     between ($this->formpage + 1) and ($this->nextpageright - 1) included, I must delete them.
+     * Second step:
+     *     I check the answers saved with verified = 0 and corresponding to items belonging to page $this->nextpageright.
+     *     For each answer I chech if it is still allowed by its realtion with answers to items in $this->formpage.
      *
      * Example: I am leaving page 3. On the basis of current input (in this page), I have $userformman->nextpageright = 10.
      * Maybe yesterday I had different data in $userformman->formpage = 3 and on that basis I was redirected to page 4.
@@ -864,27 +870,128 @@ class view_form extends formbase {
     public function drop_jumped_saved_data() {
         global $DB;
 
-        if ($this->nextpageright == ($this->get_formpage() + 1)) {
-            return;
-        }
-        if ($this->nextpageright == SURVEYPRO_RIGHT_OVERFLOW) {
-            $pages = range($this->get_formpage() + 1, $this->get_maxassignedpage());
+        $submissionid = $this->get_submissionid();
+        $movingpage = $this->get_formpage();
+
+        // Save to $answerstokill...
+        // the list of the answers to items living between ($movingpage + 1) and ($this->nextpageright - 1)
+        // and saved with verified = 0
+        if ($this->nextpageright == ($movingpage + 1)) {
+            $answerstokill = [];
         } else {
-            $pages = range($this->get_formpage() + 1, $this->nextpageright - 1);
+            if ($this->nextpageright == SURVEYPRO_RIGHT_OVERFLOW) {
+                $lastjumpedpage = $this->get_maxassignedpage();
+            } else {
+                $lastjumpedpage = $this->nextpageright - 1;
+            }
+
+            $sql = 'SELECT a.id
+                FROM {surveypro_answer} a
+                    JOIN {surveypro_item} i ON i.id = a.itemid
+                WHERE a.verified = :verified
+                    AND a.submissionid = :submissionid
+                    AND i.surveyproid = :surveyproid
+                    AND i.formpage > :movingpage
+                    AND i.formpage <= :lastjumpedpage';
+            $whereparams['verified'] = 0;
+            $whereparams['submissionid'] = $submissionid;
+            $whereparams['surveyproid'] = $this->surveypro->id;
+            $whereparams['movingpage'] = $movingpage;
+            $whereparams['lastjumpedpage'] = $lastjumpedpage;
+
+            $answerstokill = $DB->get_records_sql_menu($sql, $whereparams);
+            $answerstokill = array_keys($answerstokill);
         }
 
-        list($insql, $whereparams) = $DB->get_in_or_equal($pages, SQL_PARAMS_NAMED, 'pages');
-        $whereparams['surveyproid'] = $this->surveypro->id;
-        $where = 'surveyproid = :surveyproid
-              AND formpage '.$insql;
-        $itemlistid = $DB->get_records_select('surveypro_item', $where, $whereparams, 'id', 'id');
-        $itemlistid = array_keys($itemlistid);
+        // Each answer to items listed in $allitemsid has to be deleted but... some more may be added.
+        // Add to $answerstokill...
+        // the list of answers to items of pages grater or equal to $this->nextpageright having verified = 0
+        // and no longer allowed by their relations. (due to the change of mind).
+        // To do this I select all the answers to items of page $this->nextpageright having verified = 0
+        // and I verify, for each one of them, if they are still allowed.
 
-        list($insql, $whereparams) = $DB->get_in_or_equal($itemlistid, SQL_PARAMS_NAMED, 'itemid');
-        $whereparams['submissionid'] = $this->formdata->submissionid;
-        $where = 'submissionid = :submissionid
-              AND itemid '.$insql;
-        $DB->delete_records_select('surveypro_answer', $where, $whereparams);
+        // Rationale.
+        // If you arrive to page 2 and you move back to page 1, each answer to items of page 2 is saved with verified = 0.
+        // When you return again to page 2 from page 1,
+        // the code has to delete all the answers previously provided for items currently no longer allowed by relations.
+        // Answers to items still allowed (maybe because not conditioned by relations) will remain alive AND INCORRECT
+        // because they still have surveypro_answer.verified = 0 but...
+        // they will be fixed when the user will move forward from page 2.
+
+        // Note.
+        // I need to verify all the anserws to items of pages GRATER OR EQUAL to $this->nextpageright having verified = 0
+        // and NOT only the anserws to items of page $this->nextpageright having verified = 0
+        // because if I was in page 1, then I moved to page 6, then I returned to page 1 and finally I moved to page 2
+        // it is possible (non sure, only possible) I need to remove answer to items from page 6 (and 6 is greater than 2).
+        if ($this->nextpageright != SURVEYPRO_RIGHT_OVERFLOW) {
+            $sql = 'SELECT a.id as answerid, i.id as itemid, i.parentid, i.parentvalue
+                FROM {surveypro_answer} a
+                    JOIN {surveypro_item} i ON i.id = a.itemid
+                WHERE a.verified = :verified
+                    AND a.submissionid = :submissionid
+                    AND i.surveyproid = :surveyproid
+                    AND i.formpage >= :formpage
+                    AND i.parentid > :parentid
+                ORDER BY i.parentid, i.parentvalue';
+            $whereparams = [];
+            $whereparams['verified'] = 0;
+            $whereparams['submissionid'] = $submissionid;
+            $whereparams['surveyproid'] = $this->surveypro->id;
+            $whereparams['formpage'] = $this->nextpageright;
+            $whereparams['parentid'] = 0;
+
+            $itemsandanswers = $DB->get_recordset_sql($sql, $whereparams);
+
+            // For each item verify if it is still allowed by its relation.
+            // If the relation is still valid, ignore it. You don't have to drop related answers.
+            // If the relation is no longer valid, add it to the list of items with answers to kill.
+            $oldparentid = -1;
+            $oldparentvalue = '';
+            foreach ($itemsandanswers as $itemandanswer) {
+                $parentid = $itemandanswer->parentid;
+                $parentvalue = $itemandanswer->parentvalue;
+
+                $condition = ($parentid == $oldparentid);
+                $condition = $condition && ($parentvalue == $oldparentvalue);
+                if ($condition) {
+                    // Do not submit a new query.
+                    // What you did before is still valid.
+                    if ($action == 'kill') {
+                        $answerstokill[] = (int)$itemandanswer->answerid;
+                    }
+                } else {
+                    $sql = 'SELECT id
+                        FROM {surveypro_answer}
+                        WHERE submissionid = :submissionid
+                            AND itemid = :itemid
+                            AND content = '.$DB->sql_compare_text(':content');
+                    $whereparams = [
+                        'submissionid' => $submissionid,
+                        'itemid' => $parentid,
+                        'content' => $parentvalue
+                    ];
+
+                    if ($DB->record_exists_sql($sql, $whereparams)) {
+                        // The item is allowed by its parent-child relation.
+                        // Do not delete its answers.
+                        $action = 'allow';
+                    } else {
+                        $answerstokill[] = (int)$itemandanswer->answerid;
+                        $action = 'kill';
+                    }
+                }
+                $oldparentid = $parentid;
+                $oldparentvalue = $parentvalue;
+            }
+        }
+
+        // Now it is time to drop answers provided to no longer justified items.
+        if (count($answerstokill)) {
+            list($insql, $whereparams) = $DB->get_in_or_equal($answerstokill, SQL_PARAMS_NAMED, 'id');
+            $where = 'id '.$insql;
+
+            $DB->delete_records_select('surveypro_answer', $where, $whereparams);
+        }
     }
 
     /**

--- a/tests/behat/change_of_mind.feature
+++ b/tests/behat/change_of_mind.feature
@@ -1,0 +1,321 @@
+@mod @mod_surveypro @surveyprofield
+Feature: deletion of no longer allowed answers on user change of mind
+  Test the deletion of no longer allowed answers in a parent-child relation over two pages when user changes his answer
+  As a teacher
+  I create a parent-child relation and as a student I fill, return back, change my answer and continue.
+
+  @javascript
+  Scenario: Test change of mind: 1-2-1-2
+    Given the following "courses" exist:
+      | fullname        | shortname     | category | groupmode |
+      | Change of mind | Change of mind | 0        | 0         |
+    And the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | teacher  | teacher1@nowhere.net |
+      | student1 | Student   | student  | student1@nowhere.net |
+    And the following "course enrolments" exist:
+      | user     | course         | role           |
+      | teacher1 | Change of mind | editingteacher |
+      | student1 | Change of mind | student        |
+    And the following "activities" exist:
+      | activity  | name                | intro               | newpageforchild | course         |
+      | surveypro | Test change of mind | Test change of mind | 1               | Change of mind |
+    And surveypro "Test change of mind" contains the following items:
+      | type   | plugin      |
+      | field  | character   |
+      | field  | boolean     |
+      | format | pagebreak   |
+      | field  | select      |
+      | field  | character   |
+    And I log in as "teacher1"
+    And I am on "Change of mind" course homepage
+    And I follow "Test change of mind"
+    And I follow "Layout"
+
+    And I follow "edit_item_1"
+    And I set the field "Required" to "1"
+    And I press "Save changes"
+
+    And I follow "edit_item_2"
+    And I set the field "Required" to "1"
+    And I press "Save changes"
+
+    And I follow "edit_item_4"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Content        | Choose a direction       |
+      | Required       | 1                        |
+      | Parent element | Boolean [2]: Is it true? |
+      | Parent content | 0                        |
+    And I set the multiline field "Options" to "North\nEast\nSouth\nWest"
+    And I press "Save changes"
+
+    And I follow "edit_item_5"
+    And I set the following fields to these values:
+      | Content    | Question without parent |
+      | Required   | 1                       |
+      | id_pattern | free pattern            |
+
+    And I press "Save changes"
+
+    And I log out
+
+    # Let the student start to fill the surveypro
+    When I log in as "student1"
+    And I am on "Change of mind" course homepage
+    And I follow "Test change of mind"
+
+    And I press "New response"
+    And I set the field "Write down your email" to "su@nowhere.net"
+    And I set the field "Is it true?" to "0"
+    And I press "Next page >>"
+    Then I should see "Choose a direction"
+    Then I should see "Question without parent"
+
+    And I set the field "Choose a direction" to "South"
+    And I set the field "Question without parent" to "This should remain"
+    And I press "<< Previous page"
+
+    And I set the field "Is it true?" to "1"
+    And I press "Next page >>"
+    Then I should not see "Choose a direction"
+    Then I should see "Question without parent"
+
+    And I press "Submit"
+    Then I should not see "Some answers of this response have been found as unverified."
+
+    And I press "Continue to responses list"
+    Then I should see "1" submissions
+
+  @javascript
+  Scenario: Test change of mind: 1-2-1-3
+    Given the following "courses" exist:
+      | fullname               | shortname              | category | groupmode |
+      | 1-2-1-3 change of mind | 1-2-1-3 change of mind | 0        | 0         |
+    And the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | teacher  | teacher1@nowhere.net |
+      | student1 | Student   | student  | student1@nowhere.net |
+    And the following "course enrolments" exist:
+      | user     | course                 | role           |
+      | teacher1 | 1-2-1-3 change of mind | editingteacher |
+      | student1 | 1-2-1-3 change of mind | student        |
+    And the following "activities" exist:
+      | activity  | name                        | intro                       | newpageforchild | course                 |
+      | surveypro | Test 1-2-1-3 change of mind | Test 1-2-1-3 change of mind | 1               | 1-2-1-3 change of mind |
+    And surveypro "Test 1-2-1-3 change of mind" contains the following items:
+      | type   | plugin      |
+      | field  | character   |
+      | field  | boolean     |
+      | format | pagebreak   |
+      | field  | radiobutton |
+      | format | pagebreak   |
+      | field  | select      |
+      | field  | checkbox    |
+      | field  | character   |
+    And I log in as "teacher1"
+    And I am on "1-2-1-3 change of mind" course homepage
+    And I follow "Test 1-2-1-3 change of mind"
+    And I follow "Layout"
+
+    And I follow "edit_item_1"
+    And I set the field "Required" to "1"
+    And I press "Save changes"
+
+    And I follow "edit_item_2"
+    And I set the field "Required" to "1"
+    And I press "Save changes"
+
+    And I follow "edit_item_4"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Content        | Which pet do you like more? |
+      | Required       | 1                           |
+      | Parent element | Boolean [2]: Is it true?    |
+      | Parent content | 1                           |
+    And I set the multiline field "Options" to "dog\ncat\nbird\ncrocodile"
+    And I press "Save changes"
+
+    And I follow "edit_item_6"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Content        | Choose a direction       |
+      | Required       | 1                        |
+      | Parent element | Boolean [2]: Is it true? |
+      | Parent content | 0                        |
+    And I set the multiline field "Options" to "North\nEast\nSouth\nWest"
+    And I press "Save changes"
+
+    And I follow "edit_item_7"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Required       | 1                        |
+      | Parent element | Boolean [2]: Is it true? |
+      | Parent content | 1                        |
+    And I press "Save changes"
+
+    And I follow "edit_item_8"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Content    | Question without parent |
+      | Required   | 1                       |
+      | id_pattern | free pattern            |
+    And I press "Save changes"
+
+    And I log out
+
+    # Let the student start to fill the surveypro
+    When I log in as "student1"
+    And I am on "1-2-1-3 change of mind" course homepage
+    And I follow "Test 1-2-1-3 change of mind"
+
+    And I press "New response"
+    And I set the field "Write down your email" to "su@nowhere.net"
+    And I set the field "Is it true?" to "1"
+    And I press "Next page >>"
+    Then I should see "Which pet do you like more?"
+
+    And I set the following fields to these values:
+      | id_surveypro_field_radiobutton_4_2 | 1 |
+    And I press "Next page >>"
+    Then I should not see "Choose a direction"
+
+    And I set the following fields to these values:
+      | id_surveypro_field_checkbox_7_1 | 1 |
+    And I set the field "Question without parent" to "This should remain"
+    And I press "<< Previous page"
+
+    And I set the following fields to these values:
+      | id_surveypro_field_radiobutton_4_3 | 1 |
+    And I press "<< Previous page"
+
+    And I set the field "Is it true?" to "0"
+    And I press "Next page >>"
+    Then I should see "Page 3 of 3"
+    Then I should not see "Which pet do you like more?"
+    Then I should not see "What do you usually get for breakfast?"
+    Then I should see "Choose a direction"
+    Then I should see "Question without parent"
+
+    And I set the field "Choose a direction" to "South"
+    And I press "Submit"
+    Then I should not see "Some answers of this response have been found as unverified."
+
+    And I press "Continue to responses list"
+    Then I should see "1" submissions
+
+  @javascript
+  Scenario: Test change of mind: 1-3-1-2
+    Given the following "courses" exist:
+      | fullname               | shortname              | category | groupmode |
+      | 1-3-1-2 change of mind | 1-3-1-2 change of mind | 0        | 0         |
+    And the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | teacher  | teacher1@nowhere.net |
+      | student1 | Student   | student  | student1@nowhere.net |
+    And the following "course enrolments" exist:
+      | user     | course                 | role           |
+      | teacher1 | 1-3-1-2 change of mind | editingteacher |
+      | student1 | 1-3-1-2 change of mind | student        |
+    And the following "activities" exist:
+      | activity  | name                        | intro                       | newpageforchild | course                 |
+      | surveypro | Test 1-3-1-2 change of mind | Test 1-3-1-2 change of mind | 1               | 1-3-1-2 change of mind |
+    And surveypro "Test 1-3-1-2 change of mind" contains the following items:
+      | type   | plugin      |
+      | field  | character   |
+      | field  | radiobutton |
+      | format | pagebreak   |
+      | field  | boolean     |
+      | field  | character   |
+      | format | pagebreak   |
+      | field  | boolean     |
+      | field  | character   |
+    And I log in as "teacher1"
+    And I am on "1-3-1-2 change of mind" course homepage
+    And I follow "Test 1-3-1-2 change of mind"
+    And I follow "Layout"
+
+    And I follow "edit_item_1"
+    And I set the field "Required" to "1"
+    And I press "Save changes"
+
+    And I follow "edit_item_2"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Content        | Which artwork did you make? |
+      | Required       | 1                           |
+    And I set the multiline field "Options" to "p::painting\ns::sculpture\nm::musical"
+    And I press "Save changes"
+
+    And I follow "edit_item_4"
+    And I set the following fields to these values:
+      | Content        | Is it A4 format?                              |
+      | Required       | 1                                             |
+      | Parent element | Radio button [2]: Which artwork did you make? |
+      | Parent content | p                                             |
+    And I press "Save changes"
+
+    And I follow "edit_item_5"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Content        | Simple parent child question                  |
+      | Required       | 1                                             |
+      | id_pattern     | free pattern                                  |
+      | Parent element | Radio button [2]: Which artwork did you make? |
+      | Parent content | p                                             |
+    And I press "Save changes"
+
+    And I follow "edit_item_7"
+    And I set the following fields to these values:
+      | Content        | Was it carved in marble?                      |
+      | Required       | 1                                             |
+      | Parent element | Radio button [2]: Which artwork did you make? |
+      | Parent content | s                                             |
+    And I press "Save changes"
+
+    And I follow "edit_item_8"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Content    | Question without parent |
+      | Required   | 1                       |
+      | id_pattern | free pattern            |
+    And I press "Save changes"
+
+    And I log out
+
+    # Let the student start to fill the surveypro
+    When I log in as "student1"
+    And I am on "1-3-1-2 change of mind" course homepage
+    And I follow "Test 1-3-1-2 change of mind"
+
+    And I press "New response"
+    And I set the field "Write down your email" to "su@nowhere.net"
+
+    And I set the following fields to these values:
+      | id_surveypro_field_radiobutton_2_1 | 1 |
+    And I press "Next page >>"
+    Then I should see "Was it carved in marble?"
+    Then I should not see "Is it A4 format?"
+
+    And I set the field "Was it carved in marble?" to "No"
+    And I set the field "Question without parent" to "I am proud of it"
+    And I press "<< Previous page"
+    Then I should see "Which artwork did you make?"
+
+    And I set the following fields to these values:
+      | id_surveypro_field_radiobutton_2_0 | 1 |
+    And I press "Next page >>"
+    Then I should see "Is it A4 format?"
+    Then I should not see "Was it carved in marble?"
+
+    And I set the field "Is it A4 format?" to "Yes"
+    And I set the field "Simple parent child question" to "I am preparing a bigger one"
+    And I press "Next page >>"
+    Then I should see "Question without parent"
+    Then I should not see "Was it carved in marble?"
+
+    And I press "Submit"
+    Then I should not see "Some answers of this response have been found as unverified."
+
+    And I press "Continue to responses list"
+    Then I should see "1" submissions


### PR DESCRIPTION
The context of this fix is this: let's suppose I have a surveypro with parent child relation spanning multiple pages.

Simple scenario
On page 1 I have a branching item.
On page 2 I have the child of the branching item AND a question without parent.
I fill the surveypro.
I add an answer for the parent item and I move to page 2.
Here I add an answer for the child item and for the free item.
At the end I return back to page 1.
I change my mind and the answer to the parent item.
I return to page 2, I fill the free item and I submit.
The submission HAS TO BE CLOSED and not marked as "in progress" because some item has answer not verified.

The original answer to the child item should, actually, be dropped when the student returns to page 2 for the seconf time.
This patch corrects the routine to drop answers to this kind of items.

Advanced scenario
On page 1 I have a branching item.
On page 2 I have an item depending from branching item when answer is 1.
On page 3 I have an item depending from branching item when answer is 0, one more item depending from branching item when answer is 1 AND one free item (without dependencies).
I fill the surveypro.
I answer 1 to the parent item and I move forward.
I find ai intem in page 2 and I provide an answer.
I move forward and, in page 3, I find the item depending from branching item when answer is 1 AND the free item.
I provide an answer to both of them and I move backward.
I land in page 2. I am free to leave the item untouched or to change the answer.
I move backward once more and I change (in page 1) the answer to branching item (from 1 to 0) and I move forward.
I land in page 3 and I see only the item depending from branching item when answer is 0 and the free item (without dependencies).
I fill the page and I submit.
The submission HAS TO BE CLOSED and not marked as "in progress" because some item has answer not verified.