### PR TITLE
Next allowed page. Do not merge. #713 fix this too.

### DIFF
--- a/classes/local/form/userform.php
+++ b/classes/local/form/userform.php
@@ -37,7 +37,7 @@ require_once($CFG->dirroot.'/lib/formslib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class surveyprofillform extends \moodleform {
+class userform extends \moodleform {
 
     /**
      * Definition.
@@ -75,7 +75,7 @@ class surveyprofillform extends \moodleform {
         $mform->setType('submissionid', PARAM_INT);
 
         // Userform: formpage.
-        $mform->addElement('hidden', 'formpage', 0); // Value is provided by $outform->set_data($prefill); from view_form.php.
+        $mform->addElement('hidden', 'formpage', 0); // Value is provided by $userform->set_data($prefill); from view_form.php.
         $mform->setType('formpage', PARAM_INT);
 
         if ($formpage == SURVEYPRO_LEFT_OVERFLOW) {

--- a/classes/local/form/usersearchform.php
+++ b/classes/local/form/usersearchform.php
@@ -37,7 +37,7 @@ require_once($CFG->dirroot.'/lib/formslib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class surveyprosearchform extends \moodleform {
+class usersearchform extends \moodleform {
 
     /**
      * Definition.

--- a/classes/utility_layout.php
+++ b/classes/utility_layout.php
@@ -1203,7 +1203,7 @@ class utility_layout {
     }
 
     /**
-     * Assign to the user outform the custom css provided for the instance.
+     * Assign to the userform the custom css provided for the instance.
      *
      * @return void
      */

--- a/classes/view_form.php
+++ b/classes/view_form.php
@@ -852,8 +852,14 @@ class view_form extends formbase {
      * Drop old answers into pages no longer valid.
      *
      * Ok, I am moving from $userformman->formpage to page $userformman->nextpageright.
-     * I need to delete all the answer that were (maybe) written during last input session in this surveypro.
-     * Answers to each item in a page between ($this->formpage + 1) and ($this->nextpageright - 1) included, must be deleted.
+     * I need to verify all the answers that were (maybe) saved during last input session and saved with verified = 0.
+     * I divide this process into two steps.
+     * First step:
+     *     if there are answers to this surveypro saved with verified = 0 and corresponding to items belonging to pages
+     *     between ($this->formpage + 1) and ($this->nextpageright - 1) included, I must delete them.
+     * Second step:
+     *     I check the answers saved with verified = 0 and corresponding to items belonging to page $this->nextpageright.
+     *     For each answer I chech if it is still allowed by its realtion with answers to items in $this->formpage.
      *
      * Example: I am leaving page 3. On the basis of current input (in this page), I have $userformman->nextpageright = 10.
      * Maybe yesterday I had different data in $userformman->formpage = 3 and on that basis I was redirected to page 4.
@@ -864,27 +870,128 @@ class view_form extends formbase {
     public function drop_jumped_saved_data() {
         global $DB;
 
-        if ($this->nextpageright == ($this->get_formpage() + 1)) {
-            return;
-        }
-        if ($this->nextpageright == SURVEYPRO_RIGHT_OVERFLOW) {
-            $pages = range($this->get_formpage() + 1, $this->get_maxassignedpage());
+        $submissionid = $this->get_submissionid();
+        $movingpage = $this->get_formpage();
+
+        // Save to $answerstokill...
+        // the list of the answers to items living between ($movingpage + 1) and ($this->nextpageright - 1)
+        // and saved with verified = 0
+        if ($this->nextpageright == ($movingpage + 1)) {
+            $answerstokill = [];
         } else {
-            $pages = range($this->get_formpage() + 1, $this->nextpageright - 1);
+            if ($this->nextpageright == SURVEYPRO_RIGHT_OVERFLOW) {
+                $lastjumpedpage = $this->get_maxassignedpage();
+            } else {
+                $lastjumpedpage = $this->nextpageright - 1;
+            }
+
+            $sql = 'SELECT a.id
+                FROM {surveypro_answer} a
+                    JOIN {surveypro_item} i ON i.id = a.itemid
+                WHERE a.verified = :verified
+                    AND a.submissionid = :submissionid
+                    AND i.surveyproid = :surveyproid
+                    AND i.formpage > :movingpage
+                    AND i.formpage <= :lastjumpedpage';
+            $whereparams['verified'] = 0;
+            $whereparams['submissionid'] = $submissionid;
+            $whereparams['surveyproid'] = $this->surveypro->id;
+            $whereparams['movingpage'] = $movingpage;
+            $whereparams['lastjumpedpage'] = $lastjumpedpage;
+
+            $answerstokill = $DB->get_records_sql_menu($sql, $whereparams);
+            $answerstokill = array_keys($answerstokill);
         }
 
-        list($insql, $whereparams) = $DB->get_in_or_equal($pages, SQL_PARAMS_NAMED, 'pages');
-        $whereparams['surveyproid'] = $this->surveypro->id;
-        $where = 'surveyproid = :surveyproid
-              AND formpage '.$insql;
-        $itemlistid = $DB->get_records_select('surveypro_item', $where, $whereparams, 'id', 'id');
-        $itemlistid = array_keys($itemlistid);
+        // Each answer to items listed in $allitemsid has to be deleted but... some more may be added.
+        // Add to $answerstokill...
+        // the list of answers to items of pages grater or equal to $this->nextpageright having verified = 0
+        // and no longer allowed by their relations. (due to the change of mind).
+        // To do this I select all the answers to items of page $this->nextpageright having verified = 0
+        // and I verify, for each one of them, if they are still allowed.
 
-        list($insql, $whereparams) = $DB->get_in_or_equal($itemlistid, SQL_PARAMS_NAMED, 'itemid');
-        $whereparams['submissionid'] = $this->formdata->submissionid;
-        $where = 'submissionid = :submissionid
-              AND itemid '.$insql;
-        $DB->delete_records_select('surveypro_answer', $where, $whereparams);
+        // Rationale.
+        // If you arrive to page 2 and you move back to page 1, each answer to items of page 2 is saved with verified = 0.
+        // When you return again to page 2 from page 1,
+        // the code has to delete all the answers previously provided for items currently no longer allowed by relations.
+        // Answers to items still allowed (maybe because not conditioned by relations) will remain alive AND INCORRECT
+        // because they still have surveypro_answer.verified = 0 but...
+        // they will be fixed when the user will move forward from page 2.
+
+        // Note.
+        // I need to verify all the anserws to items of pages GRATER OR EQUAL to $this->nextpageright having verified = 0
+        // and NOT only the anserws to items of page $this->nextpageright having verified = 0
+        // because if I was in page 1, then I moved to page 6, then I returned to page 1 and finally I moved to page 2
+        // it is possible (non sure, only possible) I need to remove answer to items from page 6 (and 6 is greater than 2).
+        if ($this->nextpageright != SURVEYPRO_RIGHT_OVERFLOW) {
+            $sql = 'SELECT a.id as answerid, i.id as itemid, i.parentid, i.parentvalue
+                FROM {surveypro_answer} a
+                    JOIN {surveypro_item} i ON i.id = a.itemid
+                WHERE a.verified = :verified
+                    AND a.submissionid = :submissionid
+                    AND i.surveyproid = :surveyproid
+                    AND i.formpage >= :formpage
+                    AND i.parentid > :parentid
+                ORDER BY i.parentid, i.parentvalue';
+            $whereparams = [];
+            $whereparams['verified'] = 0;
+            $whereparams['submissionid'] = $submissionid;
+            $whereparams['surveyproid'] = $this->surveypro->id;
+            $whereparams['formpage'] = $this->nextpageright;
+            $whereparams['parentid'] = 0;
+
+            $itemsandanswers = $DB->get_recordset_sql($sql, $whereparams);
+
+            // For each item verify if it is still allowed by its relation.
+            // If the relation is still valid, ignore it. You don't have to drop related answers.
+            // If the relation is no longer valid, add it to the list of items with answers to kill.
+            $oldparentid = -1;
+            $oldparentvalue = '';
+            foreach ($itemsandanswers as $itemandanswer) {
+                $parentid = $itemandanswer->parentid;
+                $parentvalue = $itemandanswer->parentvalue;
+
+                $condition = ($parentid == $oldparentid);
+                $condition = $condition && ($parentvalue == $oldparentvalue);
+                if ($condition) {
+                    // Do not submit a new query.
+                    // What you did before is still valid.
+                    if ($action == 'kill') {
+                        $answerstokill[] = (int)$itemandanswer->answerid;
+                    }
+                } else {
+                    $sql = 'SELECT id
+                        FROM {surveypro_answer}
+                        WHERE submissionid = :submissionid
+                            AND itemid = :itemid
+                            AND content = '.$DB->sql_compare_text(':content');
+                    $whereparams = [
+                        'submissionid' => $submissionid,
+                        'itemid' => $parentid,
+                        'content' => $parentvalue
+                    ];
+
+                    if ($DB->record_exists_sql($sql, $whereparams)) {
+                        // The item is allowed by its parent-child relation.
+                        // Do not delete its answers.
+                        $action = 'allow';
+                    } else {
+                        $answerstokill[] = (int)$itemandanswer->answerid;
+                        $action = 'kill';
+                    }
+                }
+                $oldparentid = $parentid;
+                $oldparentvalue = $parentvalue;
+            }
+        }
+
+        // Now it is time to drop answers provided to no longer justified items.
+        if (count($answerstokill)) {
+            list($insql, $whereparams) = $DB->get_in_or_equal($answerstokill, SQL_PARAMS_NAMED, 'id');
+            $where = 'id '.$insql;
+
+            $DB->delete_records_select('surveypro_answer', $where, $whereparams);
+        }
     }
 
     /**

--- a/field/age/classes/item.php
+++ b/field/age/classes/item.php
@@ -439,7 +439,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -564,7 +564,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/autofill/classes/item.php
+++ b/field/autofill/classes/item.php
@@ -427,7 +427,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -489,7 +489,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/boolean/classes/item.php
+++ b/field/boolean/classes/item.php
@@ -461,7 +461,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -603,7 +603,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/character/classes/item.php
+++ b/field/character/classes/item.php
@@ -401,7 +401,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * Cool for browsers supporting html 5
      * if ($this->pattern == SURVEYPROFIELD_CHARACTER_EMAILPATTERN) {
@@ -477,7 +477,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/checkbox/classes/item.php
+++ b/field/checkbox/classes/item.php
@@ -531,7 +531,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -657,7 +657,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/date/classes/item.php
+++ b/field/date/classes/item.php
@@ -464,7 +464,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -633,7 +633,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/datetime/classes/item.php
+++ b/field/datetime/classes/item.php
@@ -510,7 +510,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -731,7 +731,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/fileupload/classes/item.php
+++ b/field/fileupload/classes/item.php
@@ -287,7 +287,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -334,7 +334,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/integer/classes/item.php
+++ b/field/integer/classes/item.php
@@ -430,7 +430,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -504,7 +504,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/multiselect/classes/item.php
+++ b/field/multiselect/classes/item.php
@@ -488,7 +488,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -611,7 +611,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/numeric/classes/item.php
+++ b/field/numeric/classes/item.php
@@ -365,7 +365,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -427,7 +427,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/radiobutton/classes/item.php
+++ b/field/radiobutton/classes/item.php
@@ -497,7 +497,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -635,7 +635,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/rate/classes/item.php
+++ b/field/rate/classes/item.php
@@ -375,7 +375,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -492,7 +492,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/recurrence/classes/item.php
+++ b/field/recurrence/classes/item.php
@@ -421,7 +421,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -578,7 +578,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/select/classes/item.php
+++ b/field/select/classes/item.php
@@ -490,7 +490,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -588,7 +588,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/shortdate/classes/item.php
+++ b/field/shortdate/classes/item.php
@@ -418,7 +418,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -567,7 +567,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/textarea/classes/item.php
+++ b/field/textarea/classes/item.php
@@ -383,7 +383,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -452,7 +452,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/time/classes/item.php
+++ b/field/time/classes/item.php
@@ -431,7 +431,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -593,7 +593,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/format/fieldset/classes/item.php
+++ b/format/fieldset/classes/item.php
@@ -202,7 +202,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -219,7 +219,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/format/fieldsetend/classes/item.php
+++ b/format/fieldsetend/classes/item.php
@@ -196,7 +196,7 @@ class item extends itembase {
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -214,7 +214,7 @@ class item extends itembase {
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/format/label/classes/item.php
+++ b/format/label/classes/item.php
@@ -278,7 +278,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -307,7 +307,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/format/pagebreak/classes/item.php
+++ b/format/pagebreak/classes/item.php
@@ -199,7 +199,7 @@ class item extends itembase {
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -214,7 +214,7 @@ class item extends itembase {
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/layout_preview.php
+++ b/layout_preview.php
@@ -26,7 +26,7 @@ use mod_surveypro\utility_layout;
 use mod_surveypro\layout_preview;
 use mod_surveypro\tabs;
 use mod_surveypro\utility_mform;
-use mod_surveypro\local\form\surveyprofillform;
+use mod_surveypro\local\form\userform;
 
 require_once(dirname(dirname(dirname(__FILE__))).'/config.php');
 
@@ -78,7 +78,7 @@ $formparams->readonly = false;
 $formparams->preview = true;
 // End of: prepare params for the form.
 
-$userform = new surveyprofillform($formurl, $formparams, 'post', '', array('id' => 'userentry'));
+$userform = new userform($formurl, $formparams, 'post', '', array('id' => 'userentry'));
 
 // Begin of: manage form submission.
 if ($data = $userform->get_data()) {

--- a/tests/behat/change_of_mind.feature
+++ b/tests/behat/change_of_mind.feature
@@ -1,9 +1,5 @@
 @mod @mod_surveypro @surveyprofield
-<<<<<<< HEAD
 Feature: deletion of no longer allowed answers on user change of mind
-=======
-Feature: simple deletion of no longer allowed answers on user change of mind
->>>>>>> 7eea9868 (Fixed the routine to drop no longer allowed answers (rev 03))
   Test the deletion of no longer allowed answers in a parent-child relation over two pages when user changes his answer
   As a teacher
   I create a parent-child relation and as a student I fill, return back, change my answer and continue.

--- a/tests/behat/change_of_mind.feature
+++ b/tests/behat/change_of_mind.feature
@@ -1,5 +1,9 @@
 @mod @mod_surveypro @surveyprofield
+<<<<<<< HEAD
 Feature: deletion of no longer allowed answers on user change of mind
+=======
+Feature: simple deletion of no longer allowed answers on user change of mind
+>>>>>>> 7eea9868 (Fixed the routine to drop no longer allowed answers (rev 03))
   Test the deletion of no longer allowed answers in a parent-child relation over two pages when user changes his answer
   As a teacher
   I create a parent-child relation and as a student I fill, return back, change my answer and continue.

--- a/tests/behat/change_of_mind.feature
+++ b/tests/behat/change_of_mind.feature
@@ -1,0 +1,321 @@
+@mod @mod_surveypro @surveyprofield
+Feature: deletion of no longer allowed answers on user change of mind
+  Test the deletion of no longer allowed answers in a parent-child relation over two pages when user changes his answer
+  As a teacher
+  I create a parent-child relation and as a student I fill, return back, change my answer and continue.
+
+  @javascript
+  Scenario: Test change of mind: 1-2-1-2
+    Given the following "courses" exist:
+      | fullname        | shortname     | category | groupmode |
+      | Change of mind | Change of mind | 0        | 0         |
+    And the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | teacher  | teacher1@nowhere.net |
+      | student1 | Student   | student  | student1@nowhere.net |
+    And the following "course enrolments" exist:
+      | user     | course         | role           |
+      | teacher1 | Change of mind | editingteacher |
+      | student1 | Change of mind | student        |
+    And the following "activities" exist:
+      | activity  | name                | intro               | newpageforchild | course         |
+      | surveypro | Test change of mind | Test change of mind | 1               | Change of mind |
+    And surveypro "Test change of mind" contains the following items:
+      | type   | plugin      |
+      | field  | character   |
+      | field  | boolean     |
+      | format | pagebreak   |
+      | field  | select      |
+      | field  | character   |
+    And I log in as "teacher1"
+    And I am on "Change of mind" course homepage
+    And I follow "Test change of mind"
+    And I follow "Layout"
+
+    And I follow "edit_item_1"
+    And I set the field "Required" to "1"
+    And I press "Save changes"
+
+    And I follow "edit_item_2"
+    And I set the field "Required" to "1"
+    And I press "Save changes"
+
+    And I follow "edit_item_4"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Content        | Choose a direction       |
+      | Required       | 1                        |
+      | Parent element | Boolean [2]: Is it true? |
+      | Parent content | 0                        |
+    And I set the multiline field "Options" to "North\nEast\nSouth\nWest"
+    And I press "Save changes"
+
+    And I follow "edit_item_5"
+    And I set the following fields to these values:
+      | Content    | Question without parent |
+      | Required   | 1                       |
+      | id_pattern | free pattern            |
+
+    And I press "Save changes"
+
+    And I log out
+
+    # Let the student start to fill the surveypro
+    When I log in as "student1"
+    And I am on "Change of mind" course homepage
+    And I follow "Test change of mind"
+
+    And I press "New response"
+    And I set the field "Write down your email" to "su@nowhere.net"
+    And I set the field "Is it true?" to "0"
+    And I press "Next page >>"
+    Then I should see "Choose a direction"
+    Then I should see "Question without parent"
+
+    And I set the field "Choose a direction" to "South"
+    And I set the field "Question without parent" to "This should remain"
+    And I press "<< Previous page"
+
+    And I set the field "Is it true?" to "1"
+    And I press "Next page >>"
+    Then I should not see "Choose a direction"
+    Then I should see "Question without parent"
+
+    And I press "Submit"
+    Then I should not see "Some answers of this response have been found as unverified."
+
+    And I press "Continue to responses list"
+    Then I should see "1" submissions
+
+  @javascript
+  Scenario: Test change of mind: 1-2-1-3
+    Given the following "courses" exist:
+      | fullname               | shortname              | category | groupmode |
+      | 1-2-1-3 change of mind | 1-2-1-3 change of mind | 0        | 0         |
+    And the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | teacher  | teacher1@nowhere.net |
+      | student1 | Student   | student  | student1@nowhere.net |
+    And the following "course enrolments" exist:
+      | user     | course                 | role           |
+      | teacher1 | 1-2-1-3 change of mind | editingteacher |
+      | student1 | 1-2-1-3 change of mind | student        |
+    And the following "activities" exist:
+      | activity  | name                        | intro                       | newpageforchild | course                 |
+      | surveypro | Test 1-2-1-3 change of mind | Test 1-2-1-3 change of mind | 1               | 1-2-1-3 change of mind |
+    And surveypro "Test 1-2-1-3 change of mind" contains the following items:
+      | type   | plugin      |
+      | field  | character   |
+      | field  | boolean     |
+      | format | pagebreak   |
+      | field  | radiobutton |
+      | format | pagebreak   |
+      | field  | select      |
+      | field  | checkbox    |
+      | field  | character   |
+    And I log in as "teacher1"
+    And I am on "1-2-1-3 change of mind" course homepage
+    And I follow "Test 1-2-1-3 change of mind"
+    And I follow "Layout"
+
+    And I follow "edit_item_1"
+    And I set the field "Required" to "1"
+    And I press "Save changes"
+
+    And I follow "edit_item_2"
+    And I set the field "Required" to "1"
+    And I press "Save changes"
+
+    And I follow "edit_item_4"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Content        | Which pet do you like more? |
+      | Required       | 1                           |
+      | Parent element | Boolean [2]: Is it true?    |
+      | Parent content | 1                           |
+    And I set the multiline field "Options" to "dog\ncat\nbird\ncrocodile"
+    And I press "Save changes"
+
+    And I follow "edit_item_6"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Content        | Choose a direction       |
+      | Required       | 1                        |
+      | Parent element | Boolean [2]: Is it true? |
+      | Parent content | 0                        |
+    And I set the multiline field "Options" to "North\nEast\nSouth\nWest"
+    And I press "Save changes"
+
+    And I follow "edit_item_7"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Required       | 1                        |
+      | Parent element | Boolean [2]: Is it true? |
+      | Parent content | 1                        |
+    And I press "Save changes"
+
+    And I follow "edit_item_8"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Content    | Question without parent |
+      | Required   | 1                       |
+      | id_pattern | free pattern            |
+    And I press "Save changes"
+
+    And I log out
+
+    # Let the student start to fill the surveypro
+    When I log in as "student1"
+    And I am on "1-2-1-3 change of mind" course homepage
+    And I follow "Test 1-2-1-3 change of mind"
+
+    And I press "New response"
+    And I set the field "Write down your email" to "su@nowhere.net"
+    And I set the field "Is it true?" to "1"
+    And I press "Next page >>"
+    Then I should see "Which pet do you like more?"
+
+    And I set the following fields to these values:
+      | id_surveypro_field_radiobutton_4_2 | 1 |
+    And I press "Next page >>"
+    Then I should not see "Choose a direction"
+
+    And I set the following fields to these values:
+      | id_surveypro_field_checkbox_7_1 | 1 |
+    And I set the field "Question without parent" to "This should remain"
+    And I press "<< Previous page"
+
+    And I set the following fields to these values:
+      | id_surveypro_field_radiobutton_4_3 | 1 |
+    And I press "<< Previous page"
+
+    And I set the field "Is it true?" to "0"
+    And I press "Next page >>"
+    Then I should see "Page 3 of 3"
+    Then I should not see "Which pet do you like more?"
+    Then I should not see "What do you usually get for breakfast?"
+    Then I should see "Choose a direction"
+    Then I should see "Question without parent"
+
+    And I set the field "Choose a direction" to "South"
+    And I press "Submit"
+    Then I should not see "Some answers of this response have been found as unverified."
+
+    And I press "Continue to responses list"
+    Then I should see "1" submissions
+
+  @javascript
+  Scenario: Test change of mind: 1-3-1-2
+    Given the following "courses" exist:
+      | fullname               | shortname              | category | groupmode |
+      | 1-3-1-2 change of mind | 1-3-1-2 change of mind | 0        | 0         |
+    And the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | teacher  | teacher1@nowhere.net |
+      | student1 | Student   | student  | student1@nowhere.net |
+    And the following "course enrolments" exist:
+      | user     | course                 | role           |
+      | teacher1 | 1-3-1-2 change of mind | editingteacher |
+      | student1 | 1-3-1-2 change of mind | student        |
+    And the following "activities" exist:
+      | activity  | name                        | intro                       | newpageforchild | course                 |
+      | surveypro | Test 1-3-1-2 change of mind | Test 1-3-1-2 change of mind | 1               | 1-3-1-2 change of mind |
+    And surveypro "Test 1-3-1-2 change of mind" contains the following items:
+      | type   | plugin      |
+      | field  | character   |
+      | field  | radiobutton |
+      | format | pagebreak   |
+      | field  | boolean     |
+      | field  | character   |
+      | format | pagebreak   |
+      | field  | boolean     |
+      | field  | character   |
+    And I log in as "teacher1"
+    And I am on "1-3-1-2 change of mind" course homepage
+    And I follow "Test 1-3-1-2 change of mind"
+    And I follow "Layout"
+
+    And I follow "edit_item_1"
+    And I set the field "Required" to "1"
+    And I press "Save changes"
+
+    And I follow "edit_item_2"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Content        | Which artwork did you make? |
+      | Required       | 1                           |
+    And I set the multiline field "Options" to "p::painting\ns::sculpture\nm::musical"
+    And I press "Save changes"
+
+    And I follow "edit_item_4"
+    And I set the following fields to these values:
+      | Content        | Is it A4 format?                              |
+      | Required       | 1                                             |
+      | Parent element | Radio button [2]: Which artwork did you make? |
+      | Parent content | p                                             |
+    And I press "Save changes"
+
+    And I follow "edit_item_5"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Content        | Simple parent child question                  |
+      | Required       | 1                                             |
+      | id_pattern     | free pattern                                  |
+      | Parent element | Radio button [2]: Which artwork did you make? |
+      | Parent content | p                                             |
+    And I press "Save changes"
+
+    And I follow "edit_item_7"
+    And I set the following fields to these values:
+      | Content        | Was it carved in marble?                      |
+      | Required       | 1                                             |
+      | Parent element | Radio button [2]: Which artwork did you make? |
+      | Parent content | s                                             |
+    And I press "Save changes"
+
+    And I follow "edit_item_8"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Content    | Question without parent |
+      | Required   | 1                       |
+      | id_pattern | free pattern            |
+    And I press "Save changes"
+
+    And I log out
+
+    # Let the student start to fill the surveypro
+    When I log in as "student1"
+    And I am on "1-3-1-2 change of mind" course homepage
+    And I follow "Test 1-3-1-2 change of mind"
+
+    And I press "New response"
+    And I set the field "Write down your email" to "su@nowhere.net"
+
+    And I set the following fields to these values:
+      | id_surveypro_field_radiobutton_2_1 | 1 |
+    And I press "Next page >>"
+    Then I should see "Was it carved in marble?"
+    Then I should not see "Is it A4 format?"
+
+    And I set the field "Was it carved in marble?" to "No"
+    And I set the field "Question without parent" to "I am proud of it"
+    And I press "<< Previous page"
+    Then I should see "Which artwork did you make?"
+
+    And I set the following fields to these values:
+      | id_surveypro_field_radiobutton_2_0 | 1 |
+    And I press "Next page >>"
+    Then I should see "Is it A4 format?"
+    Then I should not see "Was it carved in marble?"
+
+    And I set the field "Is it A4 format?" to "Yes"
+    And I set the field "Simple parent child question" to "I am preparing a bigger one"
+    And I press "Next page >>"
+    Then I should see "Question without parent"
+    Then I should not see "Was it carved in marble?"
+
+    And I press "Submit"
+    Then I should not see "Some answers of this response have been found as unverified."
+
+    And I press "Continue to responses list"
+    Then I should see "1" submissions

--- a/tests/behat/readonly_browse_allowed_pages_only.feature
+++ b/tests/behat/readonly_browse_allowed_pages_only.feature
@@ -1,0 +1,90 @@
+@mod @mod_surveypro @surveyprofield
+Feature: In read only mode browse a submission jumping now filled pages
+  Test during read only browse of responses user jumps pages without answers
+  As a teacher
+  I create a surveypro and as a student I fill, submit and browse, in read only mode, my submission.
+
+  @javascript
+  Scenario: Jump unused survepro pages in read only mode
+    Given the following "courses" exist:
+      | fullname               | shortname              | category | groupmode |
+      | Jump not allowed pages | Jump not allowed pages | 0        | 0         |
+    And the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | teacher  | teacher1@nowhere.net |
+      | student1 | Student   | student  | student1@nowhere.net |
+    And the following "course enrolments" exist:
+      | user     | course                | role           |
+      | teacher1 | Jump not allowed pages | editingteacher |
+      | student1 | Jump not allowed pages | student        |
+    And the following "activities" exist:
+      | activity  | name                        | intro                       | newpageforchild | course                 |
+      | surveypro | Test jump not allowed pages | Test jump not allowed pages | 1               | Jump not allowed pages |
+    And surveypro "Test jump not allowed pages" contains the following items:
+      | type   | plugin      |
+      | field  | boolean     |
+      | format | pagebreak   |
+      | field  | select      |
+      | format | pagebreak   |
+      | field  | character   |
+      | format | pagebreak   |
+      | field  | boolean     |
+    And I log in as "teacher1"
+    And I am on "Jump not allowed pages" course homepage
+    And I follow "Test jump not allowed pages"
+    And I follow "Layout"
+
+    And I follow "edit_item_3"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Content        | Question of page 2       |
+      | Required       | 1                        |
+      | Parent element | Boolean [1]: Is it true? |
+      | Parent content | 1                        |
+    And I set the multiline field "Options" to "Up\nDown"
+    And I press "Save changes"
+
+    And I follow "edit_item_5"
+    And I set the following fields to these values:
+      | Content        | Question of page 3       |
+      | Parent element | Boolean [1]: Is it true? |
+      | Parent content | 0                        |
+    And I press "Save changes"
+
+    And I follow "edit_item_7"
+    And I set the following fields to these values:
+      | Content        | Question of page 4             |
+      | Parent element | Select [3]: Question of page 2 |
+      | Parent content | Up                             |
+    And I press "Save changes"
+
+    And I log out
+
+    # Let the student start to fill the surveypro
+    When I log in as "student1"
+    And I am on "Jump not allowed pages" course homepage
+    And I follow "Test jump not allowed pages"
+
+    And I press "New response"
+    And I set the field "Is it true?" to "1"
+    And I press "Next page >>"
+    Then I should see "Question of page 2"
+
+    And I set the field "Question of page 2" to "Up"
+    And I press "Next page >>"
+    Then I should see "Question of page 4"
+
+    And I set the field "Question of page 4" to "0"
+    And I press "Submit"
+
+    And I press "Continue to responses list"
+    Then I should see "1" submissions
+
+    And I follow "view_submission_row_1"
+    Then I should see "Is it true?"
+
+    And I press "Next page >>"
+    Then I should see "Question of page 2"
+
+    And I press "Next page >>"
+    Then I should see "Question of page 4"

--- a/view_form.php
+++ b/view_form.php
@@ -26,7 +26,7 @@ use mod_surveypro\utility_layout;
 use mod_surveypro\tabs;
 use mod_surveypro\utility_mform;
 use mod_surveypro\view_form;
-use mod_surveypro\local\form\surveyprofillform;
+use mod_surveypro\local\form\userform;
 
 require_once(dirname(dirname(dirname(__FILE__))).'/config.php');
 
@@ -45,7 +45,7 @@ if (!empty($id)) {
 $cm = cm_info::create($cm);
 
 $submissionid = optional_param('submissionid', 0, PARAM_INT);
-$formpage = optional_param('formpage', 0, PARAM_INT); // Form page number.
+$formpage = optional_param('formpage', 1, PARAM_INT); // Userform page number.
 $view = optional_param('view', SURVEYPRO_NOVIEW, PARAM_INT);
 
 require_course_login($course, false, $cm);
@@ -79,16 +79,16 @@ $formparams->preview = false;
 // End of: prepare params for the form.
 
 $editable = ($view == SURVEYPRO_READONLYRESPONSE) ? false : true;
-$outform = new surveyprofillform($formurl, $formparams, 'post', '', array('id' => 'userentry'), $editable);
+$userform = new userform($formurl, $formparams, 'post', '', array('id' => 'userentry'), $editable);
 
 // Begin of: manage form submission.
-if ($outform->is_cancelled()) {
+if ($userform->is_cancelled()) {
     $localparamurl = array('id' => $cm->id, 'view' => $view);
     $redirecturl = new \moodle_url('/mod/surveypro/view_submissions.php', $localparamurl);
     redirect($redirecturl, get_string('usercanceled', 'mod_surveypro'));
 }
 
-if ($userformman->formdata = $outform->get_data()) {
+if ($userformman->formdata = $userform->get_data()) {
     $userformman->save_user_data(); // SAVE SAVE SAVE SAVE.
 
     // If "pause" button has been pressed, redirect.
@@ -104,8 +104,8 @@ if ($userformman->formdata = $outform->get_data()) {
     // If "previous" button has been pressed, redirect.
     $prevbutton = isset($userformman->formdata->prevbutton);
     if ($prevbutton) {
-        $userformman->next_not_empty_page(false);
-        $paramurl['formpage'] = $userformman->get_nextpageleft();
+        $userformman->next_not_empty_page(false); // false means direction = left.
+        $paramurl['formpage'] = $userformman->get_nextpage();
         $redirecturl = new \moodle_url('/mod/surveypro/view_form.php', $paramurl);
         redirect($redirecturl); // Redirect to the first non empty page.
     }
@@ -113,25 +113,24 @@ if ($userformman->formdata = $outform->get_data()) {
     // If "next" button has been pressed, redirect.
     $nextbutton = isset($userformman->formdata->nextbutton);
     if ($nextbutton) {
-        $userformman->next_not_empty_page(true);
-
-        // Ok, I am moving from $userformman->formpage to page $userformman->nextpageright.
+        // Ok, I am moving from $userformman->formpage to page $userformman->nextpage.
         // I need to delete all the answer that were (maybe) written during a previous walk along the surveypro.
-        // Answers to each item in a page between ($this->formpage + 1) and ($this->nextpageright - 1) included, must be deleted.
+        // Answers to each item in a page between ($this->formpage + 1) and ($this->nextpage - 1) included, must be deleted.
         //
         // Let's suppose the following scenario.
         // 1) User is filling a surveypro divided into 15 pages.
         // 2) User fills all the fields of page 3 and push next to move to the next page.
-        // 3) On the basis of current input, $userformman->nextpageright is 4 so page 4 is displayed.
+        // 3) On the basis of current input, $userformman->nextpage is 4 so page 4 is displayed.
         // 4) User fills all the fields of page 4 and push next to move to the next page.
-        // 5) On the basis of current input, $userformman->nextpageright is 5 so page 5 is displayed.
+        // 5) On the basis of current input, $userformman->nextpage is 5 so page 5 is displayed.
         // 6) Once arrived in page 5 user returns back up to page 3.
         // 7) User changes the answers in page 3 and push next to move to the next page.
-        // 8) On the basis of current input, $userformman->nextpageright is 10 so page 10 is displayed.
+        // 8) On the basis of current input, $userformman->nextpage is 10 so page 10 is displayed.
         // 9) Now that the answers to items in page 3 move me to page 10, for sure answers to items in page 4 must be deleted.
-        $userformman->drop_jumped_saved_data();
 
-        $paramurl['formpage'] = $userformman->get_nextpageright();
+        $userformman->next_not_empty_page(true); // true means direction = right.
+        $userformman->drop_jumped_saved_data();
+        $paramurl['formpage'] = $userformman->get_nextpage();
         $redirecturl = new \moodle_url('/mod/surveypro/view_form.php', $paramurl);
         redirect($redirecturl); // Redirect to the first non empty page.
     }
@@ -189,8 +188,8 @@ $prefill = $userformman->get_prefill_data();
 $prefill['formpage'] = $userformman->get_formpage();
 // End of: calculate prefill for fields and prepare standard editors and filemanager.
 
-$outform->set_data($prefill);
-$outform->display();
+$userform->set_data($prefill);
+$userform->display();
 
 // If surveypro is multipage and $userformman->tabpage == SURVEYPRO_READONLYRESPONSE.
 // I need to add navigation buttons manually

--- a/view_search.php
+++ b/view_search.php
@@ -25,7 +25,7 @@
 use mod_surveypro\tabs;
 use mod_surveypro\utility_mform;
 use mod_surveypro\view_search;
-use mod_surveypro\local\form\surveyprosearchform;
+use mod_surveypro\local\form\usersearchform;
 
 require_once(dirname(dirname(dirname(__FILE__))).'/config.php');
 
@@ -66,7 +66,7 @@ $formparams = new \stdClass();
 $formparams->cm = $cm;
 $formparams->surveypro = $surveypro;
 $formparams->canaccessreserveditems = has_capability('mod/surveypro:accessreserveditems', $context);
-$searchform = new surveyprosearchform($formurl, $formparams, 'post', '', array('id' => 'usersearch'));
+$searchform = new usersearchform($formurl, $formparams, 'post', '', array('id' => 'usersearch'));
 // End of: prepare params for the form.
 
 // Begin of: manage form submission.


### PR DESCRIPTION
Browsing a submitted response in read-only mode (by pushing the glasses icon in the responses list page) the student is allowed to see each page of the surveypro even if some page was not allowed at submission time.
With this patch I changed the way nextpage is calculated and I used this updated routine for the buttons to browse the read-only responses, too.

Each behat test runs fine.
This PR has been built on top of #707.