### PR TITLE
Fixed the routine to drop undesiderd answers (rev 04)

### DIFF
--- a/classes/layout_preview.php
+++ b/classes/layout_preview.php
@@ -44,21 +44,21 @@ class layout_preview extends formbase {
     public function setup($submissionid, $formpage) {
         global $DB;
 
+        // Assign pages to items.
+        $userformpagecount = $DB->get_field('surveypro_item', 'MAX(formpage)', array('surveyproid' => $this->surveypro->id));
+        if (!$userformpagecount) {
+            $utilitylayoutman = new utility_layout($this->cm, $this->surveypro);
+            $userformpagecount = $utilitylayoutman->assign_pages();
+        }
+        $this->set_userformpagecount($userformpagecount);
+        $this->set_user_boundary_formpages();
+
         $this->set_submissionid($submissionid);
         $this->set_formpage($formpage);
 
         $this->prevent_direct_user_input();
         $this->trigger_event();
 
-        // Assign pages to items.
-        $maxassignedpage = $DB->get_field('surveypro_item', 'MAX(formpage)', array('surveyproid' => $this->surveypro->id));
-        if (!$maxassignedpage) {
-            $utilitylayoutman = new utility_layout($this->cm, $this->surveypro);
-            $maxassignedpage = $utilitylayoutman->assign_pages();
-            $this->set_maxassignedpage($maxassignedpage);
-        } else {
-            $this->set_maxassignedpage($maxassignedpage);
-        }
     }
 
     /**

--- a/classes/local/form/usersearch.php
+++ b/classes/local/form/usersearch.php
@@ -37,7 +37,7 @@ require_once($CFG->dirroot.'/lib/formslib.php');
  * @copyright 2013 onwards kordan <kordan@mclink.it>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class surveyprosearchform extends \moodleform {
+class usersearch extends \moodleform {
 
     /**
      * Definition.
@@ -79,10 +79,13 @@ class surveyprosearchform extends \moodleform {
             if ($position == SURVEYPRO_POSITIONFULLWIDTH) {
                 $questioncontent = $item->get_content();
                 if ($elementnumber) {
-                    // I want to change "4.2:<p>Do you live in NY?</p>" to "<p>4.2: Do you live in NY?</p>".
-                    if (preg_match('~^<p>(.*)$~', $questioncontent, $match)) {
-                        // print_object($match);
-                        $questioncontent = '<p>'.$elementnumber.' '.$match[1];
+                    // I want to change "4.2:<p dir="ltr" style="text-align:left;">Do you live in NY?</p>"
+                    // to
+                    // "<p dir="ltr" style="text-align:left;">4.2: Do you live in NY?</p>".
+                    if (preg_match('~^<p([^>]*)>(.*)$~', $questioncontent, $match)) {
+                        $questioncontent = '<p'.$match[1].'>'.$elementnumber.' '.$match[2];
+                    } else {
+                        $questioncontent = $elementnumber.' '.$questioncontent;
                     }
                 }
                 $content = '';

--- a/classes/utility_layout.php
+++ b/classes/utility_layout.php
@@ -79,7 +79,7 @@ class utility_layout {
         $where['surveyproid'] = $this->surveypro->id;
         $where['hidden'] = 0;
 
-        $maxassignedpage = 0;
+        $userformpagecount = 0;
         $lastwaspagebreak = true; // Whether 2 page breaks in line, the second one is ignored.
         $pagenumber = 1;
         $items = $DB->get_recordset('surveypro_item', $where, 'sortindex', 'id, type, plugin, parentid, formpage, sortindex');
@@ -104,10 +104,10 @@ class utility_layout {
                 }
             }
             $items->close();
-            $maxassignedpage = $pagenumber;
+            $userformpagecount = $pagenumber;
         }
 
-        return $maxassignedpage;
+        return $userformpagecount;
     }
 
     /**
@@ -308,9 +308,11 @@ class utility_layout {
      * or, to delete, a single answer of a submission (or set of answers).
      * If I delete a submission this function (delete_submissions) will call the delete_answers function.
      * If I directly call delete_answers, this function (delete_submissions) will never be called.
+     * Even if I ask to delete a single answer, it may be possible I need to delete the corresponding submission.
+     * So, I can not delete submissions here (in delete_submissions) because I may need to delete a submission without passing here.
      * Because of this, without care to which function I call, once an answer is deleted
      * the deletion of the parent submission is actually executed into the function delete_answers and not here.
-     * All of this to say that it may appear strange but the function "delete_submissions" does not delete anything.
+     * All of this to say that it may appear strange but the function "delete_submissions" does not delete submissions.
      *
      * surveypro_submission           surveypro_answer
      *   id  <-----------------|        id
@@ -334,12 +336,12 @@ class utility_layout {
         $condition = array_key_exists('surveyproid', $whereparams);
         $condition = $condition || array_key_exists('id', $whereparams);
         if (!$condition) {
-            $message = 'I can not delete submissions without id, surveyproid';
+            $message = 'I can not delete submissions missing submissionid AND surveyproid both';
             debugging('Error at line '.__LINE__.' of file '.__FILE__.'. '.$message , DEBUG_DEVELOPER);
         }
         // End of: Verify input params integrity.
 
-        // Just in case the call is missing the surveypro id, add it.
+        // Just to avoid I go to delete single submission belonging to a sureypro different from the one where I am in.
         if (!array_key_exists('surveyproid', $whereparams)) {
             $whereparams['surveyproid'] = $this->surveypro->id;
         }
@@ -1203,7 +1205,7 @@ class utility_layout {
     }
 
     /**
-     * Assign to the user outform the custom css provided for the instance.
+     * Assign to the userform the custom css provided for the instance.
      *
      * @return void
      */

--- a/classes/view_submissions.php
+++ b/classes/view_submissions.php
@@ -781,9 +781,9 @@ class view_submissions {
         $deleteall = $candeleteownsubmissions;
         $deleteall = $deleteall && $candeleteotherssubmissions;
         $deleteall = $deleteall && empty($this->searchquery);
-        $deleteall = $deleteall && empty($tifirst); // Hide the deleteall button if only partial responses are shown.
-        $deleteall = $deleteall && empty($tilast);  // Hide the deleteall button if only partial responses are shown.
-        $deleteall = $deleteall && ($next > 1);
+        $deleteall = $deleteall && empty($tifirst); // Hide the deleteall button if not all the responses are shown.
+        $deleteall = $deleteall && empty($tilast);  // Hide the deleteall button if not all the responses are shown.
+        $deleteall = $deleteall && ($next > 1); // Show the deleteall button only if there are responses to delete.
         // End of: is the button to delete all responses going to be the page?
 
         $buttoncount = 0;

--- a/field/age/classes/item.php
+++ b/field/age/classes/item.php
@@ -439,7 +439,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -564,7 +564,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/autofill/classes/item.php
+++ b/field/autofill/classes/item.php
@@ -427,7 +427,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -489,7 +489,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/boolean/classes/item.php
+++ b/field/boolean/classes/item.php
@@ -461,7 +461,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -603,7 +603,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/character/classes/item.php
+++ b/field/character/classes/item.php
@@ -401,7 +401,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * Cool for browsers supporting html 5
      * if ($this->pattern == SURVEYPROFIELD_CHARACTER_EMAILPATTERN) {
@@ -477,7 +477,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/checkbox/classes/item.php
+++ b/field/checkbox/classes/item.php
@@ -531,7 +531,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -657,7 +657,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/date/classes/item.php
+++ b/field/date/classes/item.php
@@ -464,7 +464,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -633,7 +633,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/datetime/classes/item.php
+++ b/field/datetime/classes/item.php
@@ -510,7 +510,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -731,7 +731,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/fileupload/classes/item.php
+++ b/field/fileupload/classes/item.php
@@ -287,7 +287,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -334,7 +334,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/integer/classes/item.php
+++ b/field/integer/classes/item.php
@@ -430,7 +430,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -504,7 +504,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/multiselect/classes/item.php
+++ b/field/multiselect/classes/item.php
@@ -488,7 +488,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -611,7 +611,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/numeric/classes/item.php
+++ b/field/numeric/classes/item.php
@@ -365,7 +365,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -427,7 +427,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/radiobutton/classes/item.php
+++ b/field/radiobutton/classes/item.php
@@ -497,7 +497,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -635,7 +635,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/rate/classes/item.php
+++ b/field/rate/classes/item.php
@@ -375,7 +375,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -492,7 +492,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/recurrence/classes/item.php
+++ b/field/recurrence/classes/item.php
@@ -421,7 +421,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -578,7 +578,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/select/classes/item.php
+++ b/field/select/classes/item.php
@@ -490,7 +490,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -588,7 +588,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/shortdate/classes/item.php
+++ b/field/shortdate/classes/item.php
@@ -418,7 +418,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -567,7 +567,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/textarea/classes/item.php
+++ b/field/textarea/classes/item.php
@@ -383,7 +383,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -452,7 +452,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/field/time/classes/item.php
+++ b/field/time/classes/item.php
@@ -431,7 +431,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -593,7 +593,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/format/fieldset/classes/item.php
+++ b/format/fieldset/classes/item.php
@@ -202,7 +202,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -219,7 +219,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/format/fieldsetend/classes/item.php
+++ b/format/fieldsetend/classes/item.php
@@ -196,7 +196,7 @@ class item extends itembase {
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -214,7 +214,7 @@ class item extends itembase {
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/format/label/classes/item.php
+++ b/format/label/classes/item.php
@@ -278,7 +278,7 @@ EOS;
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -307,7 +307,7 @@ EOS;
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/format/pagebreak/classes/item.php
+++ b/format/pagebreak/classes/item.php
@@ -199,7 +199,7 @@ class item extends itembase {
     // MARK userform.
 
     /**
-     * Define the mform element for the outform and the searchform.
+     * Define the mform element for the userform and the searchform.
      *
      * @param \moodleform $mform
      * @param bool $searchform
@@ -214,7 +214,7 @@ class item extends itembase {
     }
 
     /**
-     * Perform outform and searchform data validation.
+     * Perform userform and searchform data validation.
      *
      * @param array $data
      * @param array $errors

--- a/lang/en/surveypro.php
+++ b/lang/en/surveypro.php
@@ -351,7 +351,7 @@ $string['optionalitem_title'] = 'Optional element. Click to make the element man
 $string['outputstyle'] = 'Output style';
 $string['overwrite_help'] = 'Selecting this checkbox you will overwrite an older template with the same name. If you leave this checkbox unselected, in case of conflicts, you will be asked for a new unique name.';
 $string['overwrite'] = 'Replace older template';
-$string['pagexofy'] = 'Page {$a->formpage} of {$a->maxassignedpage}';
+$string['pagexofy'] = 'Page {$a->formpage} of {$a->userformpagecount}';
 $string['parentconstraints'] = 'Parent constraints';
 $string['parentcontent_help'] = 'This is what the user is supposed to answer to the parent element in order to enable/display this element.';
 $string['parentcontent'] = 'Parent content';
@@ -500,6 +500,7 @@ $string['typeformat'] = 'Formats';
 $string['typeplugin_help'] = 'This is the list of available elements. Survey elements are of two types: "field" type and "format" type. Choose the element that better suite your needs.';
 $string['typeplugin'] = 'Element';
 $string['uerr_willbetrimmed'] = 'Answer will be cleaned up from trailing spaces';
+$string['unaccesiblepages_note'] = '(Few pages may not be accessible due to lack of permissions)';
 $string['unavailableelement_title'] = 'Unavailable element. Unhide it to make it available.';
 $string['unhandledvalue'] = 'Unhandled return value from {$a}';
 $string['unixtime'] = 'unix time';
@@ -545,7 +546,7 @@ $string['welcome_utemplatesave'] = 'Save a user template with the structure of t
 User templates are useful to quickly add to your surveys static sets of predefined items. At any time you can download and share it with other moodle users or reuse it into your own surveys. Be careful to "{$a}" if you want to reuse your templates without downloading and uploading them again.';
 $string['willclose'] = 'Closure time';
 $string['willopen'] = 'This survey will open at';
-$string['wrong_direction_found'] = 'Invalid $direction provided to {$a->methodname} in conjunction with $startingpage == {$a->methodname}';
+$string['wrong_direction_found'] = 'Invalid $direction provided in {$a->methodname} in conjunction with $startingpage == {$a->startingpage}';
 $string['wrong_sharinglevel_found'] = 'Invalid $sharinglevel = "{$a->sharinglevel}" provided to {$a->methodname}';
 $string['wrong_userdatarec_found'] = 'Invalid $userdatarec = \'{$a}\' has not been replaced';
 $string['wrongrelation'] = '"{$a}" will never match';

--- a/lang/es/surveypro.php
+++ b/lang/es/surveypro.php
@@ -339,7 +339,7 @@ $string['optionalitem_title'] = 'Elemento opcional. Haga click para volver oblig
 $string['outputstyle'] = 'Estilo de salida';
 $string['overwrite_help'] = 'Al seleccionar esta casilla Usted sobre-escribirá una plantilla más antigua con el mismo nombre. Si Usted deja esta casilla sin seleccionar, en caso de conflictos se le pedirá un nuevo nombre único.';
 $string['overwrite'] = 'Remplazar plantilla más antigua';
-$string['pagexofy'] = 'Página {$a->formpage} de {$a->maxassignedpage}';
+$string['pagexofy'] = 'Página {$a->formpage} de {$a->userformpagecount}';
 $string['parentconstraints'] = 'Limitantes paternas';
 $string['parentcontent_help'] = 'Esto es lo que el usuario se supone que deba contestar al elemento paterno para  habilitar/mostrar este elementp.';
 $string['parentcontent'] = 'Contenido paterno';
@@ -518,7 +518,7 @@ $string['welcome_utemplatesave'] = 'Guardar una plantilla de usuario con la estr
 Las plantillas de usuario son útiles para añadir rápidamente a su encuesta conjuntos estáticos de ítems pre-definidos. En cualquier momento Usted puede descargarlas y compartirlas con otros usuarios de Moodle o re-utilizarlas en sus propias encuestas. Sea cuidadoso con el "{$a}" si Usted quiere re-utilizar sus plantillas sin descargarlas y subirlas otra vez.';
 $string['willclose'] = 'Hora de cierre';
 $string['willopen'] = 'Esta encuesta se abrirá en';
-$string['wrong_direction_found'] = '$direction inválida proporcionada a {$a->methodname} en conjunto con $startingpage == {$a->methodname}';
+$string['wrong_direction_found'] = '$direction inválida proporcionada a {$a->methodname} en conjunto con $startingpage == {$a->startingpage}';
 $string['wrong_sharinglevel_found'] = '$sharinglevel = "{$a->sharinglevel}" inválido proporcionado a {$a->methodname}';
 $string['wrong_userdatarec_found'] = '$userdatarec = \'{$a}\' inválida no ha sido remplazada';
 $string['wrongrelation'] = '"{$a}" nunca coincidirá';

--- a/lang/es_mx/surveypro.php
+++ b/lang/es_mx/surveypro.php
@@ -339,7 +339,7 @@ $string['optionalitem_title'] = 'Elemento opcional. Haga click para volver oblig
 $string['outputstyle'] = 'Estilo de salida';
 $string['overwrite_help'] = 'Al seleccionar esta casilla Usted sobre-escribirá una plantilla más antigua con el mismo nombre. Si Usted deja esta casilla sin seleccionar, en caso de conflictos se le pedirá un nuevo nombre único.';
 $string['overwrite'] = 'Remplazar plantilla más antigua';
-$string['pagexofy'] = 'Página {$a->formpage} de {$a->maxassignedpage}';
+$string['pagexofy'] = 'Página {$a->formpage} de {$a->userformpagecount}';
 $string['parentconstraints'] = 'Limitantes paternas';
 $string['parentcontent_help'] = 'Esto es lo que el usuario se supone que deba contestar al elemento paterno para  habilitar/mostrar este elementp.';
 $string['parentcontent'] = 'Contenido paterno';
@@ -518,7 +518,7 @@ $string['welcome_utemplatesave'] = 'Guardar una plantilla de usuario con la estr
 Las plantillas de usuario son útiles para añadir rápidamente a su encuesta conjuntos estáticos de ítems pre-definidos. En cualquier momento Usted puede descargarlas y compartirlas con otros usuarios de Moodle o re-utilizarlas en sus propias encuestas. Sea cuidadoso con el "{$a}" si Usted quiere re-utilizar sus plantillas sin descargarlas y subirlas otra vez.';
 $string['willclose'] = 'Hora de cierre';
 $string['willopen'] = 'Esta encuesta se abrirá en';
-$string['wrong_direction_found'] = '$direction inválida proporcionada a {$a->methodname} en conjunto con $startingpage == {$a->methodname}';
+$string['wrong_direction_found'] = '$direction inválida proporcionada a {$a->methodname} en conjunto con $startingpage == {$a->startingpage}';
 $string['wrong_sharinglevel_found'] = '$sharinglevel = "{$a->sharinglevel}" inválido proporcionado a {$a->methodname}';
 $string['wrong_userdatarec_found'] = '$userdatarec = \'{$a}\' inválida no ha sido remplazada';
 $string['wrongrelation'] = '"{$a}" nunca coincidirá';

--- a/lang/it/surveypro.php
+++ b/lang/it/surveypro.php
@@ -193,6 +193,7 @@ $string['submissions_welcome'] = 'Risposte acquisite';
 $string['timecreated'] = 'Creato';
 $string['timemodified'] = 'Modificato';
 $string['typeplugin'] = 'Elemento';
+$string['unaccesiblepages_note'] = '(Qualche pagina non sarà accessibile per mancanza di permessi)';
 $string['userenrolled'] = 'Utente iscritto: 1';
 $string['usersenrolled'] = 'Utenti iscritti: {$a}';
 $string['variable_help'] = 'Il nome della variabile associata all\'informazione richiesta.';

--- a/layout_preview.php
+++ b/layout_preview.php
@@ -26,7 +26,7 @@ use mod_surveypro\utility_layout;
 use mod_surveypro\layout_preview;
 use mod_surveypro\tabs;
 use mod_surveypro\utility_mform;
-use mod_surveypro\local\form\surveyprofillform;
+use mod_surveypro\local\form\userform;
 
 require_once(dirname(dirname(dirname(__FILE__))).'/config.php');
 
@@ -44,8 +44,9 @@ if (!empty($id)) {
 }
 $cm = cm_info::create($cm);
 
-$formpage = optional_param('formpage', 0, PARAM_INT); // Form page number.
 $submissionid = optional_param('submissionid', 0, PARAM_INT);
+$formpage = optional_param('formpage', 1, PARAM_INT); // Form page number.
+$overflowpage = optional_param('overflowpage', 0, PARAM_INT); // Went the user to a overflow page?
 $edit = optional_param('edit', -1, PARAM_BOOL);
 
 require_course_login($course, false, $cm);
@@ -70,15 +71,18 @@ $formparams = new \stdClass();
 $formparams->cm = $cm;
 $formparams->surveypro = $surveypro;
 $formparams->submissionid = $submissionid;
-$formparams->maxassignedpage = $previewman->get_maxassignedpage();
+$formparams->userformpagecount = $previewman->get_userformpagecount();
 $formparams->canaccessreserveditems = has_capability('mod/surveypro:accessreserveditems', $context);
-$formparams->formpage = $previewman->get_formpage(); // The page of the form to select subset of fields
+$formparams->formpage = $formpage; // The page of the form to select subset of fields
+$formparams->userfirstpage = $previewman->get_userfirstpage(); // The user first page
+$formparams->userlastpage = $previewman->get_userlastpage(); // The user last page
+$formparams->overflowpage = $overflowpage; // Went the user to a overflow page?
 $formparams->tabpage = SURVEYPRO_LAYOUT_PREVIEW; // This is the page of the TAB-PAGE structure.
 $formparams->readonly = false;
 $formparams->preview = true;
 // End of: prepare params for the form.
 
-$userform = new surveyprofillform($formurl, $formparams, 'post', '', array('id' => 'userentry'));
+$userform = new userform($formurl, $formparams, 'post', '', array('id' => 'userentry'));
 
 // Begin of: manage form submission.
 if ($data = $userform->get_data()) {
@@ -87,7 +91,9 @@ if ($data = $userform->get_data()) {
     // If "previous" button has been pressed, redirect.
     $prevbutton = isset($data->prevbutton);
     if ($prevbutton) {
-        $paramurl['formpage'] = --$formpage;
+        $previewman->next_not_empty_page(false);
+        $paramurl['formpage'] = $previewman->get_nextpage();
+        $paramurl['overflowpage'] = $previewman->get_overflowpage();
         $redirecturl = new \moodle_url('/mod/surveypro/layout_preview.php', $paramurl);
         redirect($redirecturl); // Go to the previous page of the form.
     }
@@ -95,7 +101,9 @@ if ($data = $userform->get_data()) {
     // If "next" button has been pressed, redirect.
     $nextbutton = isset($data->nextbutton);
     if ($nextbutton) {
-        $paramurl['formpage'] = ++$formpage;
+        $previewman->next_not_empty_page(true);
+        $paramurl['formpage'] = $previewman->get_nextpage();
+        $paramurl['overflowpage'] = $previewman->get_overflowpage();
         $redirecturl = new \moodle_url('/mod/surveypro/layout_preview.php', $paramurl);
         redirect($redirecturl); // Go to the next page of the form.
     }

--- a/lib.php
+++ b/lib.php
@@ -147,12 +147,6 @@ define('SURVEYPRO_CHANGEORDERASK'  , '5');
 define('SURVEYPRO_RESPONSETOPDF'   , '6');
 
 /**
- * OVERFLOW
- */
-define('SURVEYPRO_LEFT_OVERFLOW' , -10);
-define('SURVEYPRO_RIGHT_OVERFLOW', -20);
-
-/**
  * SENDERS
  */
 define('SURVEYPRO_TAB'  , 1);

--- a/tests/behat/change_of_mind.feature
+++ b/tests/behat/change_of_mind.feature
@@ -1,0 +1,321 @@
+@mod @mod_surveypro @surveyprofield
+Feature: deletion of no longer allowed answers on user change of mind
+  Test the deletion of no longer allowed answers in a parent-child relation over two pages when user changes his answer
+  As a teacher
+  I create a parent-child relation and as a student I fill, return back, change my answer and continue.
+
+  @javascript
+  Scenario: Test change of mind: 1-2-1-2
+    Given the following "courses" exist:
+      | fullname        | shortname     | category | groupmode |
+      | Change of mind | Change of mind | 0        | 0         |
+    And the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | teacher  | teacher1@nowhere.net |
+      | student1 | Student   | student  | student1@nowhere.net |
+    And the following "course enrolments" exist:
+      | user     | course         | role           |
+      | teacher1 | Change of mind | editingteacher |
+      | student1 | Change of mind | student        |
+    And the following "activities" exist:
+      | activity  | name                | intro               | newpageforchild | course         |
+      | surveypro | Test change of mind | Test change of mind | 1               | Change of mind |
+    And surveypro "Test change of mind" contains the following items:
+      | type   | plugin      |
+      | field  | character   |
+      | field  | boolean     |
+      | format | pagebreak   |
+      | field  | select      |
+      | field  | character   |
+    And I log in as "teacher1"
+    And I am on "Change of mind" course homepage
+    And I follow "Test change of mind"
+    And I follow "Layout"
+
+    And I follow "edit_item_1"
+    And I set the field "Required" to "1"
+    And I press "Save changes"
+
+    And I follow "edit_item_2"
+    And I set the field "Required" to "1"
+    And I press "Save changes"
+
+    And I follow "edit_item_4"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Content        | Choose a direction       |
+      | Required       | 1                        |
+      | Parent element | Boolean [2]: Is it true? |
+      | Parent content | 0                        |
+    And I set the multiline field "Options" to "North\nEast\nSouth\nWest"
+    And I press "Save changes"
+
+    And I follow "edit_item_5"
+    And I set the following fields to these values:
+      | Content    | Question without parent |
+      | Required   | 1                       |
+      | id_pattern | free pattern            |
+
+    And I press "Save changes"
+
+    And I log out
+
+    # Let the student start to fill the surveypro
+    When I log in as "student1"
+    And I am on "Change of mind" course homepage
+    And I follow "Test change of mind"
+
+    And I press "New response"
+    And I set the field "Write down your email" to "su@nowhere.net"
+    And I set the field "Is it true?" to "0"
+    And I press "Next page >>"
+    Then I should see "Choose a direction"
+    Then I should see "Question without parent"
+
+    And I set the field "Choose a direction" to "South"
+    And I set the field "Question without parent" to "This should remain"
+    And I press "<< Previous page"
+
+    And I set the field "Is it true?" to "1"
+    And I press "Next page >>"
+    Then I should not see "Choose a direction"
+    Then I should see "Question without parent"
+
+    And I press "Submit"
+    Then I should not see "Some answers of this response have been found as unverified."
+
+    And I press "Continue to responses list"
+    Then I should see "1" submissions
+
+  @javascript
+  Scenario: Test change of mind: 1-2-1-3
+    Given the following "courses" exist:
+      | fullname               | shortname              | category | groupmode |
+      | 1-2-1-3 change of mind | 1-2-1-3 change of mind | 0        | 0         |
+    And the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | teacher  | teacher1@nowhere.net |
+      | student1 | Student   | student  | student1@nowhere.net |
+    And the following "course enrolments" exist:
+      | user     | course                 | role           |
+      | teacher1 | 1-2-1-3 change of mind | editingteacher |
+      | student1 | 1-2-1-3 change of mind | student        |
+    And the following "activities" exist:
+      | activity  | name                        | intro                       | newpageforchild | course                 |
+      | surveypro | Test 1-2-1-3 change of mind | Test 1-2-1-3 change of mind | 1               | 1-2-1-3 change of mind |
+    And surveypro "Test 1-2-1-3 change of mind" contains the following items:
+      | type   | plugin      |
+      | field  | character   |
+      | field  | boolean     |
+      | format | pagebreak   |
+      | field  | radiobutton |
+      | format | pagebreak   |
+      | field  | select      |
+      | field  | checkbox    |
+      | field  | character   |
+    And I log in as "teacher1"
+    And I am on "1-2-1-3 change of mind" course homepage
+    And I follow "Test 1-2-1-3 change of mind"
+    And I follow "Layout"
+
+    And I follow "edit_item_1"
+    And I set the field "Required" to "1"
+    And I press "Save changes"
+
+    And I follow "edit_item_2"
+    And I set the field "Required" to "1"
+    And I press "Save changes"
+
+    And I follow "edit_item_4"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Content        | Which pet do you like more? |
+      | Required       | 1                           |
+      | Parent element | Boolean [2]: Is it true?    |
+      | Parent content | 1                           |
+    And I set the multiline field "Options" to "dog\ncat\nbird\ncrocodile"
+    And I press "Save changes"
+
+    And I follow "edit_item_6"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Content        | Choose a direction       |
+      | Required       | 1                        |
+      | Parent element | Boolean [2]: Is it true? |
+      | Parent content | 0                        |
+    And I set the multiline field "Options" to "North\nEast\nSouth\nWest"
+    And I press "Save changes"
+
+    And I follow "edit_item_7"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Required       | 1                        |
+      | Parent element | Boolean [2]: Is it true? |
+      | Parent content | 1                        |
+    And I press "Save changes"
+
+    And I follow "edit_item_8"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Content    | Question without parent |
+      | Required   | 1                       |
+      | id_pattern | free pattern            |
+    And I press "Save changes"
+
+    And I log out
+
+    # Let the student start to fill the surveypro
+    When I log in as "student1"
+    And I am on "1-2-1-3 change of mind" course homepage
+    And I follow "Test 1-2-1-3 change of mind"
+
+    And I press "New response"
+    And I set the field "Write down your email" to "su@nowhere.net"
+    And I set the field "Is it true?" to "1"
+    And I press "Next page >>"
+    Then I should see "Which pet do you like more?"
+
+    And I set the following fields to these values:
+      | id_surveypro_field_radiobutton_4_2 | 1 |
+    And I press "Next page >>"
+    Then I should not see "Choose a direction"
+
+    And I set the following fields to these values:
+      | id_surveypro_field_checkbox_7_1 | 1 |
+    And I set the field "Question without parent" to "This should remain"
+    And I press "<< Previous page"
+
+    And I set the following fields to these values:
+      | id_surveypro_field_radiobutton_4_3 | 1 |
+    And I press "<< Previous page"
+
+    And I set the field "Is it true?" to "0"
+    And I press "Next page >>"
+    Then I should see "Page 3 of 3"
+    Then I should not see "Which pet do you like more?"
+    Then I should not see "What do you usually get for breakfast?"
+    Then I should see "Choose a direction"
+    Then I should see "Question without parent"
+
+    And I set the field "Choose a direction" to "South"
+    And I press "Submit"
+    Then I should not see "Some answers of this response have been found as unverified."
+
+    And I press "Continue to responses list"
+    Then I should see "1" submissions
+
+  @javascript
+  Scenario: Test change of mind: 1-3-1-2
+    Given the following "courses" exist:
+      | fullname               | shortname              | category | groupmode |
+      | 1-3-1-2 change of mind | 1-3-1-2 change of mind | 0        | 0         |
+    And the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | teacher  | teacher1@nowhere.net |
+      | student1 | Student   | student  | student1@nowhere.net |
+    And the following "course enrolments" exist:
+      | user     | course                 | role           |
+      | teacher1 | 1-3-1-2 change of mind | editingteacher |
+      | student1 | 1-3-1-2 change of mind | student        |
+    And the following "activities" exist:
+      | activity  | name                        | intro                       | newpageforchild | course                 |
+      | surveypro | Test 1-3-1-2 change of mind | Test 1-3-1-2 change of mind | 1               | 1-3-1-2 change of mind |
+    And surveypro "Test 1-3-1-2 change of mind" contains the following items:
+      | type   | plugin      |
+      | field  | character   |
+      | field  | radiobutton |
+      | format | pagebreak   |
+      | field  | boolean     |
+      | field  | character   |
+      | format | pagebreak   |
+      | field  | boolean     |
+      | field  | character   |
+    And I log in as "teacher1"
+    And I am on "1-3-1-2 change of mind" course homepage
+    And I follow "Test 1-3-1-2 change of mind"
+    And I follow "Layout"
+
+    And I follow "edit_item_1"
+    And I set the field "Required" to "1"
+    And I press "Save changes"
+
+    And I follow "edit_item_2"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Content        | Which artwork did you make? |
+      | Required       | 1                           |
+    And I set the multiline field "Options" to "p::painting\ns::sculpture\nm::musical"
+    And I press "Save changes"
+
+    And I follow "edit_item_4"
+    And I set the following fields to these values:
+      | Content        | Is it A4 format?                              |
+      | Required       | 1                                             |
+      | Parent element | Radio button [2]: Which artwork did you make? |
+      | Parent content | p                                             |
+    And I press "Save changes"
+
+    And I follow "edit_item_5"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Content        | Simple parent child question                  |
+      | Required       | 1                                             |
+      | id_pattern     | free pattern                                  |
+      | Parent element | Radio button [2]: Which artwork did you make? |
+      | Parent content | p                                             |
+    And I press "Save changes"
+
+    And I follow "edit_item_7"
+    And I set the following fields to these values:
+      | Content        | Was it carved in marble?                      |
+      | Required       | 1                                             |
+      | Parent element | Radio button [2]: Which artwork did you make? |
+      | Parent content | s                                             |
+    And I press "Save changes"
+
+    And I follow "edit_item_8"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Content    | Question without parent |
+      | Required   | 1                       |
+      | id_pattern | free pattern            |
+    And I press "Save changes"
+
+    And I log out
+
+    # Let the student start to fill the surveypro
+    When I log in as "student1"
+    And I am on "1-3-1-2 change of mind" course homepage
+    And I follow "Test 1-3-1-2 change of mind"
+
+    And I press "New response"
+    And I set the field "Write down your email" to "su@nowhere.net"
+
+    And I set the following fields to these values:
+      | id_surveypro_field_radiobutton_2_1 | 1 |
+    And I press "Next page >>"
+    Then I should see "Was it carved in marble?"
+    Then I should not see "Is it A4 format?"
+
+    And I set the field "Was it carved in marble?" to "No"
+    And I set the field "Question without parent" to "I am proud of it"
+    And I press "<< Previous page"
+    Then I should see "Which artwork did you make?"
+
+    And I set the following fields to these values:
+      | id_surveypro_field_radiobutton_2_0 | 1 |
+    And I press "Next page >>"
+    Then I should see "Is it A4 format?"
+    Then I should not see "Was it carved in marble?"
+
+    And I set the field "Is it A4 format?" to "Yes"
+    And I set the field "Simple parent child question" to "I am preparing a bigger one"
+    And I press "Next page >>"
+    Then I should see "Question without parent"
+    Then I should not see "Was it carved in marble?"
+
+    And I press "Submit"
+    Then I should not see "Some answers of this response have been found as unverified."
+
+    And I press "Continue to responses list"
+    Then I should see "1" submissions

--- a/tests/behat/readonly_browse_allowed_pages_only.feature
+++ b/tests/behat/readonly_browse_allowed_pages_only.feature
@@ -1,0 +1,90 @@
+@mod @mod_surveypro @surveyprofield
+Feature: In read only mode browse a submission jumping now filled pages
+  Test during read only browse of responses user jumps pages without answers
+  As a teacher
+  I create a surveypro and as a student I fill, submit and browse, in read only mode, my submission.
+
+  @javascript
+  Scenario: Jump unused survepro pages in read only mode
+    Given the following "courses" exist:
+      | fullname               | shortname              | category | groupmode |
+      | Jump not allowed pages | Jump not allowed pages | 0        | 0         |
+    And the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | teacher  | teacher1@nowhere.net |
+      | student1 | Student   | student  | student1@nowhere.net |
+    And the following "course enrolments" exist:
+      | user     | course                | role           |
+      | teacher1 | Jump not allowed pages | editingteacher |
+      | student1 | Jump not allowed pages | student        |
+    And the following "activities" exist:
+      | activity  | name                        | intro                       | newpageforchild | course                 |
+      | surveypro | Test jump not allowed pages | Test jump not allowed pages | 1               | Jump not allowed pages |
+    And surveypro "Test jump not allowed pages" contains the following items:
+      | type   | plugin      |
+      | field  | boolean     |
+      | format | pagebreak   |
+      | field  | select      |
+      | format | pagebreak   |
+      | field  | character   |
+      | format | pagebreak   |
+      | field  | boolean     |
+    And I log in as "teacher1"
+    And I am on "Jump not allowed pages" course homepage
+    And I follow "Test jump not allowed pages"
+    And I follow "Layout"
+
+    And I follow "edit_item_3"
+    And I expand all fieldsets
+    And I set the following fields to these values:
+      | Content        | Question of page 2       |
+      | Required       | 1                        |
+      | Parent element | Boolean [1]: Is it true? |
+      | Parent content | 1                        |
+    And I set the multiline field "Options" to "Up\nDown"
+    And I press "Save changes"
+
+    And I follow "edit_item_5"
+    And I set the following fields to these values:
+      | Content        | Question of page 3       |
+      | Parent element | Boolean [1]: Is it true? |
+      | Parent content | 0                        |
+    And I press "Save changes"
+
+    And I follow "edit_item_7"
+    And I set the following fields to these values:
+      | Content        | Question of page 4             |
+      | Parent element | Select [3]: Question of page 2 |
+      | Parent content | Up                             |
+    And I press "Save changes"
+
+    And I log out
+
+    # Let the student start to fill the surveypro
+    When I log in as "student1"
+    And I am on "Jump not allowed pages" course homepage
+    And I follow "Test jump not allowed pages"
+
+    And I press "New response"
+    And I set the field "Is it true?" to "1"
+    And I press "Next page >>"
+    Then I should see "Question of page 2"
+
+    And I set the field "Question of page 2" to "Up"
+    And I press "Next page >>"
+    Then I should see "Question of page 4"
+
+    And I set the field "Question of page 4" to "0"
+    And I press "Submit"
+
+    And I press "Continue to responses list"
+    Then I should see "1" submissions
+
+    And I follow "view_submission_row_1"
+    Then I should see "Is it true?"
+
+    And I press "Next page >>"
+    Then I should see "Question of page 2"
+
+    And I press "Next page >>"
+    Then I should see "Question of page 4"

--- a/view_search.php
+++ b/view_search.php
@@ -25,7 +25,7 @@
 use mod_surveypro\tabs;
 use mod_surveypro\utility_mform;
 use mod_surveypro\view_search;
-use mod_surveypro\local\form\surveyprosearchform;
+use mod_surveypro\local\form\usersearch;
 
 require_once(dirname(dirname(dirname(__FILE__))).'/config.php');
 
@@ -66,7 +66,7 @@ $formparams = new \stdClass();
 $formparams->cm = $cm;
 $formparams->surveypro = $surveypro;
 $formparams->canaccessreserveditems = has_capability('mod/surveypro:accessreserveditems', $context);
-$searchform = new surveyprosearchform($formurl, $formparams, 'post', '', array('id' => 'usersearch'));
+$searchform = new usersearch($formurl, $formparams, 'post', '', array('id' => 'usersearch'));
 // End of: prepare params for the form.
 
 // Begin of: manage form submission.


### PR DESCRIPTION
The context of this fix is this: let's suppose I have a surveypro with parent child relation spanning multiple pages.

Simple scenario
On page 1 I have a branching item.
On page 2 I have the child of the branching item AND a question without parent. I fill the surveypro.
I add an answer for the parent item and I move to page 2. Here I add an answer for the child item and for the free item. At the end I return back to page 1.
I change my mind and the answer to the parent item. I return to page 2, I fill the free item and I submit. The submission HAS TO BE CLOSED and not marked as "in progress" because some item has answer not verified.

The original answer to the child item should, actually, be dropped. This patch corrects the routine to drop answers to this kind of items.

Advanced scenario
On page 1 I have a branching item.
On page 2 I have an item depending from branching item when answer is 1. On page 3 I have an item depending from branching item when answer is 0, one more item depending from branching item when answer is 1 AND one free item (without dependencies). I fill the surveypro.
I answer 1 to the parent item and I move forward.
I find an item in page 2 and I provide an answer.
I move forward and, in page 3, I find the item depending from branching item when answer is 1 AND the free item. I provide an answer to both of them and I move backward. I land in page 2. I am free to leave the item untouched or to change the answer. I move backward once more and I change (in page 1) the answer to branching item (from 1 to 0) and I move forward. I land in page 3 and I see only the item depending from branching item when answer is 0 and the free item (without dependencies). I fill the page and I submit.
The submission HAS TO BE CLOSED and not marked as "in progress" because some item has answer not verified.