### PR TITLE
No modification time at first submit

### DIFF
--- a/classes/view_cover.php
+++ b/classes/view_cover.php
@@ -159,7 +159,8 @@ class view_cover {
         // End of: general info.
 
         if ($addnew) {
-            $url = new \moodle_url('/mod/surveypro/view_form.php', array('id' => $this->cm->id, 'view' => SURVEYPRO_NEWRESPONSE));
+            $paramurl = ['id' => $this->cm->id, 'view' => SURVEYPRO_NEWRESPONSE, 'begin' => 1];
+            $url = new \moodle_url('/mod/surveypro/view_form.php', $paramurl);
             $message = get_string('addnewsubmission', 'mod_surveypro');
             echo $OUTPUT->box($OUTPUT->single_button($url, $message, 'get'), 'clearfix mdl-align');
         } else {

--- a/classes/view_submissions.php
+++ b/classes/view_submissions.php
@@ -653,6 +653,8 @@ class view_submissions {
                 }
                 if ($displayediticon) {
                     $paramurl['view'] = SURVEYPRO_EDITRESPONSE;
+                    $paramurl['begin'] = 1;
+
                     if ($submission->status == SURVEYPRO_STATUSINPROGRESS) {
                         // Here title and alt are ALWAYS $nonhistoryeditstr.
                         $link = new \moodle_url('/mod/surveypro/view_form.php', $paramurl);
@@ -666,6 +668,7 @@ class view_submissions {
                     }
                 } else {
                     $paramurl['view'] = SURVEYPRO_READONLYRESPONSE;
+                    $paramurl['begin'] = 1;
 
                     $link = new \moodle_url('/mod/surveypro/view_form.php', $paramurl);
                     $paramlink = array('id' => 'view_submission_'.$submissionsuffix, 'title' => $readonlyaccessstr);
@@ -788,7 +791,8 @@ class view_submissions {
 
         $buttoncount = 0;
         if ($addnew) {
-            $addurl = new \moodle_url('/mod/surveypro/view_form.php', array('id' => $this->cm->id, 'view' => SURVEYPRO_NEWRESPONSE));
+            $paramurl = ['id' => $this->cm->id, 'view' => SURVEYPRO_NEWRESPONSE, 'begin' => 1];
+            $addurl = new \moodle_url('/mod/surveypro/view_form.php', $paramurl);
             $buttoncount = 1;
         }
         if ($deleteall) {
@@ -968,7 +972,7 @@ class view_submissions {
 
         $paramurlbase = array('id' => $this->cm->id);
         if ($cansubmitmore) { // If the user is allowed to submit one more response.
-            $paramurl = $paramurlbase + array('view' => SURVEYPRO_NEWRESPONSE);
+            $paramurl = $paramurlbase + array('view' => SURVEYPRO_NEWRESPONSE, 'begin' => 1);
             $buttonurl = new \moodle_url('/mod/surveypro/view_form.php', $paramurl);
             $onemore = new \single_button($buttonurl, get_string('addnewsubmission', 'mod_surveypro'));
 

--- a/tests/behat/modificationdate.feature
+++ b/tests/behat/modificationdate.feature
@@ -1,0 +1,53 @@
+@mod @mod_surveypro @surveyprofield
+Feature: Submission modification time
+  Check that even filling a multipage surveypro moving forward and backword, timemodified is recorded ONLY at modification time
+  As a teacher
+  I create a multipage surveypro and as a student I fill it going forward and backword, and I submit.
+
+  @javascript
+  Scenario: Check submission modification time
+    Given the following "courses" exist:
+      | fullname                               | shortname                              | category | groupmode |
+      | Timemodified only at modification time | Timemodified only at modification time | 0        | 0         |
+    And the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | teacher  | teacher1@nowhere.net |
+      | student1 | Student   | student  | student1@nowhere.net |
+    And the following "course enrolments" exist:
+      | user     | course                | role           |
+      | teacher1 | Timemodified only at modification time | editingteacher |
+      | student1 | Timemodified only at modification time | student        |
+    And the following "activities" exist:
+      | activity  | name                   | intro                  | newpageforchild | course                                 |
+      | surveypro | Test modification time | Test modification time | 1               | Timemodified only at modification time |
+    And surveypro "Test modification time" contains the following items:
+      | type   | plugin      |
+      | field  | boolean     |
+      | format | pagebreak   |
+      | field  | character   |
+    And I log in as "teacher1"
+    And I am on "Timemodified only at modification time" course homepage
+    And I follow "Test modification time"
+
+    And I log out
+
+    # Let the student start to fill the surveypro
+    When I log in as "student1"
+    And I am on "Timemodified only at modification time" course homepage
+    And I follow "Test modification time"
+
+    And I press "New response"
+    And I set the field "Is it true?" to "1"
+    And I press "Next page >>"
+
+    And I set the field "Write down your email" to "su@nowhere.net"
+    And I press "<< Previous page"
+
+    And I set the field "Is it true?" to "0"
+    And I press "Next page >>"
+
+    And I press "Submit"
+
+    And I press "Continue to responses list"
+    Then I should see "1" submissions
+    Then I should see "Never"

--- a/tests/behat/reserved_at_first.feature
+++ b/tests/behat/reserved_at_first.feature
@@ -1,0 +1,53 @@
+@mod @mod_surveypro @surveyprofield
+Feature: Access a surveypro from the second page if the first one has only reserved items
+  Test accessing the surveypro starting from page 2 if the first one has only reserved items
+  As a teacher
+  I create a surveypro and
+  As a student I get it starting from the second page.
+
+  @javascript
+  Scenario: Get the surveypro starting from page 2
+    Given the following "courses" exist:
+      | fullname   | shortname  | category | groupmode |
+      | Start at 2 | Start at 2 | 0        | 0         |
+    And the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | teacher  | teacher1@nowhere.net |
+      | student1 | Student   | student  | student1@nowhere.net |
+    And the following "course enrolments" exist:
+      | user     | course     | role           |
+      | teacher1 | Start at 2 | editingteacher |
+      | student1 | Start at 2 | student        |
+    And the following "activities" exist:
+      | activity  | name            | intro           | newpageforchild | course     |
+      | surveypro | Test start at 2 | Test start at 2 | 1               | Start at 2 |
+    And surveypro "Test start at 2" contains the following items:
+      | type   | plugin      |
+      | field  | boolean     |
+      | format | pagebreak   |
+      | field  | character   |
+    And I log in as "teacher1"
+    And I am on "Start at 2" course homepage
+    And I follow "Test start at 2"
+    And I follow "Layout"
+
+    And I click on "//a[contains(@class,'quickeditlink')]//img[contains(@id, 'makereserved_item_1')]" "xpath_element"
+
+    And I log out
+
+    # Let the student start to fill the surveypro
+    When I log in as "student1"
+    And I am on "Start at 2" course homepage
+    And I follow "Test start at 2"
+
+    And I press "New response"
+    Then I should see "Write down your email"
+
+    And I set the field "Write down your email" to "su@nowhere.net"
+    And I press "Submit"
+
+    And I press "Continue to responses list"
+    Then I should see "1" submissions
+
+    And I follow "view_submission_row_1"
+    Then I should see "Write down your email"

--- a/view_form.php
+++ b/view_form.php
@@ -48,6 +48,7 @@ $submissionid = optional_param('submissionid', 0, PARAM_INT);
 $formpage = optional_param('formpage', 1, PARAM_INT); // Form page number.
 $overflowpage = optional_param('overflowpage', 0, PARAM_INT); // Went the user to a overflow page?
 $view = optional_param('view', SURVEYPRO_NOVIEW, PARAM_INT);
+$begin = optional_param('begin', 0, PARAM_INT);
 
 require_course_login($course, false, $cm);
 $context = \context_module::instance($cm->id);
@@ -73,13 +74,18 @@ $formparams->surveypro = $surveypro;
 $formparams->submissionid = $submissionid;
 $formparams->userformpagecount = $userformman->get_userformpagecount();
 $formparams->canaccessreserveditems = has_capability('mod/surveypro:accessreserveditems', $context);
-$formparams->formpage = $formpage; // The page of the form to select subset of fields
 $formparams->userfirstpage = $userformman->get_userfirstpage(); // The user first page
 $formparams->userlastpage = $userformman->get_userlastpage(); // The user last page
 $formparams->overflowpage = $overflowpage; // Went the user to a overflow page?
 $formparams->tabpage = $userformman->get_tabpage(); // The page of the TAB-PAGE structure.
 $formparams->readonly = ($userformman->get_tabpage() == SURVEYPRO_SUBMISSION_READONLY);
 $formparams->preview = false;
+if ($begin == 1) {
+    $userformman->next_not_empty_page(true, 0); // True means direction = right.
+    $nextpage = $userformman->get_nextpage(); // The page of the form to select subset of fields
+    $userformman->set_formpage($nextpage);
+}
+$formparams->formpage = $userformman->get_formpage(); // The page of the form to select subset of fields
 // End of: prepare params for the form.
 
 $editable = ($view == SURVEYPRO_READONLYRESPONSE) ? false : true;


### PR DESCRIPTION
Even filling a multipage surveypro moving forward and backword, timemodified is recorded ONLY at modification time