### PR TITLE
Replaced useless $DB->sql_compare_text

### DIFF
--- a/classes/formbase.php
+++ b/classes/formbase.php
@@ -123,7 +123,7 @@ class formbase {
                         FROM {surveypro_item}
                         WHERE surveyproid = :surveyproid
                             AND reserved = :reserved
-                            AND plugin <> '.$DB->sql_compare_text(':plugin');
+                            AND plugin <> :plugin';
             $whereparams = ['surveyproid' => $this->surveypro->id, 'reserved' => 0, 'plugin' => 'pagebreak'];
             $boundaries = $DB->get_record_sql($sql, $whereparams);
 


### PR DESCRIPTION
Queries involving the database field surveypro_answer.plugin don't need $DB->sql_compare_text and I deleted it. I am not sure about surveypro_answer.content and for this reason I leave it as it was. (at the moment).