### PR TITLE
Added format_text to fix file name

### DIFF
--- a/classes/view_export.php
+++ b/classes/view_export.php
@@ -226,7 +226,7 @@ class view_export {
      * @return void
      */
     public function get_export_filename($extension = '') {
-        $filename = $this->surveypro->name;
+        $filename = format_text($this->surveypro->name, FORMAT_HTML);
 
         if ($this->formdata->status == SURVEYPRO_STATUSCLOSED) {
             $filename .= ' '.str_replace(' ', '', get_string('statusclosed', 'surveypro'));


### PR DESCRIPTION
Even if a surveypro has a name using multilang syntax like, for instance, '\<span lang="it" class="multilang"\>Buongiorno mondo\</span\>\<span lang="en" class="multilang"\>Hello world\</span\>', the name of the file to export responses has to be 'Hello world' and not all the multilang syntax.