### PR TITLE
Removed a redundant clean

### DIFF
--- a/classes/view_export.php
+++ b/classes/view_export.php
@@ -241,7 +241,6 @@ class view_export {
         if ($extension) {
             $filename .= '.'.$extension;
         }
-        $filename = clean_filename($filename);
 
         return $filename;
     }


### PR DESCRIPTION
I didn't remove that line to save time but because for multilang names I had (from line 229)

`$filename = '<a class="autolink" title="prova" href="http://localhost:8888/MOODLE_311_STABLE/mod/surveypro/view.php?id=14">prova</a>'`

and using (in line 244) the removed

`$filename = clean_filename($filename);`

I got

`$filename = 'a class=autolink title=prova href=httplocalhost8888MOODLE_311_STABLEmodsurveyproview.php?id=14provaa closed verbose 202210251144.csv'`

while I only want: 'prova closed verbose 202210251155.csv'