### PR TITLE
Added check over report writing names

### DIFF
--- a/classes/itembase.php
+++ b/classes/itembase.php
@@ -142,8 +142,8 @@ class itembase {
         'variable' => true,
         'indent' => true,
         'hidden' => true,
-        'reserved' => true,
         'insearchform' => true,
+        'reserved' => true,
         'parentid' => true
     );
 

--- a/classes/mastertemplate.php
+++ b/classes/mastertemplate.php
@@ -735,7 +735,7 @@ class mastertemplate extends templatebase {
             }
         }
 
-        return "\n".implode("\n", $stringsastext);
+        return "\n".implode("\n", $stringsastext)."\n";
     }
 
     /**
@@ -784,6 +784,6 @@ class mastertemplate extends templatebase {
             }
         }
 
-        return "\n".implode("\n", $stringsastext);
+        return "\n".implode("\n", $stringsastext)."\n";
     }
 }

--- a/classes/tabs.php
+++ b/classes/tabs.php
@@ -335,6 +335,9 @@ class tabs {
 
                 break;
             case SURVEYPRO_TABREPORTS:
+                $surveyproreportlist = \core_component::get_plugin_list('surveyproreport');
+
+                $canalwaysseeowner = has_capability('mod/surveypro:alwaysseeowner', $this->context);
                 $canaccessreports = has_capability('mod/surveypro:accessreports', $this->context);
                 $canaccessownreports = has_capability('mod/surveypro:accessownreports', $this->context);
 
@@ -343,21 +346,15 @@ class tabs {
                 $inactive = array($tabreportsname);
                 $activetwo = array($tabreportsname);
 
-                if ($surveyproreportlist = get_plugin_list('surveyproreport')) {
-                    $counter = 0;
-                    foreach ($surveyproreportlist as $reportname => $reportpath) {
-                        $classname = 'surveyproreport_'.$reportname.'\report';
-                        $reportman = new $classname($this->cm, $this->context, $this->surveypro);
-                        $reportappliesto = $reportman->report_applies_to();
-                        if (($reportappliesto == ['each']) || in_array($this->surveypro->template, $reportappliesto)) {
-                            if ($canaccessreports || ($reportman->has_student_report() && $canaccessownreports)) {
-                                if ($reportman->report_apply()) {
-                                    if ($elementurl = $this->tabpagesurl['tab_reports'][$reportname]) {
-                                        $strlabel = get_string('pluginname', 'surveyproreport_'.$reportname);
-                                        $row[] = new \tabobject('idpage'.$counter, $elementurl->out(), $strlabel);
-                                    }
-                                }
-                            }
+                $counter = 0;
+                foreach ($surveyproreportlist as $reportname => $reportpath) {
+                    $classname = 'surveyproreport_'.$reportname.'\report';
+                    $reportman = new $classname($this->cm, $this->context, $this->surveypro);
+
+                    if ($reportman->is_report_allowed($reportname)) {
+                        if ($elementurl = $this->tabpagesurl['tab_reports'][$reportname]) {
+                            $strlabel = get_string('pluginname', 'surveyproreport_'.$reportname);
+                            $row[] = new \tabobject('idpage'.$counter, $elementurl->out(), $strlabel);
                         }
                         $counter++;
                     }

--- a/classes/view_cover.php
+++ b/classes/view_cover.php
@@ -75,6 +75,7 @@ class view_cover {
 
         $labelsep = get_string('labelsep', 'langconfig'); // Separator usually is ': '..
 
+        $canalwaysseeowner = has_capability('mod/surveypro:alwaysseeowner', $this->context);
         $cansubmit = has_capability('mod/surveypro:submit', $this->context);
         $canmanageitems = has_capability('mod/surveypro:manageitems', $this->context);
         $canaccessreports = has_capability('mod/surveypro:accessreports', $this->context);
@@ -198,25 +199,21 @@ class view_cover {
         // Begin of: report section.
         $surveyproreportlist = get_plugin_list('surveyproreport');
         $paramurlbase = array('id' => $this->cm->id);
-        foreach ($surveyproreportlist as $pluginname => $pluginpath) {
-            $classname = 'surveyproreport_'.$pluginname.'\report';
+
+        foreach ($surveyproreportlist as $reportname => $pluginpath) {
+            $classname = 'surveyproreport_'.$reportname.'\report';
             $reportman = new $classname($this->cm, $this->context, $this->surveypro);
 
-            $reportappliesto = $reportman->report_applies_to();
-            if (($reportappliesto == ['each']) || in_array($this->surveypro->template, $reportappliesto)) {
-                if ($canaccessreports || ($reportman->has_student_report() && $canaccessownreports)) {
-                    if ($reportman->report_apply()) {
-                        if ($childreports = $reportman->has_childreports($canaccessreports)) {
-                            $reportname = get_string('pluginname', 'surveyproreport_'.$pluginname);
-                            $this->add_report_link($childreports, $pluginname, $messages, $reportname);
-                        } else {
-                            $url = new \moodle_url('/mod/surveypro/report/'.$pluginname.'/view.php', $paramurlbase);
-                            $a = new \stdClass();
-                            $a->href = $url->out();
-                            $a->reportname = get_string('pluginname', 'surveyproreport_'.$pluginname);
-                            $messages[] = get_string('runreport', 'mod_surveypro', $a);
-                        }
-                    }
+            if ($reportman->is_report_allowed($reportname)) {
+                if ($childrenreports = $reportman->get_haschildrenreports()) {
+                    $linklabel = get_string('pluginname', 'surveyproreport_'.$reportname);
+                    $this->add_report_link($childrenreports, $reportname, $messages, $linklabel);
+                } else {
+                    $url = new \moodle_url('/mod/surveypro/report/'.$reportname.'/view.php', $paramurlbase);
+                    $a = new \stdClass();
+                    $a->href = $url->out();
+                    $a->reportname = get_string('pluginname', 'surveyproreport_'.$reportname);
+                    $messages[] = get_string('runreport', 'mod_surveypro', $a);
                 }
             }
         }
@@ -269,19 +266,19 @@ class view_cover {
     /**
      * Recursive function to populate the $messages array for reports nested as much times as wanted
      *
-     * Uncomment lines of has_childreports method in surveyproreport_colles\report class of report/colles/classes/report.php file
+     * Uncomment lines of get_haschildrenreports method in surveyproreport_colles\report class of report/colles/classes/report.php file
      * to see this function in action.
      *
-     * @param string $childreports
+     * @param string $childrenreports
      * @param string $pluginname
      * @param array $messages
      * @param string $categoryname
      * @return void
      */
-    public function add_report_link($childreports, $pluginname, &$messages, $categoryname) {
+    public function add_report_link($childrenreports, $pluginname, &$messages, $categoryname) {
         global $PAGE;
 
-        foreach ($childreports as $reportkey => $childparams) {
+        foreach ($childrenreports as $reportkey => $childparams) {
             $subreport = get_string($reportkey, 'surveyprotemplate_'.$this->surveypro->template);
             if (is_array(reset($childparams))) { // If the first element of $childparams is an array.
                 $categoryname .= ' > '.$subreport;

--- a/field/textarea/mform/textarea_editor.php
+++ b/field/textarea/mform/textarea_editor.php
@@ -85,6 +85,7 @@ class surveypromform_textarea_editor extends \MoodleQuickForm_editor {
         $class = empty($this->_attributes['class']) ? 'indent-0' : $this->_attributes['class'];
         $replacement = $tabs.'<div class="'.$class.'">';
         $output = preg_replace($pattern, $replacement, $output);
+
         return $output;
     }
 
@@ -112,6 +113,7 @@ class surveypromform_textarea_editor extends \MoodleQuickForm_editor {
         $output .= $value;
         $output .= \html_writer::end_tag('textarea');
         $output .= $this->_getPersistantData();
+
         return $output;
     }
 }

--- a/field/textarea/mform/textarea_plain.php
+++ b/field/textarea/mform/textarea_plain.php
@@ -114,6 +114,7 @@ class surveypromform_textarea_plain extends \MoodleQuickForm_textarea {
         $output .= $value;
         $output .= \html_writer::end_tag('textarea');
         $output .= $this->_getPersistantData();
+
         return $output;
     }
 }

--- a/report/attachments/classes/report.php
+++ b/report/attachments/classes/report.php
@@ -45,15 +45,31 @@ class report extends reportbase {
     public $outputtable = null;
 
     /**
-     * Return if this report applies.
-     *
-     * true means: the report applies
-     * empty($this->surveypro->anonymous) means that reports applies ONLY IF the survey is not anonymous
+     * Is this report equipped with student reports.
      *
      * @return boolean
      */
-    public function report_apply() {
-        return (empty($this->surveypro->anonymous));
+    public static function get_hasstudentreport() {
+        return false;
+    }
+
+    /**
+     * Does the current report apply to the passed mastertemplates?
+     *
+     * @param string $mastertemplate
+     * @return boolean
+     */
+    public function report_applies_to($mastertemplate) {
+        return true;
+    }
+
+    /**
+     * Get if this report displays user names.
+     *
+     * @return boolean
+     */
+    public static function get_displayusernames() {
+        return true;
     }
 
     /**
@@ -221,17 +237,6 @@ class report extends reportbase {
             echo $OUTPUT->box($message, 'notice centerpara');
             echo $OUTPUT->footer();
             die();
-        }
-    }
-
-    /**
-     * Prevent direct user input.
-     *
-     * @return void
-     */
-    public function prevent_direct_user_input() {
-        if (!empty($this->surveypro->anonymous)) {
-            throw new \moodle_exception('incorrectaccessdetected', 'mod_surveypro');
         }
     }
 }

--- a/report/attachments/view.php
+++ b/report/attachments/view.php
@@ -118,7 +118,7 @@ $surveyproreportlist = get_plugin_list('surveyproreport');
 $reportkey = array_search('attachments', array_keys($surveyproreportlist));
 new tabs($cm, $context, $surveypro, SURVEYPRO_TABREPORTS, $reportkey);
 
-$reportman->prevent_direct_user_input();
+$reportman->prevent_direct_user_input('attachments');
 $reportman->check_attachmentitems();
 
 if ($showjumper) {

--- a/report/colles/classes/report.php
+++ b/report/colles/classes/report.php
@@ -140,37 +140,41 @@ class report extends reportbase {
     }
 
     /**
-     * Get the list of mastertemplates to which this report is applicable.
+     * Does the current report apply to the passed mastertemplates?
      *
-     * If ruturns an empty array, each report is added to admin menu
-     * If returns a non empty array, only reports listed will be added to admin menu
-     *
-     * @return void
+     * @param string $mastertemplate
+     * @return boolean
      */
-    public function report_applies_to() {
-        return array('collesactual', 'collespreferred', 'collesactualpreferred');
+    public function report_applies_to($mastertemplate) {
+        $validutemplates = array('collesactual', 'collespreferred', 'collesactualpreferred');
+
+        return in_array($mastertemplate, $validutemplates);
     }
 
     /**
-     * Has_student_report.
+     * Is this report equipped with student reports.
      *
-     * @return void
+     * @return boolean
      */
-    public function has_student_report() {
+    public static function get_hasstudentreport() {
         return true;
+    }
+
+    /**
+     * Get if this report displays user names.
+     *
+     * @return boolean
+     */
+    public static function get_displayusernames() {
+        return false;
     }
 
     /**
      * Get child reports.
      *
-     * @param bool $canaccessreports
-     * @return $childreports
+     * @return $childrenreports
      */
-    public function has_childreports($canaccessreports) {
-        if (!$canaccessreports) {
-            return false;
-        }
-
+    public function get_haschildrenreports() {
         $questionreports = array();
         $questionreports['fieldset_content_01'] = array('type' => 'questions', 'area' => 0);
         $questionreports['fieldset_content_02'] = array('type' => 'questions', 'area' => 1);
@@ -179,10 +183,10 @@ class report extends reportbase {
         $questionreports['fieldset_content_05'] = array('type' => 'questions', 'area' => 4);
         $questionreports['fieldset_content_06'] = array('type' => 'questions', 'area' => 5);
 
-        $childreports = array();
-        $childreports['summary'] = array('type' => 'summary');
-        $childreports['scales'] = array('type' => 'scales');
-        $childreports['areas'] = $questionreports;
+        $childrenreports = array();
+        $childrenreports['summary'] = array('type' => 'summary');
+        $childrenreports['scales'] = array('type' => 'scales');
+        $childrenreports['areas'] = $questionreports;
 
         // In order to uncomment the next code to get examples of nested navigation into admin > report block,
         // you have to add strings corresponding to keys to $this->surveypro->template lang file.
@@ -196,9 +200,9 @@ class report extends reportbase {
         // $fourtharray['4.2'] = array('type' => 'fourth', 'foo' => 2);
         // $fourtharray['4.3'] = $subfourtharray;
 
-        // $childreports['fourth'] = $fourtharray;
+        // $childrenreports['fourth'] = $fourtharray;
 
-        return $childreports;
+        return $childrenreports;
     }
 
     /**

--- a/report/colles/view.php
+++ b/report/colles/view.php
@@ -132,6 +132,7 @@ $surveyproreportlist = get_plugin_list('surveyproreport');
 $reportkey = array_search('colles', array_keys($surveyproreportlist));
 new tabs($cm, $context, $surveypro, SURVEYPRO_TABREPORTS, $reportkey);
 
+$reportman->prevent_direct_user_input();
 $reportman->nosubmissions_stop();
 
 // Begin of: manage form submission.

--- a/report/frequency/classes/report.php
+++ b/report/frequency/classes/report.php
@@ -45,6 +45,34 @@ class report extends reportbase {
     public $outputtable = null;
 
     /**
+     * Is this report equipped with student reports.
+     *
+     * @return boolean
+     */
+    public static function get_hasstudentreport() {
+        return false;
+    }
+
+    /**
+     * Does the current report apply to the passed mastertemplates?
+     *
+     * @param string $mastertemplate
+     * @return boolean
+     */
+    public function report_applies_to($mastertemplate) {
+        return true;
+    }
+
+    /**
+     * Get if this report displays user names.
+     *
+     * @return boolean
+     */
+    public static function get_displayusernames() {
+        return false;
+    }
+
+    /**
      * Setup_outputtable
      *
      * @param int $itemid

--- a/report/frequency/view.php
+++ b/report/frequency/view.php
@@ -111,6 +111,7 @@ $surveyproreportlist = get_plugin_list('surveyproreport');
 $reportkey = array_search('frequency', array_keys($surveyproreportlist));
 new tabs($cm, $context, $surveypro, SURVEYPRO_TABREPORTS, $reportkey);
 
+$reportman->prevent_direct_user_input();
 $reportman->stop_if_textareas_only();
 
 // Begin of: manage form submission.

--- a/report/lateusers/classes/report.php
+++ b/report/lateusers/classes/report.php
@@ -45,6 +45,34 @@ class report extends reportbase {
     public $outputtable = null;
 
     /**
+     * Is this report equipped with student reports.
+     *
+     * @return boolean
+     */
+    public static function get_hasstudentreport() {
+        return false;
+    }
+
+    /**
+     * Does the current report apply to the passed mastertemplates?
+     *
+     * @param string $mastertemplate
+     * @return boolean
+     */
+    public function report_applies_to($mastertemplate) {
+        return true;
+    }
+
+    /**
+     * Get if this report displays user names.
+     *
+     * @return boolean
+     */
+    public static function get_displayusernames() {
+        return true;
+    }
+
+    /**
      * Setup_outputtable
      */
     public function setup_outputtable() {

--- a/report/lateusers/view.php
+++ b/report/lateusers/view.php
@@ -130,6 +130,8 @@ $surveyproreportlist = get_plugin_list('surveyproreport');
 $reportkey = array_search('lateusers', array_keys($surveyproreportlist));
 new tabs($cm, $context, $surveypro, SURVEYPRO_TABREPORTS, $reportkey);
 
+$reportman->prevent_direct_user_input();
+
 if ($showjumper) {
     $groupfilterform->set_data(array('groupid' => $groupid));
     $groupfilterform->display();

--- a/report/responsesperuser/classes/report.php
+++ b/report/responsesperuser/classes/report.php
@@ -45,6 +45,34 @@ class report extends reportbase {
     public $outputtable = null;
 
     /**
+     * Is this report equipped with student reports.
+     *
+     * @return boolean
+     */
+    public static function get_hasstudentreport() {
+        return false;
+    }
+
+    /**
+     * Does the current report apply to the passed mastertemplates?
+     *
+     * @param string $mastertemplate
+     * @return boolean
+     */
+    public function report_applies_to($mastertemplate) {
+        return true;
+    }
+
+    /**
+     * Get if this report displays user names.
+     *
+     * @return boolean
+     */
+    public static function get_displayusernames() {
+        return true;
+    }
+
+    /**
      * Setup_outputtable
      */
     public function setup_outputtable() {

--- a/report/responsesperuser/view.php
+++ b/report/responsesperuser/view.php
@@ -117,6 +117,8 @@ $surveyproreportlist = get_plugin_list('surveyproreport');
 $reportkey = array_search('responsesperuser', array_keys($surveyproreportlist));
 new tabs($cm, $context, $surveypro, SURVEYPRO_TABREPORTS, $reportkey);
 
+$reportman->prevent_direct_user_input();
+
 if ($showjumper) {
     $groupfilterform->set_data(array('groupid' => $groupid));
     $groupfilterform->display();

--- a/report/userspercount/classes/report.php
+++ b/report/userspercount/classes/report.php
@@ -45,6 +45,34 @@ class report extends reportbase {
     public $outputtable = null;
 
     /**
+     * Is this report equipped with student reports.
+     *
+     * @return boolean
+     */
+    public static function get_hasstudentreport() {
+        return false;
+    }
+
+    /**
+     * Does the current report apply to the passed mastertemplates?
+     *
+     * @param string $mastertemplate
+     * @return boolean
+     */
+    public function report_applies_to($mastertemplate) {
+        return true;
+    }
+
+    /**
+     * Get if this report displays user names.
+     *
+     * @return boolean
+     */
+    public static function get_displayusernames() {
+        return false;
+    }
+
+    /**
      * Setup_outputtable
      */
     public function setup_outputtable() {

--- a/report/userspercount/view.php
+++ b/report/userspercount/view.php
@@ -117,6 +117,8 @@ $surveyproreportlist = get_plugin_list('surveyproreport');
 $reportkey = array_search('userspercount', array_keys($surveyproreportlist));
 new tabs($cm, $context, $surveypro, SURVEYPRO_TABREPORTS, $reportkey);
 
+$reportman->prevent_direct_user_input();
+
 if ($showjumper) {
     $groupfilterform->set_data(array('groupid' => $groupid));
     $groupfilterform->display();

--- a/template/collesactual/tests/behat/graphs.feature
+++ b/template/collesactual/tests/behat/graphs.feature
@@ -69,7 +69,7 @@ Feature: apply a COLLES (actual) mastertemplate to test graphs
       | Do you have any other comments?                | Am I sexy? |
     And I press "Submit"
 
-    And I navigate to "Report > Colles report" in current page administration
+    And I navigate to "Report > Colles report > Summary" in current page administration
     Then I should not see "Summary report"
 
     And I log out

--- a/template/collesactualpreferred/tests/behat/graphs.feature
+++ b/template/collesactualpreferred/tests/behat/graphs.feature
@@ -99,7 +99,7 @@ Feature: apply a COLLES (actual and preferred) mastertemplate to test graphs
       | Do you have any other comments?                | Am I sexy? |
     And I press "Submit"
 
-    And I navigate to "Report > Colles report" in current page administration
+    And I navigate to "Report > Colles report > Summary" in current page administration
     Then I should not see "Summary report"
 
     And I log out

--- a/template/collespreferred/tests/behat/graphs.feature
+++ b/template/collespreferred/tests/behat/graphs.feature
@@ -69,7 +69,7 @@ Feature: apply a COLLES (preferred) mastertemplate to test graphs
       | Do you have any other comments?                | Am I sexy? |
     And I press "Submit"
 
-    And I navigate to "Report > Colles report" in current page administration
+    And I navigate to "Report > Colles report > Summary" in current page administration
     Then I should not see "Summary report"
 
     And I log out

--- a/tests/behat/gdpr_anonimity.feature
+++ b/tests/behat/gdpr_anonimity.feature
@@ -1,0 +1,130 @@
+@mod @mod_surveypro
+Feature: gdpr anonimitytest anonymous surveypro are really anonymous
+  In order to test that an anonymous surveypro is really anonymous
+  As teacher
+  I go to look for reports and pages showwing user names
+
+  @javascript
+  Scenario: Anonymous surveypro and user with alwaysseeowner capability
+    Given the following "courses" exist:
+      | fullname         | shortname        | category | groupmode |
+      | Anonymous course | Anonymous course | 0        | 0         |
+    And the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | teacher  | teacher1@nowhere.net |
+    And the following "course enrolments" exist:
+      | user     | course           | role           |
+      | teacher1 | Anonymous course | editingteacher |
+    And the following "activities" exist:
+      | activity  | name                | intro               | course           |
+      | surveypro | Anonymous surveypro | Anonymous surveypro | Anonymous course |
+    And surveypro "Anonymous surveypro" contains the following items:
+      | type  | plugin  |
+      | field | boolean |
+
+    When I am on the "Anonymous surveypro" "Activity editing" page logged in as teacher1
+    And I expand all fieldsets
+    And I set the field "Anonymous responses" to "1"
+    And I press "Save and display"
+    And I follow "Survey" page in tab bar
+    Then I should see "Run Attachments overview report"
+    Then I should see "Run Frequency distribution report"
+    Then I should see "Run Late users report"
+    Then I should see "Run Responses per user report"
+    Then I should see "Run Users per count of responses report"
+    And I log out
+
+  @javascript
+  Scenario: Not anonymous surveypro and user with alwaysseeowner capability
+    Given the following "courses" exist:
+      | fullname         | shortname        | category | groupmode |
+      | Anonymous course | Anonymous course | 0        | 0         |
+    And the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | teacher  | teacher1@nowhere.net |
+    And the following "course enrolments" exist:
+      | user     | course           | role           |
+      | teacher1 | Anonymous course | editingteacher |
+    And the following "activities" exist:
+      | activity  | name                | intro               | course           |
+      | surveypro | Anonymous surveypro | Anonymous surveypro | Anonymous course |
+    And surveypro "Anonymous surveypro" contains the following items:
+      | type  | plugin  |
+      | field | boolean |
+
+    When I am on the "Anonymous surveypro" activity page logged in as teacher1
+    And I follow "Survey" page in tab bar
+    Then I should see "Run Attachments overview report"
+    Then I should see "Run Frequency distribution report"
+    Then I should see "Run Late users report"
+    Then I should see "Run Responses per user report"
+    Then I should see "Run Users per count of responses report"
+    And I log out
+
+  @javascript
+  Scenario: Anonymous surveypro and user without alwaysseeowner capability
+    Given the following "courses" exist:
+      | fullname         | shortname        | category | groupmode |
+      | Anonymous course | Anonymous course | 0        | 0         |
+    And the following "roles" exist:
+      | shortname  | name       | archetype |
+      | lowteacher | lowteacher | teacher   |
+    And the following "permission overrides" exist:
+      | capability                   | permission | role           | contextlevel | reference        |
+      | mod/surveypro:alwaysseeowner | Prevent    | editingteacher | Course       | Anonymous course |
+    And the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | teacher  | teacher1@nowhere.net |
+    And the following "course enrolments" exist:
+      | user     | course           | role           |
+      | teacher1 | Anonymous course | editingteacher |
+    And the following "activities" exist:
+      | activity  | name                | intro               | course           |
+      | surveypro | Anonymous surveypro | Anonymous surveypro | Anonymous course |
+    And surveypro "Anonymous surveypro" contains the following items:
+      | type  | plugin  |
+      | field | boolean |
+
+    When I am on the "Anonymous surveypro" "Activity editing" page logged in as teacher1
+    And I expand all fieldsets
+    And I set the field "Anonymous responses" to "1"
+    And I press "Save and display"
+    And I follow "Survey" page in tab bar
+    Then I should not see "Run Attachments overview report"
+    Then I should see "Run Frequency distribution report"
+    Then I should not see "Run Late users report"
+    Then I should not see "Run Responses per user report"
+    Then I should see "Run Users per count of responses report"
+    And I log out
+
+  @javascript
+  Scenario: Not anonymous surveypro and user without alwaysseeowner capability
+    Given the following "courses" exist:
+      | fullname         | shortname        | category | groupmode |
+      | Anonymous course | Anonymous course | 0        | 0         |
+    And the following "roles" exist:
+      | shortname  | name       | archetype |
+      | lowteacher | lowteacher | teacher   |
+    And the following "permission overrides" exist:
+      | capability                   | permission | role           | contextlevel | reference        |
+      | mod/surveypro:alwaysseeowner | Prevent    | editingteacher | Course       | Anonymous course |
+    And the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | teacher  | teacher1@nowhere.net |
+    And the following "course enrolments" exist:
+      | user     | course           | role           |
+      | teacher1 | Anonymous course | editingteacher |
+    And the following "activities" exist:
+      | activity  | name                | intro               | course           |
+      | surveypro | Anonymous surveypro | Anonymous surveypro | Anonymous course |
+    And surveypro "Anonymous surveypro" contains the following items:
+      | type  | plugin  |
+      | field | boolean |
+
+    When I am on the "Anonymous surveypro" activity page logged in as teacher1
+    Then I should see "Run Attachments overview report"
+    Then I should see "Run Frequency distribution report"
+    Then I should see "Run Late users report"
+    Then I should see "Run Responses per user report"
+    Then I should see "Run Users per count of responses report"
+    And I log out


### PR DESCRIPTION
Because of GDPR user names are not going to be shared.
Now, if the surveypro is anonymous then each user without capability 'mod/surveypro:alwaysseeowner' is NOT supposed see user names.
Users with 'mod/surveypro:alwaysseeowner' can still see them.