### PR TITLE
Small updates to GHA to avoid some warnings and bump versions

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:12
+        image: postgres:13
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -16,7 +16,7 @@ jobs:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
       mariadb:
-        image: mariadb:10.5
+        image: mariadb:10
         env:
           MYSQL_USER: 'root'
           MYSQL_ALLOW_EMPTY_PASSWORD: "true"
@@ -40,14 +40,9 @@ jobs:
             profile: default
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: plugin
-
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: '14.15.0'
 
       - name: Setup PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
If all the tests end passing and without any warning, this can be considered. Let' see.

It just updates a few components and remove not needed ones. Should be enough to avoid some warnings and be ready for future Moodle versions (like 4.2) that have higher database requirements.

Ciao :-)