### PR TITLE
Reduce resources to save submissions

### DIFF
--- a/classes/view_search.php
+++ b/classes/view_search.php
@@ -123,7 +123,7 @@ class view_search {
             $item = surveypro_get_item($this->cm, $this->surveypro, $iteminfo->itemid, $iteminfo->type, $iteminfo->plugin);
 
             $userdata = new \stdClass();
-            $item->userform_save_preprocessing($iteminfo->contentperelement, $userdata, true);
+            $item->userform_get_user_answer($iteminfo->contentperelement, $userdata, true);
 
             if (!is_null($userdata->content)) {
                 $searchfields[$iteminfo->itemid] = $userdata->content;

--- a/field/age/classes/item.php
+++ b/field/age/classes/item.php
@@ -681,7 +681,7 @@ EOS;
      * @param bool $searchform
      * @return void
      */
-    public function userform_save_preprocessing($answer, &$olduseranswer, $searchform) {
+    public function userform_get_user_answer($answer, &$olduseranswer, $searchform) {
         if (isset($answer['noanswer'])) { // This is correct for input and search form both.
             $olduseranswer->content = SURVEYPRO_NOANSWERVALUE;
         } else {

--- a/field/autofill/classes/item.php
+++ b/field/autofill/classes/item.php
@@ -511,7 +511,7 @@ EOS;
      * @param bool $searchform
      * @return void
      */
-    public function userform_save_preprocessing($answer, &$olduseranswer, $searchform) {
+    public function userform_get_user_answer($answer, &$olduseranswer, $searchform) {
         if ($searchform) {
             if (isset($answer['ignoreme'])) {
                 $olduseranswer->content = null;

--- a/field/boolean/classes/item.php
+++ b/field/boolean/classes/item.php
@@ -675,7 +675,7 @@ EOS;
      * @param bool $searchform
      * @return void
      */
-    public function userform_save_preprocessing($answer, &$olduseranswer, $searchform) {
+    public function userform_get_user_answer($answer, &$olduseranswer, $searchform) {
         if (isset($answer['noanswer'])) {
             $olduseranswer->content = SURVEYPRO_NOANSWERVALUE;
         } else {

--- a/field/character/classes/item.php
+++ b/field/character/classes/item.php
@@ -619,7 +619,7 @@ EOS;
      * @param bool $searchform
      * @return void
      */
-    public function userform_save_preprocessing($answer, &$olduseranswer, $searchform) {
+    public function userform_get_user_answer($answer, &$olduseranswer, $searchform) {
         if (isset($answer['ignoreme'])) {
             $olduseranswer->content = null;
             return;

--- a/field/checkbox/classes/item.php
+++ b/field/checkbox/classes/item.php
@@ -881,7 +881,7 @@ EOS;
      * @param bool $searchform
      * @return void
      */
-    public function userform_save_preprocessing($answer, &$olduseranswer, $searchform) {
+    public function userform_get_user_answer($answer, &$olduseranswer, $searchform) {
         if ( isset($answer['noanswer']) && ($answer['noanswer'] == 1) ) { // This is correct for input and search form both.
             $olduseranswer->content = SURVEYPRO_NOANSWERVALUE;
             return;

--- a/field/date/classes/item.php
+++ b/field/date/classes/item.php
@@ -760,7 +760,7 @@ EOS;
      * @param bool $searchform
      * @return void
      */
-    public function userform_save_preprocessing($answer, &$olduseranswer, $searchform) {
+    public function userform_get_user_answer($answer, &$olduseranswer, $searchform) {
         if (isset($answer['noanswer'])) { // This is correct for input and search form both.
             $olduseranswer->content = SURVEYPRO_NOANSWERVALUE;
         } else {

--- a/field/datetime/classes/item.php
+++ b/field/datetime/classes/item.php
@@ -867,7 +867,7 @@ EOS;
      * @param bool $searchform
      * @return void
      */
-    public function userform_save_preprocessing($answer, &$olduseranswer, $searchform) {
+    public function userform_get_user_answer($answer, &$olduseranswer, $searchform) {
         if (isset($answer['noanswer'])) { // This is correct for input and search form both.
             $olduseranswer->content = SURVEYPRO_NOANSWERVALUE;
         } else {

--- a/field/fileupload/classes/item.php
+++ b/field/fileupload/classes/item.php
@@ -368,7 +368,7 @@ EOS;
      * @param bool $searchform
      * @return void
      */
-    public function userform_save_preprocessing($answer, &$olduseranswer, $searchform) {
+    public function userform_get_user_answer($answer, &$olduseranswer, $searchform) {
         if (!empty($answer)) {
             $context = \context_module::instance($this->cm->id);
 

--- a/field/integer/classes/item.php
+++ b/field/integer/classes/item.php
@@ -634,7 +634,7 @@ EOS;
      * @param bool $searchform
      * @return void
      */
-    public function userform_save_preprocessing($answer, &$olduseranswer, $searchform) {
+    public function userform_get_user_answer($answer, &$olduseranswer, $searchform) {
         $olduseranswer->content = $answer['mainelement'];
     }
 

--- a/field/multiselect/classes/item.php
+++ b/field/multiselect/classes/item.php
@@ -781,7 +781,7 @@ EOS;
      * @param bool $searchform
      * @return void
      */
-    public function userform_save_preprocessing($answer, &$olduseranswer, $searchform) {
+    public function userform_get_user_answer($answer, &$olduseranswer, $searchform) {
         if (isset($answer['noanswer'])) {
             $olduseranswer->content = SURVEYPRO_NOANSWERVALUE;
             return;

--- a/field/numeric/classes/item.php
+++ b/field/numeric/classes/item.php
@@ -558,7 +558,7 @@ EOS;
      * @param bool $searchform
      * @return void
      */
-    public function userform_save_preprocessing($answer, &$olduseranswer, $searchform) {
+    public function userform_get_user_answer($answer, &$olduseranswer, $searchform) {
         if (isset($answer['ignoreme'])) {
             $olduseranswer->content = null;
             return;

--- a/field/radiobutton/classes/item.php
+++ b/field/radiobutton/classes/item.php
@@ -739,7 +739,7 @@ EOS;
      * @param bool $searchform
      * @return void
      */
-    public function userform_save_preprocessing($answer, &$olduseranswer, $searchform) {
+    public function userform_get_user_answer($answer, &$olduseranswer, $searchform) {
         if (isset($answer['mainelement'])) {
             switch ($answer['mainelement']) {
                 case 'other':

--- a/field/rate/classes/item.php
+++ b/field/rate/classes/item.php
@@ -576,7 +576,7 @@ EOS;
      * @param bool $searchform
      * @return void
      */
-    public function userform_save_preprocessing($answer, &$olduseranswer, $searchform) {
+    public function userform_get_user_answer($answer, &$olduseranswer, $searchform) {
         if (isset($answer['noanswer'])) {
             $olduseranswer->content = SURVEYPRO_NOANSWERVALUE;
         } else {

--- a/field/recurrence/classes/item.php
+++ b/field/recurrence/classes/item.php
@@ -720,7 +720,7 @@ EOS;
      * @param bool $searchform
      * @return void
      */
-    public function userform_save_preprocessing($answer, &$olduseranswer, $searchform) {
+    public function userform_get_user_answer($answer, &$olduseranswer, $searchform) {
         if (isset($answer['noanswer'])) { // This is correct for input and search form both.
             $olduseranswer->content = SURVEYPRO_NOANSWERVALUE;
         } else {

--- a/field/select/classes/item.php
+++ b/field/select/classes/item.php
@@ -692,7 +692,7 @@ EOS;
      * @param bool $searchform
      * @return void
      */
-    public function userform_save_preprocessing($answer, &$olduseranswer, $searchform) {
+    public function userform_get_user_answer($answer, &$olduseranswer, $searchform) {
         if ($answer['mainelement'] == SURVEYPRO_INVITEVALUE) {
             $olduseranswer->content = null;
             return;

--- a/field/shortdate/classes/item.php
+++ b/field/shortdate/classes/item.php
@@ -684,7 +684,7 @@ EOS;
      * @param bool $searchform
      * @return void
      */
-    public function userform_save_preprocessing($answer, &$olduseranswer, $searchform) {
+    public function userform_get_user_answer($answer, &$olduseranswer, $searchform) {
         if (isset($answer['noanswer'])) { // This is correct for input and search form both.
             $olduseranswer->content = SURVEYPRO_NOANSWERVALUE;
         } else {

--- a/field/textarea/classes/item.php
+++ b/field/textarea/classes/item.php
@@ -540,7 +540,7 @@ EOS;
      * @param bool $searchform
      * @return void
      */
-    public function userform_save_preprocessing($answer, &$olduseranswer, $searchform) {
+    public function userform_get_user_answer($answer, &$olduseranswer, $searchform) {
         if (!empty($this->useeditor) && (!$searchform)) {
             $context = \context_module::instance($this->cm->id);
             $olduseranswer->{$this->itemname.'_editor'} = empty($this->trimonsave) ? $answer['editor'] : trim($answer['editor']);

--- a/field/time/classes/item.php
+++ b/field/time/classes/item.php
@@ -732,7 +732,7 @@ EOS;
      * @param bool $searchform
      * @return void
      */
-    public function userform_save_preprocessing($answer, &$olduseranswer, $searchform) {
+    public function userform_get_user_answer($answer, &$olduseranswer, $searchform) {
         if (isset($answer['noanswer'])) { // This is correct for input and search form both.
             $olduseranswer->content = SURVEYPRO_NOANSWERVALUE;
         } else {


### PR DESCRIPTION
I removed from $itemhelperinfo array the two elements: $surveyproid and $submissionid.
Those elements are the same for each item of the form and do not need to be specified for each single item.
They are 100% waste of memory.