### PR TITLE
Reintroduced missing return true

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -369,4 +369,6 @@ function xmldb_surveypro_upgrade($oldversion) {
         // Surveypro savepoint reached.
         upgrade_mod_savepoint(true, 2023012600, 'surveypro');
     }
+
+    return true;
 }


### PR DESCRIPTION
At the end of db/upgrade.php I missed the mandatory return true;. It has beed added again.