### PR TITLE
Added compatibility between parent and child methods

### DIFF
--- a/field/textarea/mform/textarea_editor.php
+++ b/field/textarea/mform/textarea_editor.php
@@ -93,7 +93,7 @@ class surveypromform_textarea_editor extends \MoodleQuickForm_editor {
      *
      * @return html of the frozen element
      */
-    public function getFrozenHtml() {
+    public function getFrozenHtml(): string {
         $complexvalue = $this->getValue();
         $value = strlen($complexvalue['text']) ? $complexvalue['text'] : '&nbsp;';
 


### PR DESCRIPTION
Declaration of surveyproform_textarea_editor::getFrozenHtml() is now compatible with MoodleQuickForm_editor::getFrozenHtml()