### PR TITLE
Renamed two capabilities

### DIFF
--- a/db/access.php
+++ b/db/access.php
@@ -407,7 +407,8 @@ $capabilities = [
             'teacher' => CAP_ALLOW,
             'editingteacher' => CAP_ALLOW,
             'manager' => CAP_ALLOW,
-        ]
+        ],
+        'clonepermissionsfrom' => 'mod/surveypro:importdata',
     ],
 
     'mod/surveypro:exportresponses' => [
@@ -418,7 +419,8 @@ $capabilities = [
             'teacher' => CAP_ALLOW,
             'editingteacher' => CAP_ALLOW,
             'manager' => CAP_ALLOW,
-        ]
+        ],
+        'clonepermissionsfrom' => 'mod/surveypro:exportdata',
     ],
 
     'mod/surveypro:manageusertemplates' => [


### PR DESCRIPTION
From this branch onwards my target is surveypro for moodle4.
I would like to change the GTA matrix from:
```
      matrix:
        include:
          - php: 8.0
            moodle-branch: MOODLE_311_STABLE
            database: pgsql
            suite: default
            profile: chrome
          - php: 7.3
            moodle-branch: MOODLE_311_STABLE
            database: mariadb
            suite: classic
            profile: default
```
 to
```
      matrix:
        include:
          - php: 8.0
            moodle-branch: MOODLE_401_STABLE
            database: pgsql
            suite: default
            profile: chrome
          - php: 7.4
            moodle-branch: MOODLE_401_STABLE
            database: mariadb
            suite: classic
            profile: default
```
but the process to have all the behat test successfull in surveypro for moodle4 using --suite=default needs a lot of changes in the code. In order to manage this process I divide it in a long stack of branches. Each branch is part of a bigger design that I am tring to merge into surveypro. Each branch should be simple to understand and, eventually, to fix.