### PR TITLE
No name in PDF header for anonymous sPro

### DIFF
--- a/classes/view_submissions.php
+++ b/classes/view_submissions.php
@@ -577,9 +577,14 @@ class view_submissions {
      * @return string $headertext
      */
     private function get_header_text($user, $timecreated, $timemodified) {
-        $textheader = get_string('responseauthor', 'mod_surveypro');
-        $textheader .= fullname($user);
-        $textheader .= "\n";
+        $canalwaysseeowner = has_capability('mod/surveypro:alwaysseeowner', $this->context);
+
+        $textheader = '';
+        if (empty($this->surveypro->anonymous) || $canalwaysseeowner) {
+            $textheader .= get_string('responseauthor', 'mod_surveypro');
+            $textheader .= fullname($user);
+            $textheader .= "\n";
+        }
         $textheader .= get_string('responsetimecreated', 'mod_surveypro');
         $textheader .= userdate($timecreated);
         if ($timemodified) {


### PR DESCRIPTION
If a surveypro is set to anonymous
and a user not having the capabliity 'mod/surveypro:alwaysseeowner'
downloads a response in PDF
he MUST not find the name of the owner of the response in the header of the page .