### PR TITLE
Fixed selected report page MASTER

### DIFF
--- a/classes/tabs.php
+++ b/classes/tabs.php
@@ -351,13 +351,12 @@ class tabs {
                     $classname = 'surveyproreport_'.$reportname.'\report';
                     $reportman = new $classname($this->cm, $this->context, $this->surveypro);
 
-                    if ($reportman->is_report_allowed($reportname)) {
-                        if ($elementurl = $this->tabpagesurl['tab_reports'][$reportname]) {
-                            $strlabel = get_string('pluginname', 'surveyproreport_'.$reportname);
-                            $row[] = new \tabobject('idpage'.$counter, $elementurl->out(), $strlabel);
-                        }
-                        $counter++;
+                    if (isset($this->tabpagesurl['tab_reports'][$reportname])) {
+                        $elementurl = $this->tabpagesurl['tab_reports'][$reportname];
+                        $strlabel = get_string('pluginname', 'surveyproreport_'.$reportname);
+                        $row[] = new \tabobject('idpage'.$counter, $elementurl->out(), $strlabel);
                     }
+                    $counter++;
                 }
 
                 $this->tabs[] = $row;


### PR DESCRIPTION
Here I fixed a silly issue that caused the selection of the wrong page (second level tab) of the tab "Reports".
This branch has to be applied to MOODLE_311_STABLE and, maybe, to MOODLE_401_STABLE.
In MOODLE_401_STABLE this branch is 100% useless as I am going to get rid of tabs and subtabs (second level tab) replacing them with the common GUI according to the other modules.