### PR TITLE
Replaced || with or

### DIFF
--- a/field/fileupload/lib.php
+++ b/field/fileupload/lib.php
@@ -69,7 +69,8 @@ function surveyprofield_fileupload_pluginfile($course, $cm, $context, $filearea,
     $fullpath = "/{$context->id}/surveyprofield_fileupload/$filearea/$answerid/$relativepath";
 
     $fs = get_file_storage();
-    if (!($file = $fs->get_file_by_hash(sha1($fullpath))) || $file->is_directory()) {
+    $file = $fs->get_file_by_hash(sha1($fullpath));
+    if (!$file || $file->is_directory()) {
         return false;
     }
 

--- a/lib.php
+++ b/lib.php
@@ -790,7 +790,8 @@ function surveypro_pluginfile($course, $cm, $context, $filearea, $args, $forcedo
     $relativepath = implode('/', $args);
     $fullpath = "/$context->id/mod_surveypro/$filearea/$itemid/$relativepath";
 
-    if (!$file = $fs->get_file_by_hash(sha1($fullpath)) || $file->is_directory()) {
+    $file = $fs->get_file_by_hash(sha1($fullpath));
+    if (!$file || $file->is_directory()) {
         send_file_not_found();
     }
 


### PR DESCRIPTION
Maybe it should be better to replace

```
    $file = $fs->get_file_by_hash(sha1($fullpath));
    if (!$file || $file->is_directory()) {
        return false;
    }
```

with

```
    $file = $fs->get_file_by_hash(sha1($fullpath));
    if (!$file || $file->is_directory()) {
        send_file_not_found();
    }
```

at line 74 of surveypro/field/fileupload/lib.php?