### PR TITLE
Fixed a bug in time like item

### DIFF
--- a/classes/itembase.php
+++ b/classes/itembase.php
@@ -275,7 +275,7 @@ class itembase {
         // You are going to change item content (maybe sortindex, maybe the parentitem)
         // so, do not forget to reset items per page.
         $utilitylayoutman = new utility_layout($this->cm, $this->surveypro);
-        $utilitylayoutman->reset_items_pages();
+        $utilitylayoutman->reset_pages();
 
         $timenow = time();
 
@@ -747,16 +747,22 @@ class itembase {
 
     /**
      * Item split unix time.
+     * Unix timestamps do not handle timezones
+     * Since php 8.0.0 timestamp is nullable.
+     *
+     * Take in mind that date('Y_m_d_H_i', 0) returns:
+     * Array (
+     *     [year] => 1970
+     *     [mon] => 01
+     *     [mday] => 01
+     *     [hours] => 01
+     *     [minutes] => 00
+     * )
      *
      * @param integer $time
      * @return void
      */
-    protected static function item_split_unix_time($time) {
-        if (!$time) {
-            $message = '$time is not set in item_split_unix_time';
-            debugging('Error at line '.__LINE__.' of '.__FILE__.'. '.$message , DEBUG_DEVELOPER);
-        }
-
+    protected function item_split_unix_time($time) {
         $datestring = date('Y_m_d_H_i', $time);
 
         // 2012_07_11_16_03.

--- a/classes/layout_itemsetup.php
+++ b/classes/layout_itemsetup.php
@@ -954,9 +954,9 @@ class layout_itemsetup {
             $DB->set_field('surveypro_item', 'sortindex', $replaceitem, ['id' => $itemid]);
         }
 
-        // You changed item order. Don't forget to reset items per page.
+        // You changed item order. Don't forget to reset the page of each items.
         $utilitylayoutman = new utility_layout($this->cm, $this->surveypro);
-        $utilitylayoutman->reset_items_pages();
+        $utilitylayoutman->reset_pages();
     }
 
     /**
@@ -1209,7 +1209,7 @@ class layout_itemsetup {
                 $DB->set_field('surveypro_item', 'hidden', 1, ['id' => $itemtohide->id]);
             }
             $utilitylayoutman = new utility_layout($this->cm, $this->surveypro);
-            $utilitylayoutman->reset_items_pages();
+            $utilitylayoutman->reset_pages();
         }
     }
 
@@ -1298,7 +1298,7 @@ class layout_itemsetup {
                 $DB->set_field('surveypro_item', 'hidden', 0, ['id' => $toshowitemid]);
             }
             $utilitylayoutman = new utility_layout($this->cm, $this->surveypro);
-            $utilitylayoutman->reset_items_pages();
+            $utilitylayoutman->reset_pages();
         }
     }
 
@@ -1384,7 +1384,7 @@ class layout_itemsetup {
             }
 
             $utilitylayoutman = new utility_layout($this->cm, $this->surveypro);
-            $utilitylayoutman->reset_items_pages();
+            $utilitylayoutman->reset_pages();
 
             $whereparams = ['surveyproid' => $this->surveypro->id];
 
@@ -1625,7 +1625,7 @@ class layout_itemsetup {
                 $DB->set_field('surveypro_item', 'reserved', 1, ['id' => $itemtoreserve->id]);
             }
             $utilitylayoutman = new utility_layout($this->cm, $this->surveypro);
-            $utilitylayoutman->reset_items_pages();
+            $utilitylayoutman->reset_pages();
         }
     }
 
@@ -1746,7 +1746,7 @@ class layout_itemsetup {
                 $DB->set_field('surveypro_item', 'reserved', 0, ['id' => $itemtoavailable->id]);
             }
             $utilitylayoutman = new utility_layout($this->cm, $this->surveypro);
-            $utilitylayoutman->reset_items_pages();
+            $utilitylayoutman->reset_pages();
         }
     }
 
@@ -1847,7 +1847,7 @@ class layout_itemsetup {
             $whereparams = ['surveyproid' => $this->surveypro->id];
             $utilitylayoutman->items_set_visibility($whereparams, 0);
 
-            $utilitylayoutman->reset_items_pages();
+            $utilitylayoutman->reset_pages();
 
             $this->set_confirm(SURVEYPRO_ACTION_EXECUTED);
         }

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -391,9 +391,9 @@ class provider implements
         list($insql, $inparams) = $DB->get_in_or_equal($userids, SQL_PARAMS_NAMED);
 
         $where = "surveyproid = :instanceid AND userid {$insql}";
-        $sqlparams = $inparams + ['instanceid' => (int)$instanceid];
+        $whereparams = $inparams + ['instanceid' => (int)$instanceid];
 
-        $rs = $DB->get_recordset_select('surveypro_submission', $where, $sqlparams, 'id', 'id');
+        $rs = $DB->get_recordset_select('surveypro_submission', $where, $whereparams, 'id', 'id');
         $submissions = [];
         foreach ($rs as $submission) {
             $submissions[] = $submission->id;

--- a/classes/usertemplate.php
+++ b/classes/usertemplate.php
@@ -581,7 +581,7 @@ class usertemplate extends templatebase {
         if ($action != SURVEYPRO_DELETEALLITEMS) {
             // Dispose assignemnt of pages.
             $utilitylayoutman = new utility_layout($this->cm, $this->surveypro);
-            $utilitylayoutman->reset_items_pages();
+            $utilitylayoutman->reset_pages();
         }
 
         $this->trigger_event('usertemplate_applied', $action);
@@ -594,7 +594,7 @@ class usertemplate extends templatebase {
                 $whereparams = ['surveyproid' => $this->surveypro->id];
                 $utilitylayoutman->items_set_visibility($whereparams, 0);
 
-                $utilitylayoutman->reset_items_pages();
+                $utilitylayoutman->reset_pages();
 
                 break;
             case SURVEYPRO_DELETEALLITEMS:

--- a/classes/utility_layout.php
+++ b/classes/utility_layout.php
@@ -68,6 +68,18 @@ class utility_layout {
     }
 
     /**
+     * Reset the pages assigned to items.
+     *
+     * @return void
+     */
+    public function reset_pages() {
+        global $DB;
+
+        $whereparams = ['surveyproid' => $this->surveypro->id];
+        $DB->set_field('surveypro_item', 'formpage', 0, $whereparams);
+    }
+
+    /**
      * Assign pages to item writing them in the db.
      *
      * @return void
@@ -75,12 +87,13 @@ class utility_layout {
     public function assign_pages() {
         global $DB;
 
-        $where = ['surveyproid' => $this->surveypro->id];
+        $where = ['surveyproid' => $this->surveypro->id, 'hidden' => 0];
 
         $userformpagecount = 0;
         $lastwaspagebreak = true; // Whether 2 page breaks in line, the second one is ignored.
         $pagenumber = 1;
         $items = $DB->get_recordset('surveypro_item', $where, 'sortindex', 'id, type, plugin, parentid, formpage, sortindex');
+
         if ($items) {
             foreach ($items as $item) {
                 if ($item->plugin == 'pagebreak') { // It is a page break.
@@ -264,7 +277,7 @@ class utility_layout {
             $this->delete_answers(['itemid' => $item->id], $item);
         }
 
-        $this->reset_items_pages();
+        $this->reset_pages();
     }
 
     /**
@@ -790,6 +803,9 @@ class utility_layout {
         // If I ask for visibility == 0, I want hidden = 1.
         // If I ask for visibility == 1, I want hidden = 0.
         $DB->set_field('surveypro_item', 'hidden', 1 - $visibility, $whereparams);
+
+        // You changed the visibility of some item. Don't forget to reset the page of each items.
+        $this->reset_pages();
     }
 
     /**
@@ -821,18 +837,6 @@ class utility_layout {
             $currentsortindex++;
         }
         $itemlist->close();
-    }
-
-    /**
-     * Reset the pages assigned to items.
-     *
-     * @return void
-     */
-    public function reset_items_pages() {
-        global $DB;
-
-        $whereparams = ['surveyproid' => $this->surveypro->id];
-        $DB->set_field('surveypro_item', 'formpage', 0, $whereparams);
     }
 
     /**

--- a/field/age/classes/item.php
+++ b/field/age/classes/item.php
@@ -258,7 +258,7 @@ class item extends itembase {
      * @param bool $applyusersettings
      * @return void
      */
-    public static function item_split_unix_time($time, $applyusersettings=true) {
+    public function item_split_unix_time($time, $applyusersettings=true) {
         $getdate = parent::item_split_unix_time($time, $applyusersettings);
 
         $getdate['year'] -= SURVEYPROFIELD_AGE_YEAROFFSET;
@@ -276,7 +276,7 @@ class item extends itembase {
      * @param array $agearray
      * @return void
      */
-    public static function item_age_to_text($agearray) {
+    public function item_age_to_text($agearray) {
         $stryears = get_string('years');
         $strmonths = get_string('months', 'surveyprofield_age');
 
@@ -319,7 +319,7 @@ class item extends itembase {
             if (!$this->{$field}) {
                 continue;
             }
-            $agearray = self::item_split_unix_time($this->{$field});
+            $agearray = $this->item_split_unix_time($this->{$field});
             $this->{$field.'year'} = $agearray['year'];
             $this->{$field.'month'} = $agearray['mon'];
         }
@@ -547,9 +547,9 @@ EOS;
                     // so $this->defaultvalue may be empty.
                     // Generally $this->lowerbound is set but... to avoid nasty surprises... I also provide a parachute else.
                     if ($this->defaultvalue) {
-                        $agearray = self::item_split_unix_time($this->defaultvalue);
+                        $agearray = $this->item_split_unix_time($this->defaultvalue);
                     } else if ($this->lowerbound) {
-                        $agearray = self::item_split_unix_time($this->lowerbound);
+                        $agearray = $this->item_split_unix_time($this->lowerbound);
                     } else {
                         $agearray['year'] = $years[1];
                         $agearray['mon'] = $months[1];
@@ -653,24 +653,24 @@ EOS;
         $hasupperbound = ($this->upperbound != $this->item_age_to_unix_time($maximumage, 11));
 
         $a = '';
-        $lowerbound = self::item_split_unix_time($this->lowerbound);
-        $upperbound = self::item_split_unix_time($this->upperbound);
+        $lowerbound = $this->item_split_unix_time($this->lowerbound);
+        $upperbound = $this->item_split_unix_time($this->upperbound);
 
         $fillinginstruction = '';
         if ($haslowerbound && $hasupperbound) {
             $a = new \stdClass();
-            $a->lowerbound = self::item_age_to_text($lowerbound);
-            $a->upperbound = self::item_age_to_text($upperbound);
+            $a->lowerbound = $this->item_age_to_text($lowerbound);
+            $a->upperbound = $this->item_age_to_text($upperbound);
 
             $fillinginstruction .= get_string('restriction_lowerupper', 'surveyprofield_age', $a);
         } else {
             if ($haslowerbound) {
-                $a = self::item_age_to_text($lowerbound);
+                $a = $this->item_age_to_text($lowerbound);
                 $fillinginstruction .= get_string('restriction_lower', 'surveyprofield_age', $a);
             }
 
             if ($hasupperbound) {
-                $a = self::item_age_to_text($upperbound);
+                $a = $this->item_age_to_text($upperbound);
                 $fillinginstruction .= get_string('restriction_upper', 'surveyprofield_age', $a);
             }
         }
@@ -728,7 +728,7 @@ EOS;
                 return $prefill;
             }
 
-            $datearray = self::item_split_unix_time($fromdb->content);
+            $datearray = $this->item_split_unix_time($fromdb->content);
             $prefill[$this->itemname.'_month'] = $datearray['mon'];
             $prefill[$this->itemname.'_year'] = $datearray['year'];
         }
@@ -759,8 +759,8 @@ EOS;
         }
 
         // Output.
-        $agearray = self::item_split_unix_time($content);
-        $return = self::item_age_to_text($agearray);
+        $agearray = $this->item_split_unix_time($content);
+        $return = $this->item_age_to_text($agearray);
 
         return $return;
     }

--- a/field/datetime/classes/item.php
+++ b/field/datetime/classes/item.php
@@ -350,7 +350,7 @@ class item extends itembase {
                 continue;
             }
 
-            $datetimearray = self::item_split_unix_time($this->{$field});
+            $datetimearray = $this->item_split_unix_time($this->{$field});
             $this->{$field.'year'} = $datetimearray['year'];
             $this->{$field.'month'} = $datetimearray['mon'];
             $this->{$field.'day'} = $datetimearray['mday'];
@@ -698,9 +698,9 @@ EOS;
                     // so $this->defaultvalue may be empty.
                     // Generally $this->lowerbound is set but... to avoid nasty surprises... I also provide a parachute else.
                     if ($this->defaultvalue) {
-                        $datetimearray = self::item_split_unix_time($this->defaultvalue);
+                        $datetimearray = $this->item_split_unix_time($this->defaultvalue);
                     } else if ($this->lowerbound) {
-                        $datetimearray = self::item_split_unix_time($this->lowerbound);
+                        $datetimearray = $this->item_split_unix_time($this->lowerbound);
                     } else {
                         $datetimearray['mday'] = $days[1];
                         $datetimearray['mon'] = $months[1];
@@ -710,7 +710,7 @@ EOS;
                     }
                     break;
                 case SURVEYPRO_TIMENOWDEFAULT:
-                    $datetimearray = self::item_split_unix_time(time());
+                    $datetimearray = $this->item_split_unix_time(time());
                     break;
                 case SURVEYPRO_LIKELASTDEFAULT:
                     // Look for my last submission.
@@ -719,9 +719,9 @@ EOS;
                     $mylastsubmissionid = $DB->get_field_select('surveypro_submission', 'id', $sql, $where, IGNORE_MISSING);
                     $where = ['itemid' => $this->itemid, 'submissionid' => $mylastsubmissionid];
                     if ($time = $DB->get_field('surveypro_answer', 'content', $where, IGNORE_MISSING)) {
-                        $datetimearray = self::item_split_unix_time($time);
+                        $datetimearray = $this->item_split_unix_time($time);
                     } else { // As in standard default.
-                        $datetimearray = self::item_split_unix_time(time());
+                        $datetimearray = $this->item_split_unix_time(time());
                     }
                     break;
                 default:
@@ -846,21 +846,21 @@ EOS;
         $haslowerbound = ($this->lowerbound != $this->item_datetime_to_unix_time($this->surveypro->startyear, 1, 1, 0, 0));
         $hasupperbound = ($this->upperbound != $this->item_datetime_to_unix_time($this->surveypro->stopyear, 12, 31, 23, 59));
 
-        $format = get_string('strftimedatetime', 'langconfig');
+        $format = 'd/m/Y, H:i';
         if ($haslowerbound && $hasupperbound) {
             $a = new \stdClass();
-            $a->lowerbound = userdate($this->lowerbound, $format, 0);
-            $a->upperbound = userdate($this->upperbound, $format, 0);
+            $a->lowerbound = date($format, $this->lowerbound);
+            $a->upperbound = date($format, $this->upperbound);
 
             $fillinginstruction = get_string('restriction_lowerupper', 'surveyprofield_datetime', $a);
         } else {
             $fillinginstruction = '';
             if ($haslowerbound) {
-                $a = userdate($this->lowerbound, $format, 0);
+                $a = date($format, $this->lowerbound);
                 $fillinginstruction = get_string('restriction_lower', 'surveyprofield_datetime', $a);
             }
             if ($hasupperbound) {
-                $a = userdate($this->upperbound, $format, 0);
+                $a = date($format, $this->upperbound);
                 $fillinginstruction = get_string('restriction_upper', 'surveyprofield_datetime', $a);
             }
         }
@@ -933,7 +933,7 @@ EOS;
                 return $prefill;
             }
 
-            $datetimearray = self::item_split_unix_time($fromdb->content);
+            $datetimearray = $this->item_split_unix_time($fromdb->content);
             $prefill[$this->itemname.'_day'] = $datetimearray['mday'];
             $prefill[$this->itemname.'_month'] = $datetimearray['mon'];
             $prefill[$this->itemname.'_year'] = $datetimearray['year'];
@@ -978,6 +978,8 @@ EOS;
         if ($format == 'unixtime') {
             $return = $content;
         } else {
+            // The last param "0" means: don't care of time zone.
+            // The date and time of my plane from NY to Paris is the same all around the world.
             $return = userdate($content, get_string($format, 'surveyprofield_datetime'), 0);
         }
 

--- a/format/pagebreak/classes/item.php
+++ b/format/pagebreak/classes/item.php
@@ -109,15 +109,6 @@ class item extends itembase {
     }
 
     /**
-     * Get content.
-     *
-     * @return the content of $content property
-     */
-    public function get_content() {
-        return $this->content;
-    }
-
-    /**
      * Item save.
      *
      * @param object $record
@@ -155,7 +146,25 @@ class item extends itembase {
         return false;
     }
 
+    /**
+     * Return the xml schema for surveypro_<<plugin>> table.
+     *
+     * @return string $schema
+     */
+    public static function item_get_plugin_schema() {
+        return;
+    }
+
     // MARK get.
+
+    /**
+     * Get content.
+     *
+     * @return the content of $content property
+     */
+    public function get_content() {
+        return $this->content;
+    }
 
     /**
      * Is this item available as a parent?
@@ -166,6 +175,8 @@ class item extends itembase {
         return self::$canbeparent;
     }
 
+    // MARK userform.
+
     /**
      * Get if the plugin uses a table into the db.
      *
@@ -174,17 +185,6 @@ class item extends itembase {
     public function uses_db_table() {
         return false;
     }
-
-    /**
-     * Return the xml schema for surveypro_<<plugin>> table.
-     *
-     * @return string $schema
-     */
-    public static function item_get_plugin_schema() {
-        return;
-    }
-
-    // MARK userform.
 
     /**
      * Define the mform element for the userform and the searchform.

--- a/lib.php
+++ b/lib.php
@@ -337,7 +337,7 @@ function surveypro_update_instance($surveypro, $mform) {
     surveypro_pre_process_checkboxes($surveypro);
 
     // Classes are not available here!
-    // So, I can't use $utilitylayoutman->reset_items_pages();
+    // So, I can't use $utilitylayoutman->reset_pages();
     $whereparams = ['surveyproid' => $surveypro->id];
     $DB->set_field('surveypro_item', 'formpage', 0, $whereparams);
 


### PR DESCRIPTION
In the frame of this PR I:
-> renamed the method "reset_items_pages" to "reset_pages"
-> reordered few methods grouping the by topic
-> added (and this is a focal point) $this->reset_pages(); at the end of utility_layout->items_set_visibility. There was an issue: I had a surveypro spanning three pages. I hided each item but one. Going to preview the surveypro was still spanning over three pages
-> replaced (and this is a focal point) userdate with date for date, datetime, recurrence, shortdate and time items
-> changed from static to standard two methods that were always called after their class was instanced