### PR TITLE
Renewed outdated utemplates

### DIFF
--- a/tests/behat/usertemplate_apply.feature
+++ b/tests/behat/usertemplate_apply.feature
@@ -23,8 +23,8 @@ Feature: Load and apply usertemplates to test partial item deletion
     # now I am in the "Manage" page
 
     And I select "Import" from the "jump" singleselect
-    And I upload "mod/surveypro/tests/fixtures/usertemplate/parent-child_2015123000.xml" file to "Choose files to import" filemanager
-    And I upload "mod/surveypro/tests/fixtures/usertemplate/MMM_2015123000.xml" file to "Choose files to import" filemanager
+    And I upload "mod/surveypro/tests/fixtures/usertemplate/parent-child_2023103100.xml" file to "Choose files to import" filemanager
+    And I upload "mod/surveypro/tests/fixtures/usertemplate/MMM_2023103100.xml" file to "Choose files to import" filemanager
 
     And I set the field "Sharing level" to "This course"
     And I press "Import"
@@ -34,7 +34,7 @@ Feature: Load and apply usertemplates to test partial item deletion
 
     And I select "Apply" from the "jump" singleselect
     And I set the following fields to these values:
-      | User templates | (This course) MMM_2015123000.xml |
+      | User templates | (This course) MMM_2023103100.xml |
       | id_action_0    | 1                                |
     And I press "Apply"
 
@@ -51,7 +51,7 @@ Feature: Load and apply usertemplates to test partial item deletion
 
     And I select "Apply" from the "jump" singleselect
     And I set the following fields to these values:
-      | User templates | (This course) parent-child_2015123000.xml |
+      | User templates | (This course) parent-child_2023103100.xml |
       | id_action_17   | 1                                         |
     And I press "Apply"
 

--- a/tests/behat/usertemplate_applyall.feature
+++ b/tests/behat/usertemplate_applyall.feature
@@ -23,24 +23,24 @@ Feature: Load and apply usertemplates
     # now I am in the "Manage" page
 
     And I select "Import" from the "jump" singleselect
-    And I upload "mod/surveypro/tests/fixtures/usertemplate/age_only_2015123000.xml" file to "Choose files to import" filemanager
+    And I upload "mod/surveypro/tests/fixtures/usertemplate/age_only_2023103100.xml" file to "Choose files to import" filemanager
     And I upload "mod/surveypro/tests/fixtures/usertemplate/attachment_only_2015123000.xml" file to "Choose files to import" filemanager
     And I upload "mod/surveypro/tests/fixtures/usertemplate/autofill_only_2015123000.xml" file to "Choose files to import" filemanager
     And I upload "mod/surveypro/tests/fixtures/usertemplate/boolean_only_2015123000.xml" file to "Choose files to import" filemanager
     And I upload "mod/surveypro/tests/fixtures/usertemplate/checkbox_only_2015123000.xml" file to "Choose files to import" filemanager
-    And I upload "mod/surveypro/tests/fixtures/usertemplate/date_only_2015123000.xml" file to "Choose files to import" filemanager
-    And I upload "mod/surveypro/tests/fixtures/usertemplate/dateshort_only_2015123000.xml" file to "Choose files to import" filemanager
-    And I upload "mod/surveypro/tests/fixtures/usertemplate/datetime_only_2015123000.xml" file to "Choose files to import" filemanager
+    And I upload "mod/surveypro/tests/fixtures/usertemplate/date_only_2023103100.xml" file to "Choose files to import" filemanager
+    And I upload "mod/surveypro/tests/fixtures/usertemplate/dateshort_only_2023103100.xml" file to "Choose files to import" filemanager
+    And I upload "mod/surveypro/tests/fixtures/usertemplate/datetime_only_2023103100.xml" file to "Choose files to import" filemanager
     And I upload "mod/surveypro/tests/fixtures/usertemplate/integer_only_2015123000.xml" file to "Choose files to import" filemanager
     And I upload "mod/surveypro/tests/fixtures/usertemplate/multiselect_only_2015123000.xml" file to "Choose files to import" filemanager
     And I upload "mod/surveypro/tests/fixtures/usertemplate/numeric_only_2015123000.xml" file to "Choose files to import" filemanager
     And I upload "mod/surveypro/tests/fixtures/usertemplate/radiobutton_only_2015123000.xml" file to "Choose files to import" filemanager
     And I upload "mod/surveypro/tests/fixtures/usertemplate/rate_only_2015123000.xml" file to "Choose files to import" filemanager
-    And I upload "mod/surveypro/tests/fixtures/usertemplate/recurrence_only_2015123000.xml" file to "Choose files to import" filemanager
+    And I upload "mod/surveypro/tests/fixtures/usertemplate/recurrence_only_2023103100.xml" file to "Choose files to import" filemanager
     And I upload "mod/surveypro/tests/fixtures/usertemplate/select_only_2015123000.xml" file to "Choose files to import" filemanager
     And I upload "mod/surveypro/tests/fixtures/usertemplate/textarea_only_2015123000.xml" file to "Choose files to import" filemanager
     And I upload "mod/surveypro/tests/fixtures/usertemplate/textshort_only_2015123000.xml" file to "Choose files to import" filemanager
-    And I upload "mod/surveypro/tests/fixtures/usertemplate/time_only_2015123000.xml" file to "Choose files to import" filemanager
+    And I upload "mod/surveypro/tests/fixtures/usertemplate/time_only_2023103100.xml" file to "Choose files to import" filemanager
 
     And I set the field "Sharing level" to "This course"
     And I press "Import"
@@ -50,7 +50,7 @@ Feature: Load and apply usertemplates
 
     And I select "Apply" from the "jump" singleselect
     And I set the following fields to these values:
-      | User templates | (This course) age_only_2015123000.xml |
+      | User templates | (This course) age_only_2023103100.xml |
       | id_action_15   | 1                                     |
     And I press "Apply"
 
@@ -95,7 +95,7 @@ Feature: Load and apply usertemplates
 
     And I select "Apply" from the "jump" singleselect
     And I set the following fields to these values:
-      | User templates | (This course) date_only_2015123000.xml |
+      | User templates | (This course) date_only_2023103100.xml |
       | id_action_15   | 1                                      |
     And I press "Apply"
 
@@ -104,7 +104,7 @@ Feature: Load and apply usertemplates
 
     And I select "Apply" from the "jump" singleselect
     And I set the following fields to these values:
-      | User templates | (This course) dateshort_only_2015123000.xml |
+      | User templates | (This course) dateshort_only_2023103100.xml |
       | id_action_15   | 1                                           |
     And I press "Apply"
 
@@ -113,7 +113,7 @@ Feature: Load and apply usertemplates
 
     And I select "Apply" from the "jump" singleselect
     And I set the following fields to these values:
-      | User templates | (This course) datetime_only_2015123000.xml |
+      | User templates | (This course) datetime_only_2023103100.xml |
       | id_action_15   | 1                                          |
     And I press "Apply"
 
@@ -167,7 +167,7 @@ Feature: Load and apply usertemplates
 
     And I select "Apply" from the "jump" singleselect
     And I set the following fields to these values:
-      | User templates | (This course) recurrence_only_2015123000.xml |
+      | User templates | (This course) recurrence_only_2023103100.xml |
       | id_action_15   | 1                                            |
     And I press "Apply"
 
@@ -203,7 +203,7 @@ Feature: Load and apply usertemplates
 
     And I select "Apply" from the "jump" singleselect
     And I set the following fields to these values:
-      | User templates | (This course) time_only_2015123000.xml |
+      | User templates | (This course) time_only_2023103100.xml |
       | id_action_15   | 1                                      |
     And I press "Apply"
 

--- a/tests/behat/usertemplate_create.feature
+++ b/tests/behat/usertemplate_create.feature
@@ -23,8 +23,8 @@ Feature: Create a usertemplate
     # now I am in the "Manage" page
 
     And I select "Import" from the "jump" singleselect
-    And I upload "mod/surveypro/tests/fixtures/usertemplate/parent-child_2015123000.xml" file to "Choose files to import" filemanager
-    And I upload "mod/surveypro/tests/fixtures/usertemplate/MMM_2015123000.xml" file to "Choose files to import" filemanager
+    And I upload "mod/surveypro/tests/fixtures/usertemplate/parent-child_2023103100.xml" file to "Choose files to import" filemanager
+    And I upload "mod/surveypro/tests/fixtures/usertemplate/MMM_2023103100.xml" file to "Choose files to import" filemanager
 
     And I set the field "Sharing level" to "This course"
     And I press "Import"
@@ -34,7 +34,7 @@ Feature: Create a usertemplate
 
     And I select "Apply" from the "jump" singleselect
     And I set the following fields to these values:
-      | User templates | (This course) MMM_2015123000.xml |
+      | User templates | (This course) MMM_2023103100.xml |
       | id_action_0    | 1                                |
     And I press "Apply"
 

--- a/tests/fixtures/usertemplate/MMM_2023103100.xml
+++ b/tests/fixtures/usertemplate/MMM_2023103100.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <items>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>1</insearchform>
@@ -17,7 +17,7 @@
       <fullwidth>1</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>1</insearchform>
@@ -40,7 +40,7 @@
       <reserved>0</reserved>
     </surveypro_item>
   </item>
-  <item type="field" plugin="age" version="2015123000">
+  <item type="field" plugin="age" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -66,7 +66,7 @@
       <upperbound>1004616000</upperbound>
     </surveyprofield_age>
   </item>
-  <item type="field" plugin="age" version="2015123000">
+  <item type="field" plugin="age" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -92,7 +92,7 @@
       <upperbound>-2119608000</upperbound>
     </surveyprofield_age>
   </item>
-  <item type="field" plugin="age" version="2015123000">
+  <item type="field" plugin="age" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -118,7 +118,7 @@
       <upperbound>-2119608000</upperbound>
     </surveyprofield_age>
   </item>
-  <item type="field" plugin="age" version="2015123000">
+  <item type="field" plugin="age" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -150,7 +150,7 @@
       <reserved>0</reserved>
     </surveypro_item>
   </item>
-  <item type="field" plugin="autofill" version="2015123000">
+  <item type="field" plugin="autofill" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -175,7 +175,7 @@
       <reserved>0</reserved>
     </surveypro_item>
   </item>
-  <item type="field" plugin="boolean" version="2015123000">
+  <item type="field" plugin="boolean" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -196,7 +196,7 @@
       <style>1</style>
     </surveyprofield_boolean>
   </item>
-  <item type="field" plugin="boolean" version="2015123000">
+  <item type="field" plugin="boolean" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -217,7 +217,7 @@
       <style>0</style>
     </surveyprofield_boolean>
   </item>
-  <item type="field" plugin="boolean" version="2015123000">
+  <item type="field" plugin="boolean" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -233,11 +233,12 @@
       <variable>boolean_003</variable>
       <extranote>The same boolean question using drop down menu as user interface and "No answer" as default</extranote>
       <defaultoption>3</defaultoption>
+      <defaultvalue>1</defaultvalue>
       <downloadformat>strfbool01</downloadformat>
       <style>0</style>
     </surveyprofield_boolean>
   </item>
-  <item type="field" plugin="boolean" version="2015123000">
+  <item type="field" plugin="boolean" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -258,7 +259,7 @@
       <style>2</style>
     </surveyprofield_boolean>
   </item>
-  <item type="field" plugin="boolean" version="2015123000">
+  <item type="field" plugin="boolean" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -351,7 +352,7 @@ Apple juice</defaultvalue>
       <reserved>0</reserved>
     </surveypro_item>
   </item>
-  <item type="field" plugin="shortdate" version="2015123000">
+  <item type="field" plugin="shortdate" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>1</insearchform>
@@ -371,7 +372,7 @@ Apple juice</defaultvalue>
       <upperbound>1378036800</upperbound>
     </surveyprofield_shortdate>
   </item>
-  <item type="field" plugin="shortdate" version="2015123000">
+  <item type="field" plugin="shortdate" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -398,7 +399,7 @@ Apple juice</defaultvalue>
       <reserved>0</reserved>
     </surveypro_item>
   </item>
-  <item type="field" plugin="date" version="2015123000">
+  <item type="field" plugin="date" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -413,12 +414,13 @@ Apple juice</defaultvalue>
       <hideinstructions>0</hideinstructions>
       <variable>date_001</variable>
       <defaultoption>2</defaultoption>
+      <defaultvalue>43200</defaultvalue>
       <downloadformat>strftime01</downloadformat>
       <lowerbound>43200</lowerbound>
       <upperbound>1262347200</upperbound>
     </surveyprofield_date>
   </item>
-  <item type="field" plugin="date" version="2015123000">
+  <item type="field" plugin="date" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -433,6 +435,7 @@ Apple juice</defaultvalue>
       <hideinstructions>0</hideinstructions>
       <variable>date_002</variable>
       <defaultoption>3</defaultoption>
+      <defaultvalue>43200</defaultvalue>
       <downloadformat>strftime01</downloadformat>
       <lowerbound>43200</lowerbound>
       <upperbound>1262347200</upperbound>
@@ -445,7 +448,7 @@ Apple juice</defaultvalue>
       <reserved>0</reserved>
     </surveypro_item>
   </item>
-  <item type="field" plugin="datetime" version="2015123000">
+  <item type="field" plugin="datetime" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -461,6 +464,7 @@ Apple juice</defaultvalue>
       <variable>datetime_001</variable>
       <step>1</step>
       <defaultoption>2</defaultoption>
+      <defaultvalue>0</defaultvalue>
       <downloadformat>strftime01</downloadformat>
       <lowerbound>0</lowerbound>
       <upperbound>1609459140</upperbound>
@@ -473,7 +477,7 @@ Apple juice</defaultvalue>
       <reserved>0</reserved>
     </surveypro_item>
   </item>
-  <item type="field" plugin="fileupload" version="2015123000">
+  <item type="field" plugin="fileupload" version="2018060501">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -493,7 +497,7 @@ Apple juice</defaultvalue>
       <filetypes>*</filetypes>
     </surveyprofield_fileupload>
   </item>
-  <item type="field" plugin="fileupload" version="2015123000">
+  <item type="field" plugin="fileupload" version="2018060501">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -520,7 +524,7 @@ Apple juice</defaultvalue>
       <reserved>0</reserved>
     </surveypro_item>
   </item>
-  <item type="field" plugin="integer" version="2015123000">
+  <item type="field" plugin="integer" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -535,11 +539,12 @@ Apple juice</defaultvalue>
       <hideinstructions>1</hideinstructions>
       <variable>integer_001</variable>
       <defaultoption>3</defaultoption>
+      <defaultvalue>0</defaultvalue>
       <lowerbound>0</lowerbound>
       <upperbound>13</upperbound>
     </surveyprofield_integer>
   </item>
-  <item type="field" plugin="integer" version="2015123000">
+  <item type="field" plugin="integer" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -600,7 +605,7 @@ chocolate</defaultvalue>
       <reserved>0</reserved>
     </surveypro_item>
   </item>
-  <item type="field" plugin="numeric" version="2015123000">
+  <item type="field" plugin="numeric" version="2017112201">
     <surveypro_item>
       <hidden>1</hidden>
       <insearchform>1</insearchform>
@@ -614,7 +619,7 @@ chocolate</defaultvalue>
       <position>0</position>
       <hideinstructions>0</hideinstructions>
       <variable>numeric_001</variable>
-      <defaultvalue>25.6</defaultvalue>
+      <defaultvalue>25</defaultvalue>
       <signed>0</signed>
       <lowerbound>12</lowerbound>
       <upperbound>30</upperbound>
@@ -628,7 +633,7 @@ chocolate</defaultvalue>
       <reserved>0</reserved>
     </surveypro_item>
   </item>
-  <item type="field" plugin="radiobutton" version="2015123000">
+  <item type="field" plugin="radiobutton" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>1</insearchform>
@@ -651,7 +656,7 @@ Lake</options>
       <adjustment>0</adjustment>
     </surveyprofield_radiobutton>
   </item>
-  <item type="field" plugin="radiobutton" version="2015123000">
+  <item type="field" plugin="radiobutton" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -675,7 +680,7 @@ Lake</options>
       <adjustment>0</adjustment>
     </surveyprofield_radiobutton>
   </item>
-  <item type="field" plugin="radiobutton" version="2015123000">
+  <item type="field" plugin="radiobutton" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -706,7 +711,7 @@ Lake</options>
       <reserved>0</reserved>
     </surveypro_item>
   </item>
-  <item type="field" plugin="rate" version="2015123000">
+  <item type="field" plugin="rate" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -737,7 +742,7 @@ Optimum</rates>
       <differentrates>0</differentrates>
     </surveyprofield_rate>
   </item>
-  <item type="field" plugin="rate" version="2015123000">
+  <item type="field" plugin="rate" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -773,7 +778,7 @@ Good</defaultvalue>
       <differentrates>0</differentrates>
     </surveyprofield_rate>
   </item>
-  <item type="field" plugin="rate" version="2015123000">
+  <item type="field" plugin="rate" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -811,7 +816,7 @@ Optimum</rates>
       <reserved>0</reserved>
     </surveypro_item>
   </item>
-  <item type="field" plugin="recurrence" version="2015123000">
+  <item type="field" plugin="recurrence" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>1</insearchform>
@@ -826,6 +831,7 @@ Optimum</rates>
       <hideinstructions>0</hideinstructions>
       <variable>recurrence_001</variable>
       <defaultoption>2</defaultoption>
+      <defaultvalue>43200</defaultvalue>
       <downloadformat>strftime01</downloadformat>
       <lowerbound>43200</lowerbound>
       <upperbound>31492800</upperbound>
@@ -838,7 +844,7 @@ Optimum</rates>
       <reserved>0</reserved>
     </surveypro_item>
   </item>
-  <item type="field" plugin="select" version="2015123000">
+  <item type="field" plugin="select" version="2017112201">
     <surveypro_item>
       <hidden>1</hidden>
       <insearchform>1</insearchform>
@@ -867,7 +873,7 @@ hill</options>
       <reserved>0</reserved>
     </surveypro_item>
   </item>
-  <item type="field" plugin="textarea" version="2015123000">
+  <item type="field" plugin="textarea" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -889,7 +895,7 @@ hill</options>
       <maxlength>1000</maxlength>
     </surveyprofield_textarea>
   </item>
-  <item type="field" plugin="textarea" version="2015123000">
+  <item type="field" plugin="textarea" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -918,7 +924,7 @@ hill</options>
       <reserved>0</reserved>
     </surveypro_item>
   </item>
-  <item type="field" plugin="time" version="2015123000">
+  <item type="field" plugin="time" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>1</insearchform>
@@ -940,7 +946,7 @@ hill</options>
       <upperbound>35940</upperbound>
     </surveyprofield_time>
   </item>
-  <item type="field" plugin="time" version="2015123000">
+  <item type="field" plugin="time" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -969,7 +975,7 @@ hill</options>
       <reserved>0</reserved>
     </surveypro_item>
   </item>
-  <item type="field" plugin="character" version="2015123000">
+  <item type="field" plugin="character" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -989,7 +995,7 @@ hill</options>
       <maxlength>16</maxlength>
     </surveyprofield_character>
   </item>
-  <item type="field" plugin="character" version="2015123000">
+  <item type="field" plugin="character" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -1008,7 +1014,7 @@ hill</options>
       <minlength>0</minlength>
     </surveyprofield_character>
   </item>
-  <item type="field" plugin="character" version="2015123000">
+  <item type="field" plugin="character" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -1034,7 +1040,7 @@ hill</options>
       <reserved>0</reserved>
     </surveypro_item>
   </item>
-  <item type="field" plugin="boolean" version="2015123000">
+  <item type="field" plugin="boolean" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -1068,7 +1074,7 @@ hill</options>
       <defaultstatus>2</defaultstatus>
     </surveyproformat_fieldset>
   </item>
-  <item type="field" plugin="select" version="2015123000">
+  <item type="field" plugin="select" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -1107,7 +1113,7 @@ C::for tracks</options>
       <defaultstatus>2</defaultstatus>
     </surveyproformat_fieldset>
   </item>
-  <item type="field" plugin="select" version="2015123000">
+  <item type="field" plugin="select" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>

--- a/tests/fixtures/usertemplate/age_only_2023103100.xml
+++ b/tests/fixtures/usertemplate/age_only_2023103100.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <items>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -13,7 +13,7 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -27,14 +27,14 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="age" version="2015123000">
+  <item type="field" plugin="age" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_age>
-      <content>&lt;p&gt;How old are you?&lt;/p&gt;</content>
+      <content>How old are you?</content>
       <contentformat>1</contentformat>
       <required>1</required>
       <indent>0</indent>
@@ -43,12 +43,12 @@
       <hideinstructions>0</hideinstructions>
       <variable>age_001</variable>
       <defaultoption>1</defaultoption>
-      <defaultvalue>-1186056000</defaultvalue>
-      <lowerbound>-2148552000</lowerbound>
-      <upperbound>1193918400</upperbound>
+      <defaultvalue>-1186059600</defaultvalue>
+      <lowerbound>-2148555600</lowerbound>
+      <upperbound>1193914800</upperbound>
     </surveyprofield_age>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -62,14 +62,14 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="age" version="2015123000">
+  <item type="field" plugin="age" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_age>
-      <content>&lt;p&gt;How old are you?&lt;/p&gt;</content>
+      <content>How old are you?</content>
       <contentformat>1</contentformat>
       <required>1</required>
       <indent>0</indent>
@@ -78,12 +78,12 @@
       <hideinstructions>0</hideinstructions>
       <variable>age_002</variable>
       <defaultoption>2</defaultoption>
-      <defaultvalue>-1</defaultvalue>
-      <lowerbound>-2148552000</lowerbound>
-      <upperbound>1193918400</upperbound>
+      <defaultvalue>-2148555600</defaultvalue>
+      <lowerbound>-2148555600</lowerbound>
+      <upperbound>1193914800</upperbound>
     </surveyprofield_age>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -97,14 +97,14 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="age" version="2015123000">
+  <item type="field" plugin="age" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_age>
-      <content>&lt;p&gt;How old are you?&lt;/p&gt;</content>
+      <content>How old are you?</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>0</indent>
@@ -113,33 +113,33 @@
       <hideinstructions>0</hideinstructions>
       <variable>age_003</variable>
       <defaultoption>1</defaultoption>
-      <defaultvalue>-1033560000</defaultvalue>
-      <lowerbound>-2148552000</lowerbound>
-      <upperbound>1193918400</upperbound>
+      <defaultvalue>-1033563600</defaultvalue>
+      <lowerbound>-2148555600</lowerbound>
+      <upperbound>1193914800</upperbound>
     </surveyprofield_age>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyproformat_label>
-      <content>&lt;ul&gt;&lt;li&gt;not mandatory (so: &quot;No answer&quot; is expected)&lt;/li&gt;&lt;li&gt;&quot;Choose...&quot; is the default&lt;/li&gt;&lt;li&gt;user answer is limited only by module level age limit&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Behaviour: The item is not mandatory but the default is set to an invalid value so the user will be forced to select an age corresponding to his/her answer. Being the item not required, the user can choose as answer: &quot;No answer&quot;.&lt;/p&gt;</content>
+      <content>&lt;ul&gt;&lt;li&gt;not mandatory (so: "No answer" is expected)&lt;/li&gt;&lt;li&gt;"Choose..." is the default&lt;/li&gt;&lt;li&gt;user answer is limited only by module level age limit&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Behaviour: The item is not mandatory but the default is set to an invalid value so the user will be forced to select an age corresponding to his/her answer. Being the item not required, the user can choose as answer: "No answer".&lt;/p&gt;</content>
       <contentformat>1</contentformat>
       <indent>0</indent>
       <customnumber>4 intro</customnumber>
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="age" version="2015123000">
+  <item type="field" plugin="age" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_age>
-      <content>&lt;p&gt;How old are you?&lt;/p&gt;</content>
+      <content>How old are you?</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>0</indent>
@@ -148,33 +148,33 @@
       <hideinstructions>0</hideinstructions>
       <variable>age_004</variable>
       <defaultoption>2</defaultoption>
-      <defaultvalue>-1</defaultvalue>
-      <lowerbound>-2148552000</lowerbound>
-      <upperbound>1193918400</upperbound>
+      <defaultvalue>-2148555600</defaultvalue>
+      <lowerbound>-2148555600</lowerbound>
+      <upperbound>1193914800</upperbound>
     </surveyprofield_age>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyproformat_label>
-      <content>&lt;ul&gt;&lt;li&gt;not mandatory (so: &quot;No answer&quot; is expected)&lt;/li&gt;&lt;li&gt;&quot;No answer&quot; is the default&lt;/li&gt;&lt;li&gt;user answer is limited only by module level age limit&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Behaviour: The item is not mandatory and the default is set to a valid value so the user can &quot;fly&quot; over this element leaving the proposed default untouched (and the question not read).&lt;/p&gt;</content>
+      <content>&lt;ul&gt;&lt;li&gt;not mandatory (so: "No answer" is expected)&lt;/li&gt;&lt;li&gt;"No answer" is the default&lt;/li&gt;&lt;li&gt;user answer is limited only by module level age limit&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Behaviour: The item is not mandatory and the default is set to a valid value so the user can "fly" over this element leaving the proposed default untouched (and the question not read).&lt;/p&gt;</content>
       <contentformat>1</contentformat>
       <indent>0</indent>
       <customnumber>5 intro</customnumber>
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="age" version="2015123000">
+  <item type="field" plugin="age" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_age>
-      <content>&lt;p&gt;How old are you?&lt;/p&gt;</content>
+      <content>How old are you?</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>0</indent>
@@ -183,11 +183,12 @@
       <hideinstructions>0</hideinstructions>
       <variable>age_005</variable>
       <defaultoption>3</defaultoption>
-      <lowerbound>-2148552000</lowerbound>
-      <upperbound>1193918400</upperbound>
+      <defaultvalue>-2148555600</defaultvalue>
+      <lowerbound>-2148555600</lowerbound>
+      <upperbound>1193914800</upperbound>
     </surveyprofield_age>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -201,14 +202,14 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="age" version="2015123000">
+  <item type="field" plugin="age" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_age>
-      <content>&lt;p&gt;How old are you?&lt;/p&gt;</content>
+      <content>How old are you?</content>
       <contentformat>1</contentformat>
       <required>1</required>
       <indent>0</indent>
@@ -217,12 +218,12 @@
       <hideinstructions>0</hideinstructions>
       <variable>age_006</variable>
       <defaultoption>1</defaultoption>
-      <defaultvalue>-1186056000</defaultvalue>
-      <lowerbound>-1517400000</lowerbound>
-      <upperbound>-886248000</upperbound>
+      <defaultvalue>-1186059600</defaultvalue>
+      <lowerbound>-1517403600</lowerbound>
+      <upperbound>-886255200</upperbound>
     </surveyprofield_age>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -236,14 +237,14 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="age" version="2015123000">
+  <item type="field" plugin="age" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_age>
-      <content>&lt;p&gt;How old are you?&lt;/p&gt;</content>
+      <content>How old are you?</content>
       <contentformat>1</contentformat>
       <required>1</required>
       <indent>0</indent>
@@ -252,12 +253,12 @@
       <hideinstructions>0</hideinstructions>
       <variable>age_007</variable>
       <defaultoption>2</defaultoption>
-      <defaultvalue>-1</defaultvalue>
-      <lowerbound>-1754136000</lowerbound>
-      <upperbound>-1580558400</upperbound>
+      <defaultvalue>-2148555600</defaultvalue>
+      <lowerbound>-1754139600</lowerbound>
+      <upperbound>-1580562000</upperbound>
     </surveyprofield_age>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -271,14 +272,14 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="age" version="2015123000">
+  <item type="field" plugin="age" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_age>
-      <content>&lt;p&gt;How old are you?&lt;/p&gt;</content>
+      <content>How old are you?</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>0</indent>
@@ -287,33 +288,33 @@
       <hideinstructions>0</hideinstructions>
       <variable>age_008</variable>
       <defaultoption>1</defaultoption>
-      <defaultvalue>-1033560000</defaultvalue>
-      <lowerbound>-1580558400</lowerbound>
-      <upperbound>1193918400</upperbound>
+      <defaultvalue>-1033563600</defaultvalue>
+      <lowerbound>-1580562000</lowerbound>
+      <upperbound>1193914800</upperbound>
     </surveyprofield_age>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyproformat_label>
-      <content>&lt;ul&gt;&lt;li&gt;not mandatory (so: &quot;No answer&quot; is expected)&lt;/li&gt;&lt;li&gt;&quot;Choose...&quot; is the default&lt;/li&gt;&lt;li&gt;user answer is limited between 0 and 3 months&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Behaviour: The item is not mandatory but the default is set to an invalid value so the user will be forced to select an age corresponding to his/her answer. Being the item not required, the user can choose as answer: &quot;No answer&quot;.&lt;/p&gt;</content>
+      <content>&lt;ul&gt;&lt;li&gt;not mandatory (so: "No answer" is expected)&lt;/li&gt;&lt;li&gt;"Choose..." is the default&lt;/li&gt;&lt;li&gt;user answer is limited between 0 and 3 months&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Behaviour: The item is not mandatory but the default is set to an invalid value so the user will be forced to select an age corresponding to his/her answer. Being the item not required, the user can choose as answer: "No answer".&lt;/p&gt;</content>
       <contentformat>1</contentformat>
       <indent>0</indent>
       <customnumber>9 intro</customnumber>
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="age" version="2015123000">
+  <item type="field" plugin="age" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_age>
-      <content>&lt;p&gt;How old are you?&lt;/p&gt;</content>
+      <content>How old are you?</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>0</indent>
@@ -322,33 +323,33 @@
       <hideinstructions>0</hideinstructions>
       <variable>age_009</variable>
       <defaultoption>2</defaultoption>
-      <defaultvalue>-1</defaultvalue>
-      <lowerbound>-2148552000</lowerbound>
-      <upperbound>-2140776000</upperbound>
+      <defaultvalue>-2148555600</defaultvalue>
+      <lowerbound>-2148555600</lowerbound>
+      <upperbound>-2140779600</upperbound>
     </surveyprofield_age>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyproformat_label>
-      <content>&lt;ul&gt;&lt;li&gt;not mandatory (so: &quot;No answer&quot; is expected)&lt;/li&gt;&lt;li&gt;&quot;No answer&quot; is the default&lt;/li&gt;&lt;li&gt;user answer is limited between 18 and 65&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Behaviour: The item is not mandatory and the default is set to a valid value so the user can &quot;fly&quot; over this element leaving the proposed default untouched (and the question not read).&lt;/p&gt;</content>
+      <content>&lt;ul&gt;&lt;li&gt;not mandatory (so: "No answer" is expected)&lt;/li&gt;&lt;li&gt;"No answer" is the default&lt;/li&gt;&lt;li&gt;user answer is limited between 18 and 65&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Behaviour: The item is not mandatory and the default is set to a valid value so the user can "fly" over this element leaving the proposed default untouched (and the question not read).&lt;/p&gt;</content>
       <contentformat>1</contentformat>
       <indent>0</indent>
       <customnumber>10 intro</customnumber>
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="age" version="2015123000">
+  <item type="field" plugin="age" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_age>
-      <content>&lt;p&gt;How old are you?&lt;/p&gt;</content>
+      <content>How old are you?</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>0</indent>
@@ -357,8 +358,9 @@
       <hideinstructions>0</hideinstructions>
       <variable>age_010</variable>
       <defaultoption>3</defaultoption>
-      <lowerbound>-1580558400</lowerbound>
-      <upperbound>-97329600</upperbound>
+      <defaultvalue>-2148555600</defaultvalue>
+      <lowerbound>-1580562000</lowerbound>
+      <upperbound>-97333200</upperbound>
     </surveyprofield_age>
   </item>
 </items>

--- a/tests/fixtures/usertemplate/date_only_2023103100.xml
+++ b/tests/fixtures/usertemplate/date_only_2023103100.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <items>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -13,7 +13,7 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -27,14 +27,14 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="date" version="2015123000">
+  <item type="field" plugin="date" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_date>
-      <content>&lt;p&gt;When did you get your degree?&lt;/p&gt;</content>
+      <content>When did you get your degree?</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>0</indent>
@@ -43,12 +43,13 @@
       <hideinstructions>0</hideinstructions>
       <variable>date_001</variable>
       <defaultoption>2</defaultoption>
+      <defaultvalue>39600</defaultvalue>
       <downloadformat>strftime09</downloadformat>
-      <lowerbound>1414843200</lowerbound>
-      <upperbound>1446292800</upperbound>
+      <lowerbound>1414839600</lowerbound>
+      <upperbound>1446289200</upperbound>
     </surveyprofield_date>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -62,14 +63,14 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="date" version="2015123000">
+  <item type="field" plugin="date" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_date>
-      <content>&lt;p&gt;When did you get your degree?&lt;/p&gt;</content>
+      <content>When did you get your degree?</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>0</indent>
@@ -78,13 +79,13 @@
       <hideinstructions>0</hideinstructions>
       <variable>date_002</variable>
       <defaultoption>1</defaultoption>
-      <defaultvalue>-599659200</defaultvalue>
+      <defaultvalue>1420110000</defaultvalue>
       <downloadformat>strftime09</downloadformat>
-      <lowerbound>1414843200</lowerbound>
-      <upperbound>1446292800</upperbound>
+      <lowerbound>1414839600</lowerbound>
+      <upperbound>1446289200</upperbound>
     </surveyprofield_date>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -98,14 +99,14 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="date" version="2015123000">
+  <item type="field" plugin="date" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_date>
-      <content>&lt;p&gt;When did you get your degree?&lt;/p&gt;</content>
+      <content>When did you get your degree?</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>0</indent>
@@ -114,12 +115,13 @@
       <hideinstructions>0</hideinstructions>
       <variable>date_003</variable>
       <defaultoption>4</defaultoption>
+      <defaultvalue>39600</defaultvalue>
       <downloadformat>strftime09</downloadformat>
-      <lowerbound>1414843200</lowerbound>
-      <upperbound>1446292800</upperbound>
+      <lowerbound>1414839600</lowerbound>
+      <upperbound>1446289200</upperbound>
     </surveyprofield_date>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -133,14 +135,14 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="date" version="2015123000">
+  <item type="field" plugin="date" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_date>
-      <content>&lt;p&gt;When did you get your degree?&lt;/p&gt;</content>
+      <content>When did you get your degree?</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>0</indent>
@@ -149,12 +151,13 @@
       <hideinstructions>0</hideinstructions>
       <variable>date_004</variable>
       <defaultoption>5</defaultoption>
+      <defaultvalue>39600</defaultvalue>
       <downloadformat>strftime09</downloadformat>
-      <lowerbound>1414843200</lowerbound>
-      <upperbound>1446292800</upperbound>
+      <lowerbound>1414839600</lowerbound>
+      <upperbound>1446289200</upperbound>
     </surveyprofield_date>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -168,14 +171,14 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="date" version="2015123000">
+  <item type="field" plugin="date" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_date>
-      <content>&lt;p&gt;When did you get your degree?&lt;/p&gt;</content>
+      <content>When did you get your degree?</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>0</indent>
@@ -184,12 +187,13 @@
       <hideinstructions>0</hideinstructions>
       <variable>date_005</variable>
       <defaultoption>3</defaultoption>
+      <defaultvalue>39600</defaultvalue>
       <downloadformat>strftime09</downloadformat>
-      <lowerbound>1414843200</lowerbound>
-      <upperbound>1446292800</upperbound>
+      <lowerbound>1414839600</lowerbound>
+      <upperbound>1446289200</upperbound>
     </surveyprofield_date>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -203,14 +207,14 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="date" version="2015123000">
+  <item type="field" plugin="date" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_date>
-      <content>&lt;p&gt;When did you get your degree?&lt;/p&gt;</content>
+      <content>When did you get your degree?</content>
       <contentformat>1</contentformat>
       <required>1</required>
       <indent>0</indent>
@@ -219,12 +223,13 @@
       <hideinstructions>0</hideinstructions>
       <variable>date_006</variable>
       <defaultoption>2</defaultoption>
+      <defaultvalue>39600</defaultvalue>
       <downloadformat>strftime09</downloadformat>
-      <lowerbound>1414843200</lowerbound>
-      <upperbound>1446292800</upperbound>
+      <lowerbound>1414839600</lowerbound>
+      <upperbound>1446289200</upperbound>
     </surveyprofield_date>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -238,14 +243,14 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="date" version="2015123000">
+  <item type="field" plugin="date" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_date>
-      <content>&lt;p&gt;When did you get your degree?&lt;/p&gt;</content>
+      <content>When did you get your degree?</content>
       <contentformat>1</contentformat>
       <required>1</required>
       <indent>0</indent>
@@ -254,13 +259,13 @@
       <hideinstructions>0</hideinstructions>
       <variable>date_007</variable>
       <defaultoption>1</defaultoption>
-      <defaultvalue>-599659200</defaultvalue>
+      <defaultvalue>1420110000</defaultvalue>
       <downloadformat>strftime09</downloadformat>
-      <lowerbound>1414843200</lowerbound>
-      <upperbound>1446292800</upperbound>
+      <lowerbound>1414839600</lowerbound>
+      <upperbound>1446289200</upperbound>
     </surveyprofield_date>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -274,14 +279,14 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="date" version="2015123000">
+  <item type="field" plugin="date" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_date>
-      <content>&lt;p&gt;When did you get your degree?&lt;/p&gt;</content>
+      <content>When did you get your degree?</content>
       <contentformat>1</contentformat>
       <required>1</required>
       <indent>0</indent>
@@ -290,12 +295,13 @@
       <hideinstructions>0</hideinstructions>
       <variable>date_008</variable>
       <defaultoption>4</defaultoption>
+      <defaultvalue>39600</defaultvalue>
       <downloadformat>strftime09</downloadformat>
-      <lowerbound>1414843200</lowerbound>
-      <upperbound>1446292800</upperbound>
+      <lowerbound>1414839600</lowerbound>
+      <upperbound>1446289200</upperbound>
     </surveyprofield_date>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -309,14 +315,14 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="date" version="2015123000">
+  <item type="field" plugin="date" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_date>
-      <content>&lt;p&gt;When did you get your degree?&lt;/p&gt;</content>
+      <content>When did you get your degree?</content>
       <contentformat>1</contentformat>
       <required>1</required>
       <indent>0</indent>
@@ -325,9 +331,10 @@
       <hideinstructions>0</hideinstructions>
       <variable>date_009</variable>
       <defaultoption>5</defaultoption>
+      <defaultvalue>39600</defaultvalue>
       <downloadformat>strftime09</downloadformat>
-      <lowerbound>1414843200</lowerbound>
-      <upperbound>1446292800</upperbound>
+      <lowerbound>1414839600</lowerbound>
+      <upperbound>1446289200</upperbound>
     </surveyprofield_date>
   </item>
 </items>

--- a/tests/fixtures/usertemplate/dateshort_only_2023103100.xml
+++ b/tests/fixtures/usertemplate/dateshort_only_2023103100.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <items>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -13,28 +13,28 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyproformat_label>
-      <content>&lt;ul&gt;&lt;li&gt;not mandatory (so: "No answer" is expected)&lt;/li&gt;&lt;li&gt;input is limited to last 15 years&lt;/li&gt;&lt;li&gt;the default invites the user to choose a value&lt;/li&gt;&lt;/ul&gt;Behaviour: The item is not mandatory and the default is set to a not valid value so the user is forced to choose a different date or tick the "No answer" checkbox.</content>
+      <content>&lt;ul&gt;&lt;li&gt;not mandatory (so: "No answer" is expected)&lt;/li&gt;&lt;li&gt;input is forced in the time window 1990-2014&lt;/li&gt;&lt;li&gt;the default invites the user to choose a value&lt;/li&gt;&lt;/ul&gt;Behaviour: The item is not mandatory and the default is set to a not valid value so the user is forced to choose a different date or tick the "No answer" checkbox.</content>
       <contentformat>1</contentformat>
       <indent>0</indent>
       <customnumber>1 intro</customnumber>
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="shortdate" version="2015123000">
+  <item type="field" plugin="shortdate" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_shortdate>
-      <content>&lt;p&gt;When did you buy your current car?&lt;/p&gt;</content>
+      <content>When did you buy your current car?</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>0</indent>
@@ -43,33 +43,34 @@
       <hideinstructions>0</hideinstructions>
       <variable>shortdate_001</variable>
       <defaultoption>2</defaultoption>
+      <defaultvalue>39600</defaultvalue>
       <downloadformat>strftime01</downloadformat>
-      <lowerbound>631195200</lowerbound>
-      <upperbound>1417435200</upperbound>
+      <lowerbound>631191600</lowerbound>
+      <upperbound>1417431600</upperbound>
     </surveyprofield_shortdate>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyproformat_label>
-      <content>&lt;ul&gt;&lt;li&gt;not mandatory (so: "No answer" is expected)&lt;/li&gt;&lt;li&gt;input is limited to last 15 years&lt;/li&gt;&lt;li&gt;the default is set to a valid value&lt;/li&gt;&lt;/ul&gt;Behaviour: the user can "fly" over this element leaving the proposed default untouched (and the question not read) or tick the "No answer" checkbox.</content>
+      <content>&lt;ul&gt;&lt;li&gt;not mandatory (so: "No answer" is expected)&lt;/li&gt;&lt;li&gt;input is forced in the time window 1990-2014&lt;/li&gt;&lt;li&gt;the default is set to a valid value&lt;/li&gt;&lt;/ul&gt;Behaviour: the user can "fly" over this element leaving the proposed default untouched (and the question not read) or tick the "No answer" checkbox.</content>
       <contentformat>1</contentformat>
       <indent>0</indent>
       <customnumber>2 intro</customnumber>
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="shortdate" version="2015123000">
+  <item type="field" plugin="shortdate" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_shortdate>
-      <content>&lt;p&gt;When did you buy your current car?&lt;/p&gt;</content>
+      <content>When did you buy your current car?</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>0</indent>
@@ -78,34 +79,34 @@
       <hideinstructions>0</hideinstructions>
       <variable>shortdate_002</variable>
       <defaultoption>1</defaultoption>
-      <defaultvalue>1254398400</defaultvalue>
+      <defaultvalue>1254391200</defaultvalue>
       <downloadformat>strftime01</downloadformat>
-      <lowerbound>631195200</lowerbound>
-      <upperbound>1417435200</upperbound>
+      <lowerbound>631191600</lowerbound>
+      <upperbound>1417431600</upperbound>
     </surveyprofield_shortdate>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyproformat_label>
-      <content>&lt;ul&gt;&lt;li&gt;not mandatory (so: "No answer" is expected)&lt;/li&gt;&lt;li&gt;input is limited to last 15 years&lt;/li&gt;&lt;li&gt;the default is set to the last input&lt;/li&gt;&lt;/ul&gt;Behaviour: The item is not mandatory and the default is probably set to a valid value so the user can "fly" over this element leaving the proposed default untouched (and the question not read) or tick the "No answer" checkbox.</content>
+      <content>&lt;ul&gt;&lt;li&gt;not mandatory (so: "No answer" is expected)&lt;/li&gt;&lt;li&gt;input is forced in the time window 1990-2014&lt;/li&gt;&lt;li&gt;the default is set to the last input&lt;/li&gt;&lt;/ul&gt;Behaviour: The item is not mandatory and the default is probably set to a valid value so the user can "fly" over this element leaving the proposed default untouched (and the question not read) or tick the "No answer" checkbox.</content>
       <contentformat>1</contentformat>
       <indent>0</indent>
       <customnumber>3 intro</customnumber>
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="shortdate" version="2015123000">
+  <item type="field" plugin="shortdate" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_shortdate>
-      <content>&lt;p&gt;When did you buy your current car?&lt;/p&gt;</content>
+      <content>When did you buy your current car?</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>0</indent>
@@ -114,33 +115,34 @@
       <hideinstructions>0</hideinstructions>
       <variable>shortdate_003</variable>
       <defaultoption>4</defaultoption>
+      <defaultvalue>39600</defaultvalue>
       <downloadformat>strftime01</downloadformat>
-      <lowerbound>631195200</lowerbound>
-      <upperbound>1417435200</upperbound>
+      <lowerbound>631191600</lowerbound>
+      <upperbound>1417431600</upperbound>
     </surveyprofield_shortdate>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyproformat_label>
-      <content>&lt;ul&gt;&lt;li&gt;not mandatory (so: "No answer" is expected)&lt;/li&gt;&lt;li&gt;input is limited to last 15 years&lt;/li&gt;&lt;li&gt;the default is set to the current date&lt;/li&gt;&lt;/ul&gt;Behaviour: If the default is valid the user can "fly" over this element leaving the proposed default untouched (and the question not read) otherwise he/she is forced to choose a different date or to tick the "No answer" checkbox.</content>
+      <content>&lt;ul&gt;&lt;li&gt;not mandatory (so: "No answer" is expected)&lt;/li&gt;&lt;li&gt;input is forced in the time window 1990-2014&lt;/li&gt;&lt;li&gt;the default is set to the current date&lt;/li&gt;&lt;/ul&gt;Behaviour: If the default is valid the user can "fly" over this element leaving the proposed default untouched (and the question not read) otherwise he/she is forced to choose a different date or to tick the "No answer" checkbox.</content>
       <contentformat>1</contentformat>
       <indent>0</indent>
       <customnumber>4 intro</customnumber>
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="shortdate" version="2015123000">
+  <item type="field" plugin="shortdate" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_shortdate>
-      <content>&lt;p&gt;When did you buy your current car?&lt;/p&gt;</content>
+      <content>When did you buy your current car?</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>0</indent>
@@ -149,33 +151,34 @@
       <hideinstructions>0</hideinstructions>
       <variable>shortdate_004</variable>
       <defaultoption>5</defaultoption>
+      <defaultvalue>39600</defaultvalue>
       <downloadformat>strftime01</downloadformat>
-      <lowerbound>631195200</lowerbound>
-      <upperbound>1417435200</upperbound>
+      <lowerbound>631191600</lowerbound>
+      <upperbound>1417431600</upperbound>
     </surveyprofield_shortdate>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyproformat_label>
-      <content>&lt;ul&gt;&lt;li&gt;not mandatory (so: "No answer" is expected)&lt;/li&gt;&lt;li&gt;input is limited to last 15 years&lt;/li&gt;&lt;li&gt;the default is set to "No answer"&lt;/li&gt;&lt;/ul&gt;Behaviour: The item is not mandatory and the default is set to a valid value so the user can "fly" over this element leaving the proposed default untouched (and the question not read) or tick the "No answer" checkbox and setting a different date.</content>
+      <content>&lt;ul&gt;&lt;li&gt;not mandatory (so: "No answer" is expected)&lt;/li&gt;&lt;li&gt;input is forced in the time window 1990-2014&lt;/li&gt;&lt;li&gt;the default is set to "No answer"&lt;/li&gt;&lt;/ul&gt;Behaviour: The item is not mandatory and the default is set to a valid value so the user can "fly" over this element leaving the proposed default untouched (and the question not read) or tick the "No answer" checkbox and setting a different date.</content>
       <contentformat>1</contentformat>
       <indent>0</indent>
       <customnumber>5 intro</customnumber>
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="shortdate" version="2015123000">
+  <item type="field" plugin="shortdate" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_shortdate>
-      <content>&lt;p&gt;When did you buy your current car?&lt;/p&gt;</content>
+      <content>When did you buy your current car?</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>0</indent>
@@ -184,33 +187,34 @@
       <hideinstructions>0</hideinstructions>
       <variable>shortdate_005</variable>
       <defaultoption>3</defaultoption>
+      <defaultvalue>39600</defaultvalue>
       <downloadformat>strftime01</downloadformat>
-      <lowerbound>631195200</lowerbound>
-      <upperbound>1417435200</upperbound>
+      <lowerbound>631191600</lowerbound>
+      <upperbound>1417431600</upperbound>
     </surveyprofield_shortdate>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyproformat_label>
-      <content>&lt;ul&gt;&lt;li&gt;mandatory (so: "No answer" is not expected)&lt;/li&gt;&lt;li&gt;input is limited to last 15 years&lt;/li&gt;&lt;li&gt;the default invites the user to choose a value&lt;/li&gt;&lt;/ul&gt;Behaviour: The item is mandatory and the default is set to a not valid value so the user is forced to choose a different date.</content>
+      <content>&lt;ul&gt;&lt;li&gt;mandatory (so: "No answer" is not expected)&lt;/li&gt;&lt;li&gt;input is forced in the time window 1990-2014&lt;/li&gt;&lt;li&gt;the default invites the user to choose a value&lt;/li&gt;&lt;/ul&gt;Behaviour: The item is mandatory and the default is set to a not valid value so the user is forced to choose a different date.</content>
       <contentformat>1</contentformat>
       <indent>0</indent>
       <customnumber>6 intro</customnumber>
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="shortdate" version="2015123000">
+  <item type="field" plugin="shortdate" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_shortdate>
-      <content>&lt;p&gt;When did you buy your current car?&lt;/p&gt;</content>
+      <content>When did you buy your current car?</content>
       <contentformat>1</contentformat>
       <required>1</required>
       <indent>0</indent>
@@ -219,33 +223,34 @@
       <hideinstructions>0</hideinstructions>
       <variable>shortdate_006</variable>
       <defaultoption>2</defaultoption>
+      <defaultvalue>39600</defaultvalue>
       <downloadformat>strftime01</downloadformat>
-      <lowerbound>631195200</lowerbound>
-      <upperbound>1417435200</upperbound>
+      <lowerbound>631191600</lowerbound>
+      <upperbound>1417431600</upperbound>
     </surveyprofield_shortdate>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyproformat_label>
-      <content>&lt;ul&gt;&lt;li&gt;mandatory (so: "No answer" is not expected)&lt;/li&gt;&lt;li&gt;input is limited to last 15 years&lt;/li&gt;&lt;li&gt;the default is set to a valid value&lt;/li&gt;&lt;/ul&gt;Behaviour: the user can "fly" over this element leaving the proposed default untouched (and the question not read).</content>
+      <content>&lt;ul&gt;&lt;li&gt;mandatory (so: "No answer" is not expected)&lt;/li&gt;&lt;li&gt;input is forced in the time window 1990-2014&lt;/li&gt;&lt;li&gt;the default is set to a valid value&lt;/li&gt;&lt;/ul&gt;Behaviour: the user can "fly" over this element leaving the proposed default untouched (and the question not read).</content>
       <contentformat>1</contentformat>
       <indent>0</indent>
       <customnumber>7 intro</customnumber>
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="shortdate" version="2015123000">
+  <item type="field" plugin="shortdate" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_shortdate>
-      <content>&lt;p&gt;When did you buy your current car?&lt;/p&gt;</content>
+      <content>When did you buy your current car?</content>
       <contentformat>1</contentformat>
       <required>1</required>
       <indent>0</indent>
@@ -254,34 +259,34 @@
       <hideinstructions>0</hideinstructions>
       <variable>shortdate_007</variable>
       <defaultoption>1</defaultoption>
-      <defaultvalue>1254398400</defaultvalue>
+      <defaultvalue>1254391200</defaultvalue>
       <downloadformat>strftime01</downloadformat>
-      <lowerbound>631195200</lowerbound>
-      <upperbound>1417435200</upperbound>
+      <lowerbound>631191600</lowerbound>
+      <upperbound>1417431600</upperbound>
     </surveyprofield_shortdate>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyproformat_label>
-      <content>&lt;ul&gt;&lt;li&gt;mandatory (so: "No answer" is not expected)&lt;/li&gt;&lt;li&gt;input is limited to last 15 years&lt;/li&gt;&lt;li&gt;the default is set to the last input&lt;/li&gt;&lt;/ul&gt;Behaviour: The item is mandatory and the default is probably set to a valid value so the user can "fly" over this element leaving the proposed default untouched (and the question not read)</content>
+      <content>&lt;ul&gt;&lt;li&gt;mandatory (so: "No answer" is not expected)&lt;/li&gt;&lt;li&gt;input is forced in the time window 1990-2014&lt;/li&gt;&lt;li&gt;the default is set to the last input&lt;/li&gt;&lt;/ul&gt;Behaviour: The item is mandatory and the default is probably set to a valid value so the user can "fly" over this element leaving the proposed default untouched (and the question not read)</content>
       <contentformat>1</contentformat>
       <indent>0</indent>
       <customnumber>8 intro</customnumber>
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="shortdate" version="2015123000">
+  <item type="field" plugin="shortdate" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_shortdate>
-      <content>&lt;p&gt;When did you buy your current car?&lt;/p&gt;</content>
+      <content>When did you buy your current car?</content>
       <contentformat>1</contentformat>
       <required>1</required>
       <indent>0</indent>
@@ -290,33 +295,34 @@
       <hideinstructions>0</hideinstructions>
       <variable>shortdate_008</variable>
       <defaultoption>4</defaultoption>
+      <defaultvalue>39600</defaultvalue>
       <downloadformat>strftime01</downloadformat>
-      <lowerbound>631195200</lowerbound>
-      <upperbound>1417435200</upperbound>
+      <lowerbound>631191600</lowerbound>
+      <upperbound>1417431600</upperbound>
     </surveyprofield_shortdate>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyproformat_label>
-      <content>&lt;ul&gt;&lt;li&gt;mandatory (so: "No answer" is not expected)&lt;/li&gt;&lt;li&gt;input is limited to last 15 years&lt;/li&gt;&lt;li&gt;the default is set to the current date&lt;/li&gt;&lt;/ul&gt;Behaviour: If the default is valid the user can "fly" over this element leaving the proposed default untouched (and the question not read) otherwise he/she is forced to choose a different date.</content>
+      <content>&lt;ul&gt;&lt;li&gt;mandatory (so: "No answer" is not expected)&lt;/li&gt;&lt;li&gt;input is forced in the time window 1990-2014&lt;/li&gt;&lt;li&gt;the default is set to the current date&lt;/li&gt;&lt;/ul&gt;Behaviour: If the default is valid the user can "fly" over this element leaving the proposed default untouched (and the question not read) otherwise he/she is forced to choose a different date.</content>
       <contentformat>1</contentformat>
       <indent>0</indent>
       <customnumber>9 intro</customnumber>
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="shortdate" version="2015123000">
+  <item type="field" plugin="shortdate" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_shortdate>
-      <content>&lt;p&gt;When did you buy your current car?&lt;/p&gt;</content>
+      <content>When did you buy your current car?</content>
       <contentformat>1</contentformat>
       <required>1</required>
       <indent>0</indent>
@@ -325,9 +331,10 @@
       <hideinstructions>0</hideinstructions>
       <variable>shortdate_009</variable>
       <defaultoption>5</defaultoption>
+      <defaultvalue>39600</defaultvalue>
       <downloadformat>strftime01</downloadformat>
-      <lowerbound>631195200</lowerbound>
-      <upperbound>1417435200</upperbound>
+      <lowerbound>631191600</lowerbound>
+      <upperbound>1417431600</upperbound>
     </surveyprofield_shortdate>
   </item>
 </items>

--- a/tests/fixtures/usertemplate/datetime_only_2023103100.xml
+++ b/tests/fixtures/usertemplate/datetime_only_2023103100.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <items>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -13,7 +13,7 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -27,14 +27,14 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="datetime" version="2015123000">
+  <item type="field" plugin="datetime" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_datetime>
-      <content>&lt;p&gt;Please, write down date and time of your last flight to Los Angeles.&lt;/p&gt;</content>
+      <content>Please, write down date and time of your last flight to Los Angeles.</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>0</indent>
@@ -44,12 +44,13 @@
       <variable>datetime_001</variable>
       <step>1</step>
       <defaultoption>2</defaultoption>
+      <defaultvalue>-3600</defaultvalue>
       <downloadformat>strftime01</downloadformat>
       <lowerbound>1442275200</lowerbound>
       <upperbound>1442966340</upperbound>
     </surveyprofield_datetime>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -63,14 +64,14 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="datetime" version="2015123000">
+  <item type="field" plugin="datetime" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_datetime>
-      <content>&lt;p&gt;Please, write down date and time of your last flight to Los Angeles.&lt;/p&gt;</content>
+      <content>Please, write down date and time of your last flight to Los Angeles.</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>0</indent>
@@ -86,7 +87,7 @@
       <upperbound>1442966340</upperbound>
     </surveyprofield_datetime>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -100,14 +101,14 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="datetime" version="2015123000">
+  <item type="field" plugin="datetime" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_datetime>
-      <content>&lt;p&gt;Please, write down date and time of your last flight to Los Angeles.&lt;/p&gt;</content>
+      <content>Please, write down date and time of your last flight to Los Angeles.</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>0</indent>
@@ -117,12 +118,13 @@
       <variable>datetime_003</variable>
       <step>1</step>
       <defaultoption>4</defaultoption>
+      <defaultvalue>-3600</defaultvalue>
       <downloadformat>strftime01</downloadformat>
       <lowerbound>1442275200</lowerbound>
       <upperbound>1442966340</upperbound>
     </surveyprofield_datetime>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -136,14 +138,14 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="datetime" version="2015123000">
+  <item type="field" plugin="datetime" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_datetime>
-      <content>&lt;p&gt;Please, write down date and time of your last flight to Los Angeles.&lt;/p&gt;</content>
+      <content>Please, write down date and time of your last flight to Los Angeles.</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>0</indent>
@@ -153,12 +155,13 @@
       <variable>datetime_004</variable>
       <step>1</step>
       <defaultoption>5</defaultoption>
+      <defaultvalue>-3600</defaultvalue>
       <downloadformat>strftime01</downloadformat>
       <lowerbound>1442275200</lowerbound>
       <upperbound>1442966340</upperbound>
     </surveyprofield_datetime>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -172,14 +175,14 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="datetime" version="2015123000">
+  <item type="field" plugin="datetime" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_datetime>
-      <content>&lt;p&gt;Please, write down date and time of your last flight to Los Angeles.&lt;/p&gt;</content>
+      <content>Please, write down date and time of your last flight to Los Angeles.</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>0</indent>
@@ -189,12 +192,13 @@
       <variable>datetime_005</variable>
       <step>1</step>
       <defaultoption>3</defaultoption>
+      <defaultvalue>-3600</defaultvalue>
       <downloadformat>strftime01</downloadformat>
       <lowerbound>1442275200</lowerbound>
       <upperbound>1442966340</upperbound>
     </surveyprofield_datetime>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -208,14 +212,14 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="datetime" version="2015123000">
+  <item type="field" plugin="datetime" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_datetime>
-      <content>&lt;p&gt;Please, write down date and time of your last flight to Los Angeles.&lt;/p&gt;</content>
+      <content>Please, write down date and time of your last flight to Los Angeles.</content>
       <contentformat>1</contentformat>
       <required>1</required>
       <indent>0</indent>
@@ -225,12 +229,13 @@
       <variable>datetime_006</variable>
       <step>1</step>
       <defaultoption>2</defaultoption>
+      <defaultvalue>-3600</defaultvalue>
       <downloadformat>strftime01</downloadformat>
       <lowerbound>1442275200</lowerbound>
       <upperbound>1442966340</upperbound>
     </surveyprofield_datetime>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -244,14 +249,14 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="datetime" version="2015123000">
+  <item type="field" plugin="datetime" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_datetime>
-      <content>&lt;p&gt;Please, write down date and time of your last flight to Los Angeles.&lt;/p&gt;</content>
+      <content>Please, write down date and time of your last flight to Los Angeles.</content>
       <contentformat>1</contentformat>
       <required>1</required>
       <indent>0</indent>
@@ -267,7 +272,7 @@
       <upperbound>1442966340</upperbound>
     </surveyprofield_datetime>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -281,14 +286,14 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="datetime" version="2015123000">
+  <item type="field" plugin="datetime" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_datetime>
-      <content>&lt;p&gt;Please, write down date and time of your last flight to Los Angeles.&lt;/p&gt;</content>
+      <content>Please, write down date and time of your last flight to Los Angeles.</content>
       <contentformat>1</contentformat>
       <required>1</required>
       <indent>0</indent>
@@ -298,12 +303,13 @@
       <variable>datetime_008</variable>
       <step>1</step>
       <defaultoption>4</defaultoption>
+      <defaultvalue>-3600</defaultvalue>
       <downloadformat>strftime01</downloadformat>
       <lowerbound>1442275200</lowerbound>
       <upperbound>1442966340</upperbound>
     </surveyprofield_datetime>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -317,14 +323,14 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="datetime" version="2015123000">
+  <item type="field" plugin="datetime" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_datetime>
-      <content>&lt;p&gt;Please, write down date and time of your last flight to Los Angeles.&lt;/p&gt;</content>
+      <content>Please, write down date and time of your last flight to Los Angeles.</content>
       <contentformat>1</contentformat>
       <required>1</required>
       <indent>0</indent>
@@ -334,6 +340,7 @@
       <variable>datetime_009</variable>
       <step>1</step>
       <defaultoption>5</defaultoption>
+      <defaultvalue>-3600</defaultvalue>
       <downloadformat>strftime01</downloadformat>
       <lowerbound>1442275200</lowerbound>
       <upperbound>1442966340</upperbound>

--- a/tests/fixtures/usertemplate/parent-child_2023103100.xml
+++ b/tests/fixtures/usertemplate/parent-child_2023103100.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <items>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -30,14 +30,14 @@
       <fullwidth>1</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="boolean" version="2015123000">
+  <item type="field" plugin="boolean" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_boolean>
-      <content>&lt;p&gt;Example with boolean item: Is this true or false?&lt;/p&gt;</content>
+      <content>Example with boolean item: Is this true or false?&lt;/p&gt;</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>0</indent>
@@ -57,7 +57,7 @@
       <reserved>0</reserved>
     </surveypro_item>
   </item>
-  <item type="field" plugin="character" version="2015123000">
+  <item type="field" plugin="character" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -68,8 +68,7 @@
       </parent>
     </surveypro_item>
     <surveyprofield_character>
-      <content>&lt;p&gt;Enter you name&lt;/p&gt;&#13;
-&lt;p&gt;(Just a detail: I marked this question as mandatory question. The attribute is actually considered ONLY if the parent item allows his child otherwise the attribute is neglected).&lt;/p&gt;</content>
+      <content>Enter you name&lt;br&gt;(Just a detail: I marked this question as mandatory question. The attribute is actually considered ONLY if the parent item allows his child otherwise the attribute is neglected).</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>1</indent>
@@ -83,7 +82,7 @@
       <minlength>0</minlength>
     </surveyprofield_character>
   </item>
-  <item type="field" plugin="integer" version="2015123000">
+  <item type="field" plugin="integer" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -94,7 +93,7 @@
       </parent>
     </surveypro_item>
     <surveyprofield_integer>
-      <content>&lt;p&gt;Number of friends you would like to invite to your next birthday party.&lt;/p&gt;</content>
+      <content>Number of friends you would like to invite to your next birthday party.</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>1</indent>
@@ -109,14 +108,14 @@
       <upperbound>105</upperbound>
     </surveyprofield_integer>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyproformat_label>
-      <content>&lt;p&gt;As you can see, by answering "No answer" to the parent item you get disabled the first such as the second child too.&lt;/p&gt;</content>
+      <content>As you can see, by answering "No answer" to the parent item you get disabled the first such as the second child too.</content>
       <contentformat>1</contentformat>
       <indent>0</indent>
       <fullwidth>0</fullwidth>
@@ -129,7 +128,7 @@
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_checkbox>
-      <content>&lt;p&gt;Example with checkbox item: What do you always want to find on your desk in the office?&lt;/p&gt;</content>
+      <content>Example with checkbox item: What do you always want to find on your desk in the office?</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>0</indent>
@@ -155,7 +154,7 @@ A4 paper</options>
       <reserved>0</reserved>
     </surveypro_item>
   </item>
-  <item type="field" plugin="character" version="2015123000">
+  <item type="field" plugin="character" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -166,7 +165,7 @@ A4 paper</options>
       </parent>
     </surveypro_item>
     <surveyprofield_character>
-      <content>&lt;p&gt;Write something.&lt;/p&gt;</content>
+      <content>Write something.</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>1</indent>
@@ -180,7 +179,7 @@ A4 paper</options>
       <minlength>0</minlength>
     </surveyprofield_character>
   </item>
-  <item type="field" plugin="textarea" version="2015123000">
+  <item type="field" plugin="textarea" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -191,7 +190,7 @@ A4 paper</options>
       </parent>
     </surveypro_item>
     <surveyprofield_textarea>
-      <content>&lt;p&gt;Please describe the best pen you have ever seen&lt;/p&gt;</content>
+      <content>Please describe the best motor you have ever seen.</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>1</indent>
@@ -207,14 +206,14 @@ A4 paper</options>
       <minlength>0</minlength>
     </surveyprofield_textarea>
   </item>
-  <item type="field" plugin="integer" version="2015123000">
+  <item type="field" plugin="integer" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_integer>
-      <content>&lt;p&gt;Example with numeric (small integer) item: Enter an integer value.&lt;/p&gt;</content>
+      <content>Example with numeric (small integer) item: Enter an integer value.</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>0</indent>
@@ -235,7 +234,7 @@ A4 paper</options>
       <reserved>0</reserved>
     </surveypro_item>
   </item>
-  <item type="field" plugin="character" version="2015123000">
+  <item type="field" plugin="character" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -246,7 +245,7 @@ A4 paper</options>
       </parent>
     </surveypro_item>
     <surveyprofield_character>
-      <content>&lt;p&gt;Enter you name.&lt;/p&gt;</content>
+      <content>Enter you name.</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>1</indent>
@@ -260,7 +259,7 @@ A4 paper</options>
       <minlength>0</minlength>
     </surveyprofield_character>
   </item>
-  <item type="field" plugin="integer" version="2015123000">
+  <item type="field" plugin="integer" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -271,7 +270,7 @@ A4 paper</options>
       </parent>
     </surveypro_item>
     <surveyprofield_integer>
-      <content>&lt;p&gt;Number of friends you would like to invite to your next birthday party.&lt;/p&gt;</content>
+      <content>Number of friends you would like to invite to your next birthday party.</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>1</indent>
@@ -293,7 +292,7 @@ A4 paper</options>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_multiselect>
-      <content>&lt;p&gt;Example with multiselect item: What do you eat for breakfast? (click or shift-click to change the selection).&lt;/p&gt;</content>
+      <content>Example with multiselect item: What do you eat for breakfast? (click or shift-click to change the selection).</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>0</indent>
@@ -322,7 +321,7 @@ ham</defaultvalue>
       <reserved>0</reserved>
     </surveypro_item>
   </item>
-  <item type="field" plugin="numeric" version="2015123000">
+  <item type="field" plugin="numeric" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -333,7 +332,7 @@ ham</defaultvalue>
       </parent>
     </surveypro_item>
     <surveyprofield_numeric>
-      <content>&lt;p&gt;You preferred room temperature?&lt;/p&gt;</content>
+      <content>You preferred room temperature?</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>1</indent>
@@ -342,12 +341,12 @@ ham</defaultvalue>
       <hideinstructions>0</hideinstructions>
       <variable>numeric_001</variable>
       <extranote>This item is allowed when the answer to its parent is "ham bread"</extranote>
-      <defaultvalue>27.45</defaultvalue>
+      <defaultvalue>27</defaultvalue>
       <signed>0</signed>
       <decimals>2</decimals>
     </surveyprofield_numeric>
   </item>
-  <item type="field" plugin="date" version="2015123000">
+  <item type="field" plugin="date" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -358,7 +357,7 @@ ham</defaultvalue>
       </parent>
     </surveypro_item>
     <surveyprofield_date>
-      <content>&lt;p&gt;Enter a full date.&lt;/p&gt;</content>
+      <content>Enter a full date.</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>1</indent>
@@ -368,19 +367,20 @@ ham</defaultvalue>
       <variable>date_001</variable>
       <extranote>This item is allowed when the answer to its parent is "jam ham tomatoes"</extranote>
       <defaultoption>2</defaultoption>
+      <defaultvalue>43200</defaultvalue>
       <downloadformat>strftime01</downloadformat>
       <lowerbound>43200</lowerbound>
       <upperbound>1609416000</upperbound>
     </surveyprofield_date>
   </item>
-  <item type="field" plugin="radiobutton" version="2015123000">
+  <item type="field" plugin="radiobutton" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_radiobutton>
-      <content>&lt;p&gt;Example with radio button item: which countryside do you like more for your summer holidays?&lt;/p&gt;</content>
+      <content>Example with radio button item: which countryside do you like more for your summer holidays?</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>0</indent>
@@ -405,7 +405,7 @@ City</options>
       <reserved>0</reserved>
     </surveypro_item>
   </item>
-  <item type="field" plugin="shortdate" version="2015123000">
+  <item type="field" plugin="shortdate" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -416,7 +416,7 @@ City</options>
       </parent>
     </surveypro_item>
     <surveyprofield_shortdate>
-      <content>&lt;p&gt;When did you buy your last car?&lt;/p&gt;</content>
+      <content>When did you buy your last car?</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>1</indent>
@@ -431,7 +431,7 @@ City</options>
       <upperbound>1606824000</upperbound>
     </surveyprofield_shortdate>
   </item>
-  <item type="field" plugin="rate" version="2015123000">
+  <item type="field" plugin="rate" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -442,7 +442,7 @@ City</options>
       </parent>
     </surveypro_item>
     <surveyprofield_rate>
-      <content>&lt;p&gt;Order the following languages as you better can make use of them.&lt;/p&gt;</content>
+      <content>Order the following languages as you better can make use of them.</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>1</indent>
@@ -471,14 +471,14 @@ bad</defaultvalue>
       <differentrates>0</differentrates>
     </surveyprofield_rate>
   </item>
-  <item type="field" plugin="select" version="2015123000">
+  <item type="field" plugin="select" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyprofield_select>
-      <content>&lt;p&gt;Example with select item: Indicate your preferred direction.&lt;/p&gt;</content>
+      <content>Example with select item: Indicate your preferred direction.</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>0</indent>
@@ -500,7 +500,7 @@ left</options>
       <reserved>0</reserved>
     </surveypro_item>
   </item>
-  <item type="field" plugin="age" version="2015123000">
+  <item type="field" plugin="age" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -511,7 +511,7 @@ left</options>
       </parent>
     </surveypro_item>
     <surveyprofield_age>
-      <content>&lt;p&gt;How old were you when you first travelled alone?&lt;/p&gt;</content>
+      <content>How old were you when you first travelled alone?</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>1</indent>
@@ -526,7 +526,7 @@ left</options>
       <upperbound>3339835200</upperbound>
     </surveyprofield_age>
   </item>
-  <item type="field" plugin="fileupload" version="2015123000">
+  <item type="field" plugin="fileupload" version="2018060501">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -537,7 +537,7 @@ left</options>
       </parent>
     </surveypro_item>
     <surveyprofield_fileupload>
-      <content>&lt;p&gt;Please attach your curriculum vitae.&lt;/p&gt;</content>
+      <content>Please attach your curriculum vitae.</content>
       <contentformat>1</contentformat>
       <required>0</required>
       <indent>1</indent>

--- a/tests/fixtures/usertemplate/recurrence_only_2023103100.xml
+++ b/tests/fixtures/usertemplate/recurrence_only_2023103100.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <items>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -13,7 +13,7 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -27,7 +27,7 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="recurrence" version="2015123000">
+  <item type="field" plugin="recurrence" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -43,12 +43,13 @@
       <hideinstructions>0</hideinstructions>
       <variable>recurrence_001</variable>
       <defaultoption>2</defaultoption>
+      <defaultvalue>39600</defaultvalue>
       <downloadformat>strftime03</downloadformat>
-      <lowerbound>43200</lowerbound>
-      <upperbound>31492800</upperbound>
+      <lowerbound>39600</lowerbound>
+      <upperbound>31489200</upperbound>
     </surveyprofield_recurrence>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -62,7 +63,7 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="recurrence" version="2015123000">
+  <item type="field" plugin="recurrence" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -78,13 +79,13 @@
       <hideinstructions>0</hideinstructions>
       <variable>recurrence_002</variable>
       <defaultoption>1</defaultoption>
-      <defaultvalue>13608000</defaultvalue>
+      <defaultvalue>13600800</defaultvalue>
       <downloadformat>strftime03</downloadformat>
-      <lowerbound>43200</lowerbound>
-      <upperbound>31492800</upperbound>
+      <lowerbound>39600</lowerbound>
+      <upperbound>31489200</upperbound>
     </surveyprofield_recurrence>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -98,7 +99,7 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="recurrence" version="2015123000">
+  <item type="field" plugin="recurrence" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -114,12 +115,13 @@
       <hideinstructions>0</hideinstructions>
       <variable>recurrence_003</variable>
       <defaultoption>4</defaultoption>
+      <defaultvalue>39600</defaultvalue>
       <downloadformat>strftime03</downloadformat>
-      <lowerbound>43200</lowerbound>
-      <upperbound>31492800</upperbound>
+      <lowerbound>39600</lowerbound>
+      <upperbound>31489200</upperbound>
     </surveyprofield_recurrence>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -133,7 +135,7 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="recurrence" version="2015123000">
+  <item type="field" plugin="recurrence" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -149,12 +151,13 @@
       <hideinstructions>0</hideinstructions>
       <variable>recurrence_004</variable>
       <defaultoption>5</defaultoption>
+      <defaultvalue>39600</defaultvalue>
       <downloadformat>strftime03</downloadformat>
-      <lowerbound>43200</lowerbound>
-      <upperbound>31492800</upperbound>
+      <lowerbound>39600</lowerbound>
+      <upperbound>31489200</upperbound>
     </surveyprofield_recurrence>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -168,7 +171,7 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="recurrence" version="2015123000">
+  <item type="field" plugin="recurrence" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -184,12 +187,13 @@
       <hideinstructions>0</hideinstructions>
       <variable>recurrence_005</variable>
       <defaultoption>3</defaultoption>
+      <defaultvalue>39600</defaultvalue>
       <downloadformat>strftime03</downloadformat>
-      <lowerbound>43200</lowerbound>
-      <upperbound>31492800</upperbound>
+      <lowerbound>39600</lowerbound>
+      <upperbound>31489200</upperbound>
     </surveyprofield_recurrence>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -203,7 +207,7 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="recurrence" version="2015123000">
+  <item type="field" plugin="recurrence" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -219,12 +223,13 @@
       <hideinstructions>0</hideinstructions>
       <variable>recurrence_006</variable>
       <defaultoption>2</defaultoption>
+      <defaultvalue>39600</defaultvalue>
       <downloadformat>strftime03</downloadformat>
-      <lowerbound>43200</lowerbound>
-      <upperbound>31492800</upperbound>
+      <lowerbound>39600</lowerbound>
+      <upperbound>31489200</upperbound>
     </surveyprofield_recurrence>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -238,7 +243,7 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="recurrence" version="2015123000">
+  <item type="field" plugin="recurrence" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -254,13 +259,13 @@
       <hideinstructions>0</hideinstructions>
       <variable>recurrence_007</variable>
       <defaultoption>1</defaultoption>
-      <defaultvalue>13608000</defaultvalue>
+      <defaultvalue>13600800</defaultvalue>
       <downloadformat>strftime03</downloadformat>
-      <lowerbound>43200</lowerbound>
-      <upperbound>31492800</upperbound>
+      <lowerbound>39600</lowerbound>
+      <upperbound>31489200</upperbound>
     </surveyprofield_recurrence>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -274,7 +279,7 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="recurrence" version="2015123000">
+  <item type="field" plugin="recurrence" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -290,12 +295,13 @@
       <hideinstructions>0</hideinstructions>
       <variable>recurrence_008</variable>
       <defaultoption>4</defaultoption>
+      <defaultvalue>39600</defaultvalue>
       <downloadformat>strftime03</downloadformat>
-      <lowerbound>43200</lowerbound>
-      <upperbound>31492800</upperbound>
+      <lowerbound>39600</lowerbound>
+      <upperbound>31489200</upperbound>
     </surveyprofield_recurrence>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -309,7 +315,7 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="recurrence" version="2015123000">
+  <item type="field" plugin="recurrence" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -325,9 +331,10 @@
       <hideinstructions>0</hideinstructions>
       <variable>recurrence_009</variable>
       <defaultoption>5</defaultoption>
+      <defaultvalue>39600</defaultvalue>
       <downloadformat>strftime03</downloadformat>
-      <lowerbound>43200</lowerbound>
-      <upperbound>31492800</upperbound>
+      <lowerbound>39600</lowerbound>
+      <upperbound>31489200</upperbound>
     </surveyprofield_recurrence>
   </item>
 </items>

--- a/tests/fixtures/usertemplate/time_only_2023103100.xml
+++ b/tests/fixtures/usertemplate/time_only_2023103100.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <items>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
       <reserved>0</reserved>
     </surveypro_item>
     <surveyproformat_label>
-      <content>&lt;h5&gt;TIME&lt;/h5&gt;&lt;p&gt;This plugin, like all the others provided by surveypro core, is equipped with a set of common settings shared with all the other surveypro elements.&lt;/p&gt;&lt;p&gt;The &lt;b&gt;common settings&lt;/b&gt; set is done by:&lt;/p&gt;&lt;ol&gt;&lt;li&gt;Required&lt;/li&gt;&lt;li&gt;Indent&lt;/li&gt;&lt;li&gt;Question position&lt;/li&gt;&lt;li&gt;Element number&lt;/li&gt;&lt;li&gt;Hide filling instruction&lt;/li&gt;&lt;li&gt;Variable&lt;/li&gt;&lt;li&gt;Additional note&lt;/li&gt;&lt;/ol&gt;&lt;p&gt;This plugin is equipped with only two &lt;b&gt;time specific setting&lt;/b&gt;:&lt;/p&gt;&lt;ol&gt;&lt;li&gt;Step&lt;/li&gt;&lt;li&gt;Default&lt;br /&gt;&lt;/li&gt;&lt;li&gt;Download format&lt;/li&gt;&lt;/ol&gt;&lt;p&gt;and with two more &lt;b&gt;validation options&lt;/b&gt;:&lt;/p&gt;&lt;ol&gt;&lt;li&gt;Lower bound&lt;/li&gt;&lt;li&gt;Upper bound&lt;/li&gt;&lt;/ol&gt;&lt;p&gt;The cartesian product of all these settings makes a very long list of possible implementations of this element. In this usertemplate few use cases are described.&lt;/p&gt;</content>
+      <content>&lt;h5&gt;TIME&lt;/h5&gt;&lt;p&gt;This plugin, like all the others provided by surveypro core, is equipped with a set of common settings shared with all the other surveypro elements.&lt;/p&gt;&lt;p&gt;The &lt;b&gt;common settings&lt;/b&gt; set is done by:&lt;/p&gt;&lt;ol&gt;&lt;li&gt;Required&lt;/li&gt;&lt;li&gt;Indent&lt;/li&gt;&lt;li&gt;Question position&lt;/li&gt;&lt;li&gt;Element number&lt;/li&gt;&lt;li&gt;Hide filling instruction&lt;/li&gt;&lt;li&gt;Variable&lt;/li&gt;&lt;li&gt;Additional note&lt;/li&gt;&lt;/ol&gt;&lt;p&gt;This plugin is equipped with only three &lt;b&gt;time specific setting&lt;/b&gt;:&lt;/p&gt;&lt;ol&gt;&lt;li&gt;Step&lt;/li&gt;&lt;li&gt;Default&lt;br&gt;&lt;/li&gt;&lt;li&gt;Download format&lt;/li&gt;&lt;/ol&gt;&lt;p&gt;and with two more &lt;b&gt;validation options&lt;/b&gt;:&lt;/p&gt;&lt;ol&gt;&lt;li&gt;Lower bound&lt;/li&gt;&lt;li&gt;Upper bound&lt;/li&gt;&lt;/ol&gt;&lt;p&gt;The cartesian product of all these settings makes a very long list of possible implementations of this element. In this usertemplate few use cases are described.&lt;/p&gt;</content>
       <contentformat>1</contentformat>
       <indent>0</indent>
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -27,7 +27,7 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="time" version="2015123000">
+  <item type="field" plugin="time" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -44,13 +44,13 @@
       <variable>time_001</variable>
       <step>15</step>
       <defaultoption>2</defaultoption>
-      <defaultvalue>0</defaultvalue>
+      <defaultvalue>-3600</defaultvalue>
       <downloadformat>strftime01</downloadformat>
-      <lowerbound>14400</lowerbound>
-      <upperbound>32340</upperbound>
+      <lowerbound>10800</lowerbound>
+      <upperbound>28740</upperbound>
     </surveyprofield_time>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -64,7 +64,7 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="time" version="2015123000">
+  <item type="field" plugin="time" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -83,11 +83,11 @@
       <defaultoption>1</defaultoption>
       <defaultvalue>26100</defaultvalue>
       <downloadformat>strftime01</downloadformat>
-      <lowerbound>14400</lowerbound>
-      <upperbound>32340</upperbound>
+      <lowerbound>10800</lowerbound>
+      <upperbound>28740</upperbound>
     </surveyprofield_time>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -101,7 +101,7 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="time" version="2015123000">
+  <item type="field" plugin="time" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -118,13 +118,13 @@
       <variable>time_003</variable>
       <step>15</step>
       <defaultoption>4</defaultoption>
-      <defaultvalue>0</defaultvalue>
+      <defaultvalue>-3600</defaultvalue>
       <downloadformat>strftime01</downloadformat>
-      <lowerbound>14400</lowerbound>
-      <upperbound>32340</upperbound>
+      <lowerbound>10800</lowerbound>
+      <upperbound>28740</upperbound>
     </surveyprofield_time>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -138,7 +138,7 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="time" version="2015123000">
+  <item type="field" plugin="time" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -155,13 +155,13 @@
       <variable>time_004</variable>
       <step>15</step>
       <defaultoption>5</defaultoption>
-      <defaultvalue>0</defaultvalue>
+      <defaultvalue>-3600</defaultvalue>
       <downloadformat>strftime01</downloadformat>
-      <lowerbound>14400</lowerbound>
-      <upperbound>32340</upperbound>
+      <lowerbound>10800</lowerbound>
+      <upperbound>28740</upperbound>
     </surveyprofield_time>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -175,7 +175,7 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="time" version="2015123000">
+  <item type="field" plugin="time" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -192,13 +192,13 @@
       <variable>time_005</variable>
       <step>15</step>
       <defaultoption>3</defaultoption>
-      <defaultvalue>0</defaultvalue>
+      <defaultvalue>-3600</defaultvalue>
       <downloadformat>strftime01</downloadformat>
-      <lowerbound>14400</lowerbound>
-      <upperbound>32340</upperbound>
+      <lowerbound>10800</lowerbound>
+      <upperbound>28740</upperbound>
     </surveyprofield_time>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -212,7 +212,7 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="time" version="2015123000">
+  <item type="field" plugin="time" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -229,13 +229,13 @@
       <variable>time_006</variable>
       <step>15</step>
       <defaultoption>2</defaultoption>
-      <defaultvalue>0</defaultvalue>
+      <defaultvalue>-3600</defaultvalue>
       <downloadformat>strftime01</downloadformat>
-      <lowerbound>14400</lowerbound>
-      <upperbound>32340</upperbound>
+      <lowerbound>10800</lowerbound>
+      <upperbound>28740</upperbound>
     </surveyprofield_time>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -249,7 +249,7 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="time" version="2015123000">
+  <item type="field" plugin="time" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -268,11 +268,11 @@
       <defaultoption>1</defaultoption>
       <defaultvalue>26100</defaultvalue>
       <downloadformat>strftime01</downloadformat>
-      <lowerbound>14400</lowerbound>
-      <upperbound>32340</upperbound>
+      <lowerbound>10800</lowerbound>
+      <upperbound>28740</upperbound>
     </surveyprofield_time>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -286,7 +286,7 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="time" version="2015123000">
+  <item type="field" plugin="time" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -303,13 +303,13 @@
       <variable>time_008</variable>
       <step>15</step>
       <defaultoption>4</defaultoption>
-      <defaultvalue>0</defaultvalue>
+      <defaultvalue>-3600</defaultvalue>
       <downloadformat>strftime01</downloadformat>
-      <lowerbound>14400</lowerbound>
-      <upperbound>32340</upperbound>
+      <lowerbound>10800</lowerbound>
+      <upperbound>28740</upperbound>
     </surveyprofield_time>
   </item>
-  <item type="format" plugin="label" version="2015123000">
+  <item type="format" plugin="label" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -323,7 +323,7 @@
       <fullwidth>0</fullwidth>
     </surveyproformat_label>
   </item>
-  <item type="field" plugin="time" version="2015123000">
+  <item type="field" plugin="time" version="2017112201">
     <surveypro_item>
       <hidden>0</hidden>
       <insearchform>0</insearchform>
@@ -340,10 +340,10 @@
       <variable>time_009</variable>
       <step>15</step>
       <defaultoption>5</defaultoption>
-      <defaultvalue>0</defaultvalue>
+      <defaultvalue>-3600</defaultvalue>
       <downloadformat>strftime01</downloadformat>
-      <lowerbound>14400</lowerbound>
-      <upperbound>32340</upperbound>
+      <lowerbound>10800</lowerbound>
+      <upperbound>28740</upperbound>
     </surveyprofield_time>
   </item>
 </items>


### PR DESCRIPTION
Changed user templates in test/fixtures/usertemplates as the different management of the time (now it is no longer time-zone dependent) causes different way to save defaults, lowerbound and upperbound at item creation).
The idea is: if my answer to the question: "At what time you love to get dinner?" is "8 pm" then, even if you live in a place with a different time zone then your time-zone, when you go to read my answer you have to read "8 pm" and not the time at your cloch when it is 8 pm at my clock.