### PR TITLE
removed an apparently useless join

### DIFF
--- a/report/attachments/classes/filterform.php
+++ b/report/attachments/classes/filterform.php
@@ -89,11 +89,9 @@ class filterform extends \moodleform {
         $sql = 'SELECT DISTINCT u.id as userid'.$userfieldsapi->selects.'
                 FROM {user} u
                     JOIN {surveypro_submission} s ON s.userid = u.id';
-        if (!$canviewhiddenactivities) {
+        if (!$canviewhiddenactivities) { // Exclude global admins and managers.
             list($enrolsql, $eparams) = get_enrolled_sql($coursecontext);
-
-            $sql .= ' JOIN ('.$enrolsql.') eu ON eu.id = u.id
-                      JOIN {role_assignments} ra ON ra.userid = u.id';
+            $sql .= ' JOIN ('.$enrolsql.') eu ON eu.id = u.id';
         }
 
         $sql .= ' WHERE surveyproid = :surveyproid';


### PR DESCRIPTION
Without going deep in the semantic of the code, I think that the query starting in 
https://github.com/kordan/moodle-mod_surveypro/blob/master/report/attachments/classes/filterform.php#L89
is objectively unnecessarily complex.
I would simplify it as follows
From:
```
        $sql = 'SELECT DISTINCT u.id as userid'.$userfieldsapi->selects.'
                FROM {user} u
                    JOIN {surveypro_submission} s ON s.userid = u.id
                    JOIN ('.$enrolsql.') eu ON eu.id = u.id
                    JOIN {role_assignments} ra ON ra.userid = u.id
                WHERE surveyproid = :surveyproid
                ORDER BY u.lastname ASC';
```
to:
```
        $sql = 'SELECT DISTINCT u.id as userid'.$userfieldsapi->selects.'
                FROM {user} u
                    JOIN {surveypro_submission} s ON s.userid = u.id
                    JOIN ('.$enrolsql.') eu ON eu.id = u.id
                WHERE surveyproid = :surveyproid
                ORDER BY u.lastname ASC';
```
Do you agree?