### PR TITLE
Fixed wrong default for surveyprofield_multiselect

### DIFF
--- a/classes/itembase.php
+++ b/classes/itembase.php
@@ -825,17 +825,30 @@ class itembase {
      *
      * Used by layout_itemsetup->display_items_table() to define the icon to show
      *
+     * There are two types of fields.
+     * 1) those for which (like the boolean)
+     * defaultoption discriminates on the desired type of default: "Custom", "Invite", "No response"
+     * and, if defaultoption == "Custom", defaultvalue intervenes and declares which custom default is chosen.
+     *
+     * 2) those for which (like multiselect).
+     * noanswerdefault = 1 means "No response".
+     *
      * @return boolean
      */
     public function item_canbemandatory() {
-        if (property_exists($this, 'defaultoption')) {
+        $return = true;
+        if (isset($this->defaultoption)) {
             if ($this->defaultoption == SURVEYPRO_NOANSWERDEFAULT) {
                 $return = false;
             } else {
                 $return = true;
             }
-        } else {
-            $return = true;
+        } else if (isset($this->noanswerdefault)) {
+            if ($this->noanswerdefault == 1) {
+                $return = false;
+            } else {
+                $return = true;
+            }
         }
 
         return $return;

--- a/field/age/db/upgrade.php
+++ b/field/age/db/upgrade.php
@@ -34,7 +34,6 @@ function xmldb_surveyprofield_age_upgrade($oldversion) {
     $dbman = $DB->get_manager();
 
     if ($oldversion < 2014051701) {
-
         // Define key surveyproid (foreign) to be dropped form surveyprofield_age.
         $table = new xmldb_table('surveyprofield_age');
         $key = new xmldb_key('surveyproid', XMLDB_KEY_FOREIGN, ['surveyproid'], 'surveypro', ['id']);

--- a/field/autofill/db/upgrade.php
+++ b/field/autofill/db/upgrade.php
@@ -34,7 +34,6 @@ function xmldb_surveyprofield_autofill_upgrade($oldversion) {
     $dbman = $DB->get_manager();
 
     if ($oldversion < 2014051701) {
-
         // Define key surveyproid (foreign) to be dropped form surveyprofield_autofill.
         $table = new xmldb_table('surveyprofield_autofill');
         $key = new xmldb_key('surveyproid', XMLDB_KEY_FOREIGN, ['surveyproid'], 'surveypro', ['id']);

--- a/field/boolean/db/upgrade.php
+++ b/field/boolean/db/upgrade.php
@@ -34,7 +34,6 @@ function xmldb_surveyprofield_boolean_upgrade($oldversion) {
     $dbman = $DB->get_manager();
 
     if ($oldversion < 2014051701) {
-
         // Define key surveyproid (foreign) to be dropped form surveyprofield_boolean.
         $table = new xmldb_table('surveyprofield_boolean');
         $key = new xmldb_key('surveyproid', XMLDB_KEY_FOREIGN, ['surveyproid'], 'surveypro', ['id']);

--- a/field/character/db/upgrade.php
+++ b/field/character/db/upgrade.php
@@ -34,7 +34,6 @@ function xmldb_surveyprofield_character_upgrade($oldversion) {
     $dbman = $DB->get_manager();
 
     if ($oldversion < 2014051701) {
-
         // Define key surveyproid (foreign) to be dropped form surveyprofield_character.
         $table = new xmldb_table('surveyprofield_character');
         $key = new xmldb_key('surveyproid', XMLDB_KEY_FOREIGN, ['surveyproid'], 'surveypro', ['id']);
@@ -59,7 +58,6 @@ function xmldb_surveyprofield_character_upgrade($oldversion) {
     // Put any upgrade step following this.
 
     if ($oldversion < 2016062401) {
-
         // Define field trimonsave to be added to surveyprofield_character.
         $table = new xmldb_table('surveyprofield_character');
         $field = new xmldb_field('trimonsave', XMLDB_TYPE_INTEGER, '4', null, null, null, null, 'required');

--- a/field/checkbox/db/upgrade.php
+++ b/field/checkbox/db/upgrade.php
@@ -34,7 +34,6 @@ function xmldb_surveyprofield_checkbox_upgrade($oldversion) {
     $dbman = $DB->get_manager();
 
     if ($oldversion < 2014051701) {
-
         // Define key surveyproid (foreign) to be dropped form surveyprofield_checkbox.
         $table = new xmldb_table('surveyprofield_checkbox');
         $key = new xmldb_key('surveyproid', XMLDB_KEY_FOREIGN, ['surveyproid'], 'surveypro', ['id']);
@@ -56,7 +55,6 @@ function xmldb_surveyprofield_checkbox_upgrade($oldversion) {
     }
 
     if ($oldversion < 2014090501) {
-
         // Define field hideinstructions to be added to surveyprofield_checkbox.
         $table = new xmldb_table('surveyprofield_checkbox');
         $field = new xmldb_field('hideinstructions', XMLDB_TYPE_INTEGER, '4', null, null, null, null, 'required');
@@ -71,7 +69,6 @@ function xmldb_surveyprofield_checkbox_upgrade($oldversion) {
     }
 
     if ($oldversion < 2014090502) {
-
         // Define field required to be dropped from surveyprofield_checkbox.
         $table = new xmldb_table('surveyprofield_checkbox');
         $field = new xmldb_field('required');
@@ -86,7 +83,6 @@ function xmldb_surveyprofield_checkbox_upgrade($oldversion) {
     }
 
     if ($oldversion < 2014111701) {
-
         // Define field noanswerdefault to be added to surveyprofield_checkbox.
         $table = new xmldb_table('surveyprofield_checkbox');
         $field = new xmldb_field('noanswerdefault', XMLDB_TYPE_INTEGER, '2', null, XMLDB_NOTNULL, null, '2', 'defaultvalue');
@@ -101,7 +97,6 @@ function xmldb_surveyprofield_checkbox_upgrade($oldversion) {
     }
 
     if ($oldversion < 2015123000) {
-
         // Define field required to be added to surveyprofield_checkbox.
         $table = new xmldb_table('surveyprofield_checkbox');
         $field = new xmldb_field('required', XMLDB_TYPE_INTEGER, '2', null, XMLDB_NOTNULL, null, '2', 'extranote');
@@ -116,7 +111,6 @@ function xmldb_surveyprofield_checkbox_upgrade($oldversion) {
     }
 
     if ($oldversion < 2018091301) {
-
         // Define field maximumrequired to be added to surveyprofield_checkbox.
         $table = new xmldb_table('surveyprofield_checkbox');
         $field = new xmldb_field('maximumrequired', XMLDB_TYPE_INTEGER, '4', null, XMLDB_NOTNULL, null, '0', 'minimumrequired');

--- a/field/date/db/upgrade.php
+++ b/field/date/db/upgrade.php
@@ -34,7 +34,6 @@ function xmldb_surveyprofield_date_upgrade($oldversion) {
     $dbman = $DB->get_manager();
 
     if ($oldversion < 2014051701) {
-
         // Define key surveyproid (foreign) to be dropped form surveyprofield_date.
         $table = new xmldb_table('surveyprofield_date');
         $key = new xmldb_key('surveyproid', XMLDB_KEY_FOREIGN, ['surveyproid'], 'surveypro', ['id']);

--- a/field/datetime/db/upgrade.php
+++ b/field/datetime/db/upgrade.php
@@ -34,7 +34,6 @@ function xmldb_surveyprofield_datetime_upgrade($oldversion) {
     $dbman = $DB->get_manager();
 
     if ($oldversion < 2014051701) {
-
         // Define key surveyproid (foreign) to be dropped form surveyprofield_datetime.
         $table = new xmldb_table('surveyprofield_datetime');
         $key = new xmldb_key('surveyproid', XMLDB_KEY_FOREIGN, ['surveyproid'], 'surveypro', ['id']);

--- a/field/fileupload/db/upgrade.php
+++ b/field/fileupload/db/upgrade.php
@@ -34,7 +34,6 @@ function xmldb_surveyprofield_fileupload_upgrade($oldversion) {
     $dbman = $DB->get_manager();
 
     if ($oldversion < 2014051701) {
-
         // Define key surveyproid (foreign) to be dropped form surveyprofield_fileupload.
         $table = new xmldb_table('surveyprofield_fileupload');
         $key = new xmldb_key('surveyproid', XMLDB_KEY_FOREIGN, ['surveyproid'], 'surveypro', ['id']);
@@ -56,7 +55,6 @@ function xmldb_surveyprofield_fileupload_upgrade($oldversion) {
     }
 
     if ($oldversion < 2016072001) {
-
         // Define field hideinstructions to be added to surveyprofield_fileupload.
         $table = new xmldb_table('surveyprofield_fileupload');
         $field = new xmldb_field('hideinstructions', XMLDB_TYPE_INTEGER, '4', null, null, null, null, 'required');
@@ -72,7 +70,6 @@ function xmldb_surveyprofield_fileupload_upgrade($oldversion) {
 
     // Moodle core added the list of allowed extensions to fileupload elements, so my instructions are no longer needed.
     if ($oldversion < 2018042401) {
-
         // Define field hideinstructions to be dropped from surveyprofield_fileupload.
         $table = new xmldb_table('surveyprofield_fileupload');
         $field = new xmldb_field('hideinstructions');
@@ -87,7 +84,6 @@ function xmldb_surveyprofield_fileupload_upgrade($oldversion) {
     }
 
     if ($oldversion < 2018060501) {
-
         // Changing precision of field filetypes on table surveyprofield_fileupload to (64).
         $table = new xmldb_table('surveyprofield_fileupload');
         $field = new xmldb_field('filetypes', XMLDB_TYPE_CHAR, '64', null, null, null, null, 'maxbytes');

--- a/field/integer/db/upgrade.php
+++ b/field/integer/db/upgrade.php
@@ -34,7 +34,6 @@ function xmldb_surveyprofield_integer_upgrade($oldversion) {
     $dbman = $DB->get_manager();
 
     if ($oldversion < 2014051701) {
-
         // Define key surveyproid (foreign) to be dropped form surveyprofield_integer.
         $table = new xmldb_table('surveyprofield_integer');
         $key = new xmldb_key('surveyproid', XMLDB_KEY_FOREIGN, ['surveyproid'], 'surveypro', ['id']);
@@ -56,7 +55,6 @@ function xmldb_surveyprofield_integer_upgrade($oldversion) {
     }
 
     if ($oldversion < 2014090401) {
-
         // Define field hideinstructions to be dropped from surveyprofield_integer.
         $table = new xmldb_table('surveyprofield_integer');
         $field = new xmldb_field('hideinstructions');
@@ -71,7 +69,6 @@ function xmldb_surveyprofield_integer_upgrade($oldversion) {
     }
 
     if ($oldversion < 2016072001) {
-
         // Define field hideinstructions to be added to surveyprofield_fileupload.
         $table = new xmldb_table('surveyprofield_integer');
         $field = new xmldb_field('hideinstructions', XMLDB_TYPE_INTEGER, '4', null, null, null, null, 'required');

--- a/field/multiselect/classes/item.php
+++ b/field/multiselect/classes/item.php
@@ -93,11 +93,6 @@ class item extends itembase {
     protected $options;
 
     /**
-     * @var string Value of the field when the form is initially displayed
-     */
-    protected $defaultvalue;
-
-    /**
      * @var string Format of the content once downloaded
      */
     protected $downloadformat;

--- a/field/multiselect/db/upgrade.php
+++ b/field/multiselect/db/upgrade.php
@@ -34,7 +34,6 @@ function xmldb_surveyprofield_multiselect_upgrade($oldversion) {
     $dbman = $DB->get_manager();
 
     if ($oldversion < 2014051701) {
-
         // Define key surveyproid (foreign) to be dropped form surveyprofield_multiselect.
         $table = new xmldb_table('surveyprofield_multiselect');
         $key = new xmldb_key('surveyproid', XMLDB_KEY_FOREIGN, ['surveyproid'], 'surveypro', ['id']);
@@ -56,7 +55,6 @@ function xmldb_surveyprofield_multiselect_upgrade($oldversion) {
     }
 
     if ($oldversion < 2014090502) {
-
         // Define field hideinstructions to be added to surveyprofield_multiselect.
         $table = new xmldb_table('surveyprofield_multiselect');
         $field = new xmldb_field('hideinstructions', XMLDB_TYPE_INTEGER, '4', null, null, null, null, 'required');
@@ -89,7 +87,6 @@ function xmldb_surveyprofield_multiselect_upgrade($oldversion) {
     }
 
     if ($oldversion < 2015123000) {
-
         // Define field required to be added to surveyprofield_multiselect.
         $table = new xmldb_table('surveyprofield_multiselect');
         $field = new xmldb_field('required', XMLDB_TYPE_INTEGER, '2', null, XMLDB_NOTNULL, null, '2', 'extranote');
@@ -104,7 +101,6 @@ function xmldb_surveyprofield_multiselect_upgrade($oldversion) {
     }
 
     if ($oldversion < 2017062301) {
-
         // Define field noanswerdefault to be added to surveyprofield_multiselect.
         $table = new xmldb_table('surveyprofield_multiselect');
         $field = new xmldb_field('noanswerdefault', XMLDB_TYPE_INTEGER, '2', null, XMLDB_NOTNULL, null, '2', 'defaultvalue');
@@ -119,7 +115,6 @@ function xmldb_surveyprofield_multiselect_upgrade($oldversion) {
     }
 
     if ($oldversion < 2018091301) {
-
         // Define field maximumrequired to be added to surveyprofield_multiselect.
         $table = new xmldb_table('surveyprofield_multiselect');
         $field = new xmldb_field('maximumrequired', XMLDB_TYPE_INTEGER, '4', null, XMLDB_NOTNULL, null, '0', 'minimumrequired');
@@ -131,6 +126,26 @@ function xmldb_surveyprofield_multiselect_upgrade($oldversion) {
 
         // Multiselect savepoint reached.
         upgrade_plugin_savepoint(true, 2018091301, 'surveyprofield', 'multiselect');
+    }
+
+    if ($oldversion < 2023111401) {
+        // Changing the default of field noanswerdefault on table surveyprofield_multiselect to 0.
+        $table = new xmldb_table('surveyprofield_multiselect');
+        $field = new xmldb_field('noanswerdefault', XMLDB_TYPE_INTEGER, '2', null, XMLDB_NOTNULL, null, '0', 'defaultvalue');
+
+        // Launch change of default for field noanswerdefault.
+        $dbman->change_field_default($table, $field);
+
+        // Update old records still having noanswerdefault == 2.
+        $sql = 'UPDATE {surveyprofield_multiselect}
+                SET noanswerdefault = :newnoanswerdefault
+                WHERE noanswerdefault = :oldnoanswerdefault';
+        $whereparams = ['newnoanswerdefault' => 1, 'oldnoanswerdefault' => 2];
+
+        $DB->execute($sql, $whereparams);
+
+        // Multiselect savepoint reached.
+        upgrade_plugin_savepoint(true, 2023111401, 'surveyprofield', 'multiselect');
     }
 
     return true;

--- a/field/multiselect/version.php
+++ b/field/multiselect/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2018091301;
+$plugin->version = 2023111401;
 $plugin->release = '1.0';
 $plugin->requires = 2015111600; // Requires this Moodle version.
 $plugin->component = 'surveyprofield_multiselect'; // Full name of the plugin (used for diagnostics).

--- a/field/numeric/db/upgrade.php
+++ b/field/numeric/db/upgrade.php
@@ -34,7 +34,6 @@ function xmldb_surveyprofield_numeric_upgrade($oldversion) {
     $dbman = $DB->get_manager();
 
     if ($oldversion < 2014051701) {
-
         // Define key surveyproid (foreign) to be dropped form surveyprofield_numeric.
         $table = new xmldb_table('surveyprofield_numeric');
         $key = new xmldb_key('surveyproid', XMLDB_KEY_FOREIGN, ['surveyproid'], 'surveypro', ['id']);

--- a/field/radiobutton/db/upgrade.php
+++ b/field/radiobutton/db/upgrade.php
@@ -34,7 +34,6 @@ function xmldb_surveyprofield_radiobutton_upgrade($oldversion) {
     $dbman = $DB->get_manager();
 
     if ($oldversion < 2014051701) {
-
         // Define key surveyproid (foreign) to be dropped form surveyprofield_radiobutton.
         $table = new xmldb_table('surveyprofield_radiobutton');
         $key = new xmldb_key('surveyproid', XMLDB_KEY_FOREIGN, ['surveyproid'], 'surveypro', ['id']);

--- a/field/rate/db/upgrade.php
+++ b/field/rate/db/upgrade.php
@@ -34,7 +34,6 @@ function xmldb_surveyprofield_rate_upgrade($oldversion) {
     $dbman = $DB->get_manager();
 
     if ($oldversion < 2014051701) {
-
         // Define key surveyproid (foreign) to be dropped form surveyprofield_rate.
         $table = new xmldb_table('surveyprofield_rate');
         $key = new xmldb_key('surveyproid', XMLDB_KEY_FOREIGN, ['surveyproid'], 'surveypro', ['id']);

--- a/field/recurrence/db/upgrade.php
+++ b/field/recurrence/db/upgrade.php
@@ -34,7 +34,6 @@ function xmldb_surveyprofield_recurrence_upgrade($oldversion) {
     $dbman = $DB->get_manager();
 
     if ($oldversion < 2014051701) {
-
         // Define key surveyproid (foreign) to be dropped form surveyprofield_recurrence.
         $table = new xmldb_table('surveyprofield_recurrence');
         $key = new xmldb_key('surveyproid', XMLDB_KEY_FOREIGN, ['surveyproid'], 'surveypro', ['id']);

--- a/field/select/db/upgrade.php
+++ b/field/select/db/upgrade.php
@@ -34,7 +34,6 @@ function xmldb_surveyprofield_select_upgrade($oldversion) {
     $dbman = $DB->get_manager();
 
     if ($oldversion < 2014051701) {
-
         // Define key surveyproid (foreign) to be dropped form surveyprofield_select.
         $table = new xmldb_table('surveyprofield_select');
         $key = new xmldb_key('surveyproid', XMLDB_KEY_FOREIGN, ['surveyproid'], 'surveypro', ['id']);

--- a/field/shortdate/db/upgrade.php
+++ b/field/shortdate/db/upgrade.php
@@ -34,7 +34,6 @@ function xmldb_surveyprofield_shortdate_upgrade($oldversion) {
     $dbman = $DB->get_manager();
 
     if ($oldversion < 2014051701) {
-
         // Define key surveyproid (foreign) to be dropped form surveyprofield_shortdate.
         $table = new xmldb_table('surveyprofield_shortdate');
         $key = new xmldb_key('surveyproid', XMLDB_KEY_FOREIGN, ['surveyproid'], 'surveypro', ['id']);

--- a/field/textarea/db/upgrade.php
+++ b/field/textarea/db/upgrade.php
@@ -34,7 +34,6 @@ function xmldb_surveyprofield_textarea_upgrade($oldversion) {
     $dbman = $DB->get_manager();
 
     if ($oldversion < 2014051701) {
-
         // Define key surveyproid (foreign) to be dropped form surveyprofield_textarea.
         $table = new xmldb_table('surveyprofield_textarea');
         $key = new xmldb_key('surveyproid', XMLDB_KEY_FOREIGN, ['surveyproid'], 'surveypro', ['id']);
@@ -59,7 +58,6 @@ function xmldb_surveyprofield_textarea_upgrade($oldversion) {
     // Put any upgrade step following this.
 
     if ($oldversion < 2016062401) {
-
         // Define field trimonsave to be added to surveyprofield_textarea.
         $table = new xmldb_table('surveyprofield_textarea');
         $field = new xmldb_field('trimonsave', XMLDB_TYPE_INTEGER, '4', null, null, null, null, 'required');

--- a/field/time/db/upgrade.php
+++ b/field/time/db/upgrade.php
@@ -34,7 +34,6 @@ function xmldb_surveyprofield_time_upgrade($oldversion) {
     $dbman = $DB->get_manager();
 
     if ($oldversion < 2014051701) {
-
         // Define key surveyproid (foreign) to be dropped form surveyprofield_time.
         $table = new xmldb_table('surveyprofield_time');
         $key = new xmldb_key('surveyproid', XMLDB_KEY_FOREIGN, ['surveyproid'], 'surveypro', ['id']);

--- a/format/fieldset/db/upgrade.php
+++ b/format/fieldset/db/upgrade.php
@@ -34,7 +34,6 @@ function xmldb_surveyproformat_fieldset_upgrade($oldversion) {
     $dbman = $DB->get_manager();
 
     if ($oldversion < 2014051701) {
-
         // Define key surveyproid (foreign) to be dropped form surveyproformat_fieldset.
         $table = new xmldb_table('surveyproformat_fieldset');
         $key = new xmldb_key('surveyproid', XMLDB_KEY_FOREIGN, ['surveyproid'], 'surveypro', ['id']);
@@ -56,7 +55,6 @@ function xmldb_surveyproformat_fieldset_upgrade($oldversion) {
     }
 
     if ($oldversion < 2018091301) {
-
         // Define field defaultstatus to be added to surveyproformat_fieldset.
         $table = new xmldb_table('surveyproformat_fieldset');
         $field = new xmldb_field('defaultstatus', XMLDB_TYPE_INTEGER, '2', null, XMLDB_NOTNULL, null, '2', 'content');

--- a/format/fieldsetend/db/upgrade.php
+++ b/format/fieldsetend/db/upgrade.php
@@ -34,7 +34,6 @@ function xmldb_surveyproformat_fieldsetend_upgrade($oldversion) {
     $dbman = $DB->get_manager();
 
     if ($oldversion < 2014051701) {
-
         // Define key surveyproid (foreign) to be dropped form surveyproformat_fieldsetend.
         $table = new xmldb_table('surveyproformat_fieldsetend');
         $key = new xmldb_key('surveyproid', XMLDB_KEY_FOREIGN, ['surveyproid'], 'surveypro', ['id']);
@@ -56,7 +55,6 @@ function xmldb_surveyproformat_fieldsetend_upgrade($oldversion) {
     }
 
     if ($oldversion < 2019031901) {
-
         // Define table surveyproformat_fieldsetend to be dropped.
         $table = new xmldb_table('surveyproformat_fieldsetend');
 

--- a/format/label/db/upgrade.php
+++ b/format/label/db/upgrade.php
@@ -34,7 +34,6 @@ function xmldb_surveyproformat_label_upgrade($oldversion) {
     $dbman = $DB->get_manager();
 
     if ($oldversion < 2014051701) {
-
         // Define key surveyproid (foreign) to be dropped form surveyproformat_label.
         $table = new xmldb_table('surveyproformat_label');
         $key = new xmldb_key('surveyproid', XMLDB_KEY_FOREIGN, ['surveyproid'], 'surveypro', ['id']);

--- a/format/pagebreak/db/upgrade.php
+++ b/format/pagebreak/db/upgrade.php
@@ -34,7 +34,6 @@ function xmldb_surveyproformat_pagebreak_upgrade($oldversion) {
     $dbman = $DB->get_manager();
 
     if ($oldversion < 2014051701) {
-
         // Define key surveyproid (foreign) to be dropped form surveyproformat_pagebreak.
         $table = new xmldb_table('surveyproformat_pagebreak');
         $key = new xmldb_key('surveyproid', XMLDB_KEY_FOREIGN, ['surveyproid'], 'surveypro', ['id']);
@@ -56,7 +55,6 @@ function xmldb_surveyproformat_pagebreak_upgrade($oldversion) {
     }
 
     if ($oldversion < 2019031901) {
-
         // Define table surveyproformat_pagebreak to be dropped.
         $table = new xmldb_table('surveyproformat_pagebreak');
 


### PR DESCRIPTION
The issue, IMHO, is here since the very first release of surveypro.
Asking for the list of items (as teacher or admin, of course) the red dot icon allow the user to mark the item (the question corresponding to the item) as mandatory or not.
Of course, if the default of the item is "No answer", that item can NOT be set to mandatory. (if it is mandatory you can not answer: "I don't answer"!)
The user is supposed to change the default to a different value and ONLY AFTER he is allowed to set the item to mandatory.
Asking for the list of items, items type = 'multiselect' were equipped with the possibility to change them to mandatory or not mandatory WITHOUT CARE to the default. This was due to the routine "item_canbemandatory" in itembase.php that was not taking care of the way some item are marked as mandatory.
Actually there are two kind of items:
 1) those for which (like the boolean)
     defaultoption discriminates on the desired type of default: "Custom", "Invite", "No response"
     and, if defaultoption == "Custom", defaultvalue intervenes and declares which custom default is chosen.

 2) those for which (like multiselect).
     noanswerdefault = 1 means "No response".

I corrected the code and, in the frame of the correction, I found that the boolean field surveyprofield_multiselect.noanswerdefault was set to have 2 as default. Of course this is a nonsense.