### PR TITLE
Modified separators definition

### DIFF
--- a/field/checkbox/classes/item.php
+++ b/field/checkbox/classes/item.php
@@ -585,6 +585,7 @@ EOS;
 
             unset($attributes['group']);
             $attributes['id'] = $idprefix.'_text';
+            $attributes['class'] = 'checkbox_check';
             $elementgroup[] = $mform->createElement('text', $this->itemname.'_text', '', $attributes);
             $mform->setType($this->itemname.'_text', PARAM_RAW);
 

--- a/field/radiobutton/classes/item.php
+++ b/field/radiobutton/classes/item.php
@@ -558,6 +558,7 @@ EOS;
                                                     $otherlabel, 'other', $attributes);
 
             $attributes['id'] = $idprefix.'_text';
+            $attributes['class'] = 'radiobutton_radio';
             $elementgroup[] = $mform->createElement('text', $this->itemname.'_text', '', $attributes);
             $mform->setType($this->itemname.'_text', PARAM_RAW);
             $mform->disabledIf($this->itemname.'_text', $this->itemname, 'neq', 'other');
@@ -565,17 +566,19 @@ EOS;
 
         if (!$this->required) {
             $attributes['id'] = $idprefix.'_noanswer';
+            $attributes['class'] = 'indent-'.$this->indent.' radiobutton_radio';
             $elementgroup[] = $mform->createElement('mod_surveypro_radiobutton', $this->itemname, '',
                                                     $noanswerstr, SURVEYPRO_NOANSWERVALUE, $attributes);
         }
         // End of: mform element.
 
         // Begin of: definition of separator.
-        $labelcount = count($labels);
         if ($this->adjustment == SURVEYPRO_VERTICAL) {
-            $separator = array_fill(0, $labelcount - 1, '<br>');
-            if ($this->defaultoption == SURVEYPRO_INVITEDEFAULT) {
-                array_unshift($separator, '<br>');
+            $labelcount = count($labels);
+            if ($labelcount > 2) {
+                $separator = array_fill(0, $labelcount - 2, '<br>');
+            } else {
+                $separator = [];
             }
             if (!empty($this->labelother)) {
                 // $separator[] = '<br>';


### PR DESCRIPTION
Now vertical radio button with the option "other" and the field "specify" close the option "other" are correctly displayed. The "specify" field had a distance from the corresponding button proportional to the indent. Now this is no longer true.

In the frame of this PR I also copied the same solution (for the distance between checkbox and the "specify" field) to the checkbox item that was affected by the same problem.