### PR TITLE
Applied hack to align noanswer checkbox in rate item

### DIFF
--- a/field/rate/tests/behat/submit_rate.feature
+++ b/field/rate/tests/behat/submit_rate.feature
@@ -68,7 +68,6 @@ Feature: Submit using a rate item
       | id_surveypro_field_rate_2_2   | Not enought        |
       | id_surveypro_field_rate_2_3   | Completely unknown |
       | id_surveypro_field_rate_2_4   | Not enought        |
-
     And I press "Submit"
 
     And I press "Continue to responses list"


### PR DESCRIPTION
Changed the appearance of rate type questions from:

![Screenshot 2023-11-15 alle 11 34 58](https://github.com/kordan/moodle-mod_surveypro/assets/554353/e6fc9229-9d60-4052-b7eb-51fc1978753e)

to:

![Screenshot 2023-11-15 alle 11 35 26](https://github.com/kordan/moodle-mod_surveypro/assets/554353/3035d25b-eb65-4072-a3a4-442a38e1bb6c)

when the indent is different from zero.