### PR TITLE
Bump to m402

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -29,12 +29,12 @@ jobs:
       matrix:
         include:
           - php: 8.1
-            moodle-branch: MOODLE_401_STABLE
+            moodle-branch: MOODLE_402_STABLE
             database: mariadb
             suite: classic
             profile: default
           - php: 8.1
-            moodle-branch: MOODLE_401_STABLE
+            moodle-branch: MOODLE_402_STABLE
             database: pgsql
             suite: default
             profile: chrome

--- a/version.php
+++ b/version.php
@@ -26,6 +26,6 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_surveypro';
 $plugin->maturity = MATURITY_BETA;
-$plugin->version = 2023111101;
+$plugin->version = 2023042400;
 $plugin->release = '1.0';
-$plugin->requires = 2022041900;
+$plugin->requires = 2023042400;


### PR DESCRIPTION
It is supposed that this PR will be merge to master ONLY AFTER the release of MOODLE_401_STABLE.
It changes the moodle reference version and the required.