### PR TITLE
Removed unused $cm in get_groupmates

### DIFF
--- a/classes/submissions_form.php
+++ b/classes/submissions_form.php
@@ -1001,7 +1001,7 @@ class submissions_form extends formbase {
                     $mygroups = groups_get_all_groups($COURSE->id, $USER->id);
                     if (count($mygroups)) {
                         $utilitysubmissionman = new utility_submission($this->cm, $this->surveypro);
-                        $mygroupmates = $utilitysubmissionman->get_groupmates($this->cm);
+                        $mygroupmates = $utilitysubmissionman->get_groupmates();
                         $mysamegroup = in_array($ownerid, $mygroupmates);
                     } else {
                         // My group is the world so, for sure you are in my group.

--- a/classes/submissions_list.php
+++ b/classes/submissions_list.php
@@ -783,7 +783,7 @@ class submissions_list {
             $groupmode = groups_get_activity_groupmode($this->cm, $COURSE);
             if ($groupmode) { // Activity is divided into groups.
                 $utilitysubmissionman = new utility_submission($this->cm, $this->surveypro);
-                $mygroupmates = $utilitysubmissionman->get_groupmates($this->cm);
+                $mygroupmates = $utilitysubmissionman->get_groupmates();
             } else {
                 $mygroupmates = [];
             }
@@ -1574,7 +1574,7 @@ class submissions_list {
             $groupmode = groups_get_activity_groupmode($this->cm, $COURSE);
             if ($groupmode) { // Activity is divided into groups.
                 $utilitysubmissionman = new utility_submission($this->cm, $this->surveypro);
-                $mygroupmates = $utilitysubmissionman->get_groupmates($this->cm);
+                $mygroupmates = $utilitysubmissionman->get_groupmates();
                 $mysamegroup = in_array($ownerid, $mygroupmates);
             } else {
                 $mysamegroup = false;

--- a/classes/utility_submission.php
+++ b/classes/utility_submission.php
@@ -147,11 +147,10 @@ class utility_submission {
     /**
      * surveypro_groupmates
      *
-     * @param object $cm
      * @param int $userid Optional $userid: the user you want to know his/her groupmates
      * @return Array with the list of groupmates of the user
      */
-    public function get_groupmates($cm, $userid=0) {
+    public function get_groupmates($userid=0) {
         global $COURSE, $USER;
 
         if (empty($userid)) {


### PR DESCRIPTION
Actually get_groupmates method from classes/utility_submission.php
never uses the param $cm so I removed it.

```
     /**
      * surveypro_groupmates
      *
-     * @param object $cm
      * @param int $userid Optional $userid: the user you want to know his/her groupmates
      * @return Array with the list of groupmates of the user
      */
-    public function get_groupmates($cm, $userid=0) {
+    public function get_groupmates($userid=0) {
```