### PR TITLE
Added a routine to get separator master

### DIFF
--- a/classes/itembase.php
+++ b/classes/itembase.php
@@ -182,9 +182,9 @@ class itembase {
 
         $context = \context_module::instance($this->cm->id);
 
-        $tablename = 'surveypro'.$this->type.'_'.$this->plugin;
         // Some item, like pagebreak or fieldsetend, may be free of the plugin table.
         if ($this->uses_db_table()) {
+            $tablename = 'surveypro'.$this->type.'_'.$this->plugin;
             $sql = 'SELECT *, i.id as itemid, p.id as pluginid
                     FROM {surveypro_item} i
                       JOIN {'.$tablename.'} p ON p.itemid = i.id
@@ -1600,11 +1600,68 @@ EOS;
      * Set variable.
      *
      * @param string $variable
-     * @return the content of $variable property
+     * @return void
      */
     public function set_variable($variable) {
         $variable = format_string($variable);
         $this->variable = $variable;
+    }
+
+    /**
+     * Set defaultoption.
+     *
+     * Introduced as needed by unit test.
+     *
+     * @param string $defaultoption
+     * @return void
+     */
+    public function set_defaultoption($defaultoption) {
+        $condition = false;
+        $condition = $condition || ($defaultoption == SURVEYPRO_CUSTOMDEFAULT);
+        $condition = $condition || ($defaultoption == SURVEYPRO_INVITEDEFAULT);
+        $condition = $condition || ($defaultoption == SURVEYPRO_NOANSWERDEFAULT);
+        if (!$condition) {
+            $message = 'Passed defaultoption is not allowed.';
+            debugging($message, DEBUG_DEVELOPER);
+        }
+
+        $this->defaultoption = $defaultoption;
+    }
+
+    /**
+     * Set labelother.
+     *
+     * Introduced as needed by unit test.
+     *
+     * @param string $labelother
+     * @return void
+     */
+    public function set_labelother($labelother) {
+        $this->labelother = (string)$labelother;
+    }
+
+    /**
+     * Set required.
+     *
+     * Introduced as needed by unit test.
+     *
+     * @param string $required
+     * @return void
+     */
+    public function set_required($required) {
+        $this->labelother = $required;
+    }
+
+    /**
+     * Set options.
+     *
+     * Introduced as needed by unit test.
+     *
+     * @param string $options
+     * @return void
+     */
+    public function set_options($options) {
+        $this->options = $options;
     }
 
     // MARK parent.

--- a/field/radiobutton/classes/item.php
+++ b/field/radiobutton/classes/item.php
@@ -574,19 +574,7 @@ EOS;
 
         // Begin of: definition of separator.
         if ($this->adjustment == SURVEYPRO_VERTICAL) {
-            $labelcount = count($labels);
-            if ($labelcount > 2) {
-                $separator = array_fill(0, $labelcount - 2, '<br>');
-            } else {
-                $separator = [];
-            }
-            if (!empty($this->labelother)) {
-                // $separator[] = '<br>';
-                $separator[] = '';
-            }
-            if (!$this->required) {
-                $separator[] = '<br>';
-            }
+            $separator = $this->userform_get_separator();
         } else { // SURVEYPRO_HORIZONTAL.
             $separator = ' ';
         }
@@ -630,6 +618,55 @@ EOS;
             $mform->setDefault($this->itemname.'_text', $othervalue);
         }
         // End of: default section.
+    }
+
+    public function userform_get_separator(): array {
+        $labels = $this->get_content_array(SURVEYPRO_LABELS, 'options');
+        $optioncount = count($labels);
+        $invitation = ($this->defaultoption == SURVEYPRO_INVITEDEFAULT);
+        $addother = !empty($this->labelother);
+        $mandatory = $this->required;
+
+        $condition = true;
+        $condition = $condition && ($optioncount == 1);
+        $condition = $condition && (!$invitation);
+        $condition = $condition && (!$addother);
+        $condition = $condition && ($mandatory);
+        if ($condition) {
+            $message = 'Mandatory radio buttons with only one option and with no invite, no "other" option are not allowed';
+            debugging($message, DEBUG_DEVELOPER);
+        }
+
+        $separator = [];
+
+        // Invitation.
+        if ($invitation) {
+            $separator[] = '<br>'; // From "Invitation" to "Option 1".
+        }
+
+        // Options.
+        for ($i = 1; $i < $optioncount; $i++) {
+            $separator[] = '<br>'; // From "Option i" to "Option i+1".
+        }
+
+        if ( $addother || (!$mandatory) ) {
+            array_pop($separator); // Bloody workaround: drop a break.
+        }
+
+        // Other and no answer.
+        if ($addother) {
+            $separator[] = '<br>'; // From "Option N" to "Other".
+            $separator[] = ' '; // From "Other" to the corresponding "text field".
+            if (!$mandatory) {
+                $separator[] = '<br>'; // From the "text field" to "No answer".
+            }
+        } else {
+            if (!$mandatory) {
+                $separator[] = '<br>'; // From Option N to No answer.
+            }
+        }
+
+        return $separator;
     }
 
     /**

--- a/field/radiobutton/tests/behat/two_option_test.feature
+++ b/field/radiobutton/tests/behat/two_option_test.feature
@@ -1,0 +1,42 @@
+@mod @mod_surveypro
+Feature: Load and apply mum_or_dad_test usertemplates to test preview do not rise up errors
+  In order to test correct preview
+  As teacher1
+  I load mum_or_dad_test usertemplates and ask for preview
+
+  @javascript @_file_upload
+  Scenario: Test mum or dad displays correctly
+    Given the following "courses" exist:
+      | fullname           | shortname  | category | groupmode |
+      | Preview mum or dad | Mum or dad | 0        | 0         |
+    And the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | teacher  | teacher1@nowhere.net |
+    And the following "course enrolments" exist:
+      | user     | course     | role           |
+      | teacher1 | Mum or dad | editingteacher |
+    And the following "activities" exist:
+      | activity  | name                  | intro                             | course     |
+      | surveypro | Test two options only | Surveypro to test two options only | Mum or dad |
+
+    When I am on the "Test two options only" "mod_surveypro > User templates from secondary navigation" page logged in as "teacher1"
+    # now I am in the "Manage" page
+
+    And I select "Import" from the "jump" singleselect
+    And I upload "mod/surveypro/field/radiobutton/tests/fixtures/usertemplate/mum_or_dad_test.xml" file to "Choose files to import" filemanager
+
+    And I set the field "Sharing level" to "This course"
+    And I press "Import"
+
+    And I am on the "Test two options only" "mod_surveypro > User templates from secondary navigation" page
+    # now I am in the "Manage" page
+
+    And I select "Apply" from the "jump" singleselect
+    And I set the following fields to these values:
+      | User templates | (This course) mum_or_dad_test.xml |
+      | id_action_0    | 1                                 |
+    And I press "Apply"
+
+    # now I am in the Element > Manage page
+    And I select "Preview" from the "jump" singleselect
+    And I should see "Who do you love the most?"

--- a/field/radiobutton/tests/fixtures/usertemplate/mum_or_dad_test.xml
+++ b/field/radiobutton/tests/fixtures/usertemplate/mum_or_dad_test.xml
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="utf-8"?>
+<items>
+  <item type="field" plugin="radiobutton" version="2017112201">
+    <surveypro_item>
+      <hidden>0</hidden>
+      <insearchform>0</insearchform>
+      <reserved>0</reserved>
+    </surveypro_item>
+    <surveyprofield_radiobutton>
+      <content>Who do you love the most?</content>
+      <contentformat>1</contentformat>
+      <required>1</required>
+      <indent>0</indent>
+      <position>0</position>
+      <variable>radiobutton_test_test_01</variable>
+      <options>Mum
+Dad</options>
+      <defaultoption>1</defaultoption>
+      <defaultvalue>Dad</defaultvalue>
+      <downloadformat>1</downloadformat>
+      <adjustment>0</adjustment>
+    </surveyprofield_radiobutton>
+  </item>
+  <item type="field" plugin="radiobutton" version="2017112201">
+    <surveypro_item>
+      <hidden>0</hidden>
+      <insearchform>0</insearchform>
+      <reserved>0</reserved>
+    </surveypro_item>
+    <surveyprofield_radiobutton>
+      <content>Who do you love the most?</content>
+      <contentformat>1</contentformat>
+      <required>1</required>
+      <indent>0</indent>
+      <position>0</position>
+      <variable>radiobutton_test_02</variable>
+      <options>Mum
+Dad</options>
+      <defaultoption>2</defaultoption>
+      <downloadformat>1</downloadformat>
+      <adjustment>0</adjustment>
+    </surveyprofield_radiobutton>
+  </item>
+  <item type="field" plugin="radiobutton" version="2017112201">
+    <surveypro_item>
+      <hidden>0</hidden>
+      <insearchform>0</insearchform>
+      <reserved>0</reserved>
+    </surveypro_item>
+    <surveyprofield_radiobutton>
+      <content>Who do you love the most?</content>
+      <contentformat>1</contentformat>
+      <required>1</required>
+      <indent>0</indent>
+      <position>0</position>
+      <variable>radiobutton_test_04</variable>
+      <options>Mum
+Dad</options>
+      <labelother>Other (please, specify)</labelother>
+      <defaultoption>1</defaultoption>
+      <defaultvalue>Dad</defaultvalue>
+      <downloadformat>1</downloadformat>
+      <adjustment>0</adjustment>
+    </surveyprofield_radiobutton>
+  </item>
+  <item type="field" plugin="radiobutton" version="2017112201">
+    <surveypro_item>
+      <hidden>0</hidden>
+      <insearchform>0</insearchform>
+      <reserved>0</reserved>
+    </surveypro_item>
+    <surveyprofield_radiobutton>
+      <content>Who do you love the most?</content>
+      <contentformat>1</contentformat>
+      <required>1</required>
+      <indent>0</indent>
+      <position>0</position>
+      <variable>radiobutton_test_05</variable>
+      <options>Mum
+Dad</options>
+      <labelother>Other (please, specify)</labelother>
+      <defaultoption>2</defaultoption>
+      <downloadformat>1</downloadformat>
+      <adjustment>0</adjustment>
+    </surveyprofield_radiobutton>
+  </item>
+  <item type="field" plugin="radiobutton" version="2017112201">
+    <surveypro_item>
+      <hidden>0</hidden>
+      <insearchform>0</insearchform>
+      <reserved>0</reserved>
+    </surveypro_item>
+    <surveyprofield_radiobutton>
+      <content>Who do you love the most?</content>
+      <contentformat>1</contentformat>
+      <required>0</required>
+      <indent>0</indent>
+      <position>0</position>
+      <variable>radiobutton_test_07</variable>
+      <options>Mum
+Dad</options>
+      <defaultoption>1</defaultoption>
+      <defaultvalue>Dad</defaultvalue>
+      <downloadformat>1</downloadformat>
+      <adjustment>0</adjustment>
+    </surveyprofield_radiobutton>
+  </item>
+  <item type="field" plugin="radiobutton" version="2017112201">
+    <surveypro_item>
+      <hidden>0</hidden>
+      <insearchform>0</insearchform>
+      <reserved>0</reserved>
+    </surveypro_item>
+    <surveyprofield_radiobutton>
+      <content>Who do you love the most?</content>
+      <contentformat>1</contentformat>
+      <required>0</required>
+      <indent>0</indent>
+      <position>0</position>
+      <variable>radiobutton_test_08</variable>
+      <options>Mum
+Dad</options>
+      <defaultoption>2</defaultoption>
+      <downloadformat>1</downloadformat>
+      <adjustment>0</adjustment>
+    </surveyprofield_radiobutton>
+  </item>
+  <item type="field" plugin="radiobutton" version="2017112201">
+    <surveypro_item>
+      <hidden>0</hidden>
+      <insearchform>0</insearchform>
+      <reserved>0</reserved>
+    </surveypro_item>
+    <surveyprofield_radiobutton>
+      <content>Who do you love the most?</content>
+      <contentformat>1</contentformat>
+      <required>0</required>
+      <indent>0</indent>
+      <position>0</position>
+      <variable>radiobutton_test_09</variable>
+      <options>Mum
+Dad</options>
+      <defaultoption>3</defaultoption>
+      <downloadformat>1</downloadformat>
+      <adjustment>0</adjustment>
+    </surveyprofield_radiobutton>
+  </item>
+  <item type="field" plugin="radiobutton" version="2017112201">
+    <surveypro_item>
+      <hidden>0</hidden>
+      <insearchform>0</insearchform>
+      <reserved>0</reserved>
+    </surveypro_item>
+    <surveyprofield_radiobutton>
+      <content>Who do you love the most?</content>
+      <contentformat>1</contentformat>
+      <required>0</required>
+      <indent>0</indent>
+      <position>0</position>
+      <variable>radiobutton_test_10</variable>
+      <options>Mum
+Dad</options>
+      <labelother>Other (please, specify)</labelother>
+      <defaultoption>1</defaultoption>
+      <defaultvalue>Dad</defaultvalue>
+      <downloadformat>1</downloadformat>
+      <adjustment>0</adjustment>
+    </surveyprofield_radiobutton>
+  </item>
+  <item type="field" plugin="radiobutton" version="2017112201">
+    <surveypro_item>
+      <hidden>0</hidden>
+      <insearchform>0</insearchform>
+      <reserved>0</reserved>
+    </surveypro_item>
+    <surveyprofield_radiobutton>
+      <content>Who do you love the most?</content>
+      <contentformat>1</contentformat>
+      <required>0</required>
+      <indent>0</indent>
+      <position>0</position>
+      <variable>radiobutton_test_11</variable>
+      <options>Mum
+Dad</options>
+      <labelother>Other (please, specify)</labelother>
+      <defaultoption>2</defaultoption>
+      <downloadformat>1</downloadformat>
+      <adjustment>0</adjustment>
+    </surveyprofield_radiobutton>
+  </item>
+  <item type="field" plugin="radiobutton" version="2017112201">
+    <surveypro_item>
+      <hidden>0</hidden>
+      <insearchform>0</insearchform>
+      <reserved>0</reserved>
+    </surveypro_item>
+    <surveyprofield_radiobutton>
+      <content>Who do you love the most?</content>
+      <contentformat>1</contentformat>
+      <required>0</required>
+      <indent>0</indent>
+      <position>0</position>
+      <variable>radiobutton_test_12</variable>
+      <options>Mum
+Dad</options>
+      <labelother>Other (please, specify)</labelother>
+      <defaultoption>3</defaultoption>
+      <downloadformat>1</downloadformat>
+      <adjustment>0</adjustment>
+    </surveyprofield_radiobutton>
+  </item>
+</items>

--- a/tests/separator_test.php
+++ b/tests/separator_test.php
@@ -1,0 +1,171 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace mod_surveypro;
+
+use advanced_testcase;
+use surveyprofield_radiobutton;
+
+defined('MOODLE_INTERNAL') || die;
+
+global $CFG;
+require_once($CFG->dirroot.'/mod/surveypro/lib.php');
+
+/**
+ * The class to verify all the lib.php global functions do work as expected.
+ *
+ * @package   mod_surveypro
+ * @copyright 2015 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers    \surveyprofield_radiobutton
+ */
+class separator_test extends advanced_testcase {
+
+    /**
+     * Data provider for test_userform_get_separator()
+     *
+     * Cases to be tested by surveyprotemplate_get_plugin_name_provider
+     *
+     * 12 cases because 12 (3x2x2) is number of cases given from cartesian product of those three sets:
+     *     $itemman->defaultoption = SURVEYPRO_CUSTOMDEFAULT;   // Needed to define $invitation.
+     *     $itemman->defaultoption = SURVEYPRO_INVITEDEFAULT;   // Needed to define $invitation.
+     *     $itemman->defaultoption = SURVEYPRO_NOANSWERDEFAULT; // Needed to define $invitation.
+     *
+     *     $itemman->labelother = '';                        // Needed to define $addother.
+     *     $itemman->labelother = 'Other (please, specify)'; // Needed to define $addother.
+     *
+     *     $itemman->required = 1; // Needed to define $mandatory.
+     *     $itemman->required = 0; // Needed to define $mandatory.
+     */
+    public function userform_get_separator_provider(): array {
+        $userinput = [];
+        $userinput['defaultoption'] = SURVEYPRO_CUSTOMDEFAULT;
+        $userinput['labelother'] = '';
+        $userinput['required'] = 1;
+        $userinput['options'] = 'mum\ndad';
+        $expected = ['<br>', ' ', '<br>'];
+        $test01 = [$userinput, $expected];
+
+        $userinput['defaultoption'] = SURVEYPRO_INVITEDEFAULT;
+        $userinput['labelother'] = '';
+        $userinput['required'] = 1;
+        $userinput['options'] = 'mum\ndad';
+        $expected = ['<br>', ' ', '<br>'];
+        $test02 = [$userinput, $expected];
+
+        // Test03: defaultoption = SURVEYPRO_NOANSWERDEFAULT is not compatible with required = 1
+
+        $userinput['defaultoption'] = SURVEYPRO_CUSTOMDEFAULT;
+        $userinput['labelother'] = 'Other (please, specify)';
+        $userinput['required'] = 1;
+        $userinput['options'] = 'mum\ndad';
+        $expected = ['<br>', ' ', '<br>'];
+        $test04 = [$userinput, $expected];
+
+        $userinput['defaultoption'] = SURVEYPRO_INVITEDEFAULT;
+        $userinput['labelother'] = 'Other (please, specify)';
+        $userinput['required'] = 1;
+        $userinput['options'] = 'mum\ndad';
+        $expected = ['<br>', ' ', '<br>'];
+        $test05 = [$userinput, $expected];
+
+        // Test06: defaultoption = SURVEYPRO_NOANSWERDEFAULT is not compatible with required = 1
+
+        $userinput['defaultoption'] = SURVEYPRO_CUSTOMDEFAULT;
+        $userinput['labelother'] = '';
+        $userinput['required'] = 0;
+        $userinput['options'] = 'mum\ndad';
+        $expected = ['<br>'];
+        $test07 = [$userinput, $expected];
+
+        $userinput['defaultoption'] = SURVEYPRO_INVITEDEFAULT;
+        $userinput['labelother'] = '';
+        $userinput['required'] = 0;
+        $userinput['options'] = 'mum\ndad';
+        $expected = ['<br>'];
+        $test08 = [$userinput, $expected];
+
+        $userinput['defaultoption'] = SURVEYPRO_NOANSWERDEFAULT;
+        $userinput['labelother'] = '';
+        $userinput['required'] = 0;
+        $userinput['options'] = 'mum\ndad';
+        $expected = ['<br>'];
+        $test09 = [$userinput, $expected];
+
+        $userinput['defaultoption'] = SURVEYPRO_CUSTOMDEFAULT;
+        $userinput['labelother'] = 'Other (please, specify)';
+        $userinput['required'] = 0;
+        $userinput['options'] = 'mum\ndad';
+        $expected = ['<br>'];
+        $test10 = [$userinput, $expected];
+
+        $userinput['defaultoption'] = SURVEYPRO_INVITEDEFAULT;
+        $userinput['labelother'] = 'Other (please, specify)';
+        $userinput['required'] = 0;
+        $userinput['options'] = 'mum\ndad';
+        $expected = ['<br>'];
+        $test11 = [$userinput, $expected];
+
+        $userinput['defaultoption'] = SURVEYPRO_NOANSWERDEFAULT;
+        $userinput['labelother'] = 'Other (please, specify)';
+        $userinput['required'] = 0;
+        $userinput['options'] = 'mum\ndad';
+        $expected = ['<br>'];
+        $test12 = [$userinput, $expected];
+
+        return [
+            $test01,
+            $test02,
+            $test04,
+            $test05,
+            $test07,
+            $test08,
+            $test09,
+            $test10,
+            $test11,
+            $test12,
+        ];
+    }
+
+    /**
+     * test_userform_get_separator
+     *
+     * @dataProvider userform_get_separator_provider
+     * @param object $userinput The passed user input
+     * @param object $expected The expected result
+     */
+    public function test_userform_get_separator($userinput, $expected) {
+        $this->resetAfterTest();
+        $this->setAdminUser();
+
+        $course = $this->getDataGenerator()->create_course();
+        $params = ['course' => $course->id, 'name' => 'One more surveypro'];
+        $surveypro = $this->getDataGenerator()->create_module('surveypro', $params);
+        $cm = get_coursemodule_from_instance('surveypro', $surveypro->id);
+        $context = \context_module::instance($cm->id);
+
+        $itemman = new surveyprofield_radiobutton\item($cm, $surveypro, null, false);
+
+        // Define parameters.
+        $itemman->set_defaultoption($userinput['defaultoption']); // Needed to define $invitation.
+        $itemman->set_labelother($userinput['labelother']);       // Needed to define $addother.
+        $itemman->set_required($userinput['required']);           // Needed to define $mandatory.
+        $itemman->set_options($userinput['options']);             // Needed to define $labels.
+
+        $returned = $itemman->userform_get_separator();
+        $this->assertEquals($expected, $returned);
+    }
+}


### PR DESCRIPTION
Radio button questions with only two options are, in my mind, boolean questions.
This is not true in the mind of some teacher using surveypro.

If you create a surveypro with a radiobutton item with the simple question: Who do you love the most? with:
-  "Choose..." at the beginning (default = invitation);
- mandatory;
- with only two options: "mum" and "dad"
surveypro crashes.

This PR fixes this issue due to wrong definition of the separator between item elements.