### PR TITLE
fixed number validation master

### DIFF
--- a/field/numeric/classes/item.php
+++ b/field/numeric/classes/item.php
@@ -231,12 +231,9 @@ class item extends itembase {
         if (core_text::strlen($this->defaultvalue)) {
             $this->defaultvalue = format_float($this->defaultvalue, $this->decimals);
         }
-        if (core_text::strlen($this->lowerbound)) {
-            $this->lowerbound = format_float($this->lowerbound, $this->decimals);
-        }
-        if (core_text::strlen($this->upperbound)) {
-            $this->upperbound = format_float($this->upperbound, $this->decimals);
-        }
+        // $this->lowerbound and $this->upperbound comes from db and are correctly written.
+        // I am not going to put them in a field so I can leave them well written
+        // instead of changing them according to the local language
     }
 
     /**
@@ -260,17 +257,17 @@ class item extends itembase {
         if (core_text::strlen($record->defaultvalue)) {
             $record->defaultvalue = $this->get_correct_number($record->defaultvalue);
         } else {
-            unset($record->defaultvalue);
+            $record->defaultvalue = null;
         }
         if (core_text::strlen($record->lowerbound)) {
             $record->lowerbound = $this->get_correct_number($record->lowerbound);
         } else {
-            unset($record->lowerbound);
+            $record->lowerbound = null;
         }
         if (core_text::strlen($record->upperbound)) {
             $record->upperbound = $this->get_correct_number($record->upperbound);
         } else {
-            unset($record->upperbound);
+            $record->upperbound = null;
         }
     }
 
@@ -446,7 +443,7 @@ EOS;
         }
 
         $userinput = $this->get_correct_number($draftuserinput);
-        if ($userinput === false) {
+        if (!is_numeric($userinput)) {
             // It is not a number, shouts.
             $errors[$errorkey] = get_string('uerr_notanumber', 'surveyprofield_numeric');
             return;

--- a/field/numeric/classes/itemsetupform.php
+++ b/field/numeric/classes/itemsetupform.php
@@ -106,19 +106,19 @@ class itemsetupform extends item_setupbaseform {
 
         $errors = parent::validation($data, $files);
 
-        $draftnumber = $data['lowerbound'];
         // Get lowerbound.
-        if (core_text::strlen($draftnumber)) {
-            if (!$lowerbound = $item->get_correct_number($draftnumber)) {
+        if (core_text::strlen($data['lowerbound'])) {
+            $lowerbound = $item->get_correct_number($data['lowerbound']);
+            if (!is_numeric($lowerbound)) {
                 $errors['lowerbound'] = get_string('ierr_notanumber', 'surveyprofield_numeric');
                 return $errors;
             }
         }
 
-        $draftnumber = $data['upperbound'];
         // Get upperbound.
-        if (core_text::strlen($draftnumber)) {
-            if (!$upperbound = $item->get_correct_number($draftnumber)) {
+        if (core_text::strlen($data['upperbound'])) {
+            $upperbound = $item->get_correct_number($data['upperbound']);
+            if (!is_numeric($upperbound)) {
                 $errors['upperbound'] = get_string('ierr_notanumber', 'surveyprofield_numeric');
                 return $errors;
             }
@@ -142,10 +142,10 @@ class itemsetupform extends item_setupbaseform {
             }
         }
 
-        $draftnumber = $data['defaultvalue'];
         // Get defaultvalue.
-        if (core_text::strlen($draftnumber)) {
-            if (!$defaultvalue = $item->get_correct_number($draftnumber)) {
+        if (core_text::strlen($data['defaultvalue'])) {
+            $defaultvalue = $item->get_correct_number($data['defaultvalue']);
+            if (!is_numeric($defaultvalue)) {
                 $errors['defaultvalue'] = get_string('ierr_notanumber', 'surveyprofield_numeric');
             } else {
                 // Constrain default between boundaries.


### PR DESCRIPTION
This PR fixes two errors regarding numeric sub-plugin.
Crate an item type numeric providing, for instance, a lowerbound.
Edit the item and try to wipe the lowerbound. It is not deleted.

Going to fill a form providing 0,0 (in italian) as number the number is wrongly classified as not a number.