### PR TITLE
Increased version from 2023111102 to 2023111103

### DIFF
--- a/version.php
+++ b/version.php
@@ -26,6 +26,6 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_surveypro';
 $plugin->maturity = MATURITY_BETA;
-$plugin->version = 2023111102;
+$plugin->version = 2023111103;
 $plugin->release = '4.1.2';
 $plugin->requires = 2022041900;


### PR DESCRIPTION
because the first release I uploaded had, wrongly, this same version number.
Now the upload page of the plugin database does not allow me to upload one more relese with the same veversion nor to drop the old version.