### PR TITLE
Added userform_get_separator to checkboxes too (master)

### DIFF
--- a/field/checkbox/classes/item.php
+++ b/field/checkbox/classes/item.php
@@ -610,19 +610,7 @@ EOS;
         }
 
         if ($this->adjustment == SURVEYPRO_VERTICAL) {
-            $labelcount = count($labels);
-            if ($labelcount > 1) {
-                $separator = array_fill(0, $labelcount - 1, '<br>');
-            } else {
-                $separator = [];
-            }
-            if (!empty($this->labelother)) {
-                // $separator[] = '<br>';
-                $separator[] = '';
-            }
-            if (!$this->required) {
-                $separator[] = '<br>';
-            }
+            $separator = $this->userform_get_separator();
         } else { // SURVEYPRO_HORIZONTAL.
             $separator = ' ';
         }
@@ -652,6 +640,47 @@ EOS;
                 $mform->_required[] = $starplace;
             }
         }
+    }
+
+    /**
+     * Define the separator needed to create the userform element.
+     *
+     * There is an issue I do not raise up because it is definitely not relevant.
+     * Checkbox type items with the "Other" option in addition to a single option
+     * cannot be shown vertically unless I miss the alignment between
+     * the "Other" option and the corresponding text field.
+     *
+     * @return array $separator
+     */
+    public function userform_get_separator(): array {
+        $labels = $this->get_content_array(SURVEYPRO_LABELS, 'options');
+        $optioncount = count($labels);
+        $addother = !empty($this->labelother);
+        $mandatory = $this->required;
+
+        $separator = [];
+
+        // Options.
+        for ($i = 1; $i < $optioncount; $i++) {
+            $separator[] = '<br>'; // From "Option i" to "Option i+1".
+        }
+
+        // Other and no answer.
+        if ($addother) {
+            $separator[] = '<br>'; // From "Option N" to "Other".
+            $separator[] = ' '; // From "Other" to the corresponding "text field".
+            if (!$mandatory) {
+                $separator[] = '<br>'; // From the "text field" to "No answer".
+            }
+        } else {
+            if (!$mandatory) {
+                $separator[] = '<br>'; // From Option N to "No answer".
+            }
+        }
+
+        array_shift($separator); // Bloody workaround: drop first break.
+
+        return $separator;
     }
 
     /**

--- a/field/radiobutton/classes/item.php
+++ b/field/radiobutton/classes/item.php
@@ -620,6 +620,11 @@ EOS;
         // End of: default section.
     }
 
+    /**
+     * Define the separator needed to create the userform element.
+     *
+     * @return array $separator
+     */
     public function userform_get_separator(): array {
         $labels = $this->get_content_array(SURVEYPRO_LABELS, 'options');
         $optioncount = count($labels);
@@ -632,7 +637,7 @@ EOS;
         $condition = $condition && (!$invitation);
         $condition = $condition && (!$addother);
         $condition = $condition && ($mandatory);
-        if ($condition) {
+        if ($condition) { // This message should never appear because corresponding item setupform should not allow this case.
             $message = 'Mandatory radio buttons with only one option and with no invite, no "other" option are not allowed';
             debugging($message, DEBUG_DEVELOPER);
         }
@@ -650,7 +655,7 @@ EOS;
         }
 
         if ( $addother || (!$mandatory) ) {
-            array_pop($separator); // Bloody workaround: drop a break.
+            array_pop($separator); // Bloody workaround: drop last break.
         }
 
         // Other and no answer.
@@ -662,7 +667,7 @@ EOS;
             }
         } else {
             if (!$mandatory) {
-                $separator[] = '<br>'; // From Option N to No answer.
+                $separator[] = '<br>'; // From "Option N" to "No answer".
             }
         }
 


### PR DESCRIPTION
For consistency with what was done for radiobutton type items, I added the userform_get_separator method to checkbox type items, too. Unlike what I did for radiobutton items, however, I cannot add a unit test here because it would fail. The error is described in the  comment of the method itself.

This PR should be cherry-picked to MOODLE_401_STABLE, MOODLE_402_STABLE and MOODLE_403_STABLE.