### PR TITLE
Replaced require_login with require_course_login

### DIFF
--- a/tools.php
+++ b/tools.php
@@ -55,9 +55,9 @@ if (!empty($id)) {
     $course = $DB->get_record('course', ['id' => $surveypro->course], '*', MUST_EXIST);
     $cm = get_coursemodule_from_instance('surveypro', $surveypro->id, $course->id, false, MUST_EXIST);
 }
+
 $cm = cm_info::create($cm);
-// require_course_login($course, false, $cm);
-require_login($course);
+require_course_login($course, false, $cm);
 $context = \context_module::instance($cm->id);
 
 // Utilitypage is going to be used in each section. This is the reason why I load it here.


### PR DESCRIPTION
With this change the use of the toggle button "Edit mode" (using the theme "boost") restarted to work for the tools page too. The strange behaviour of the missing (or repeated) breadcrumb element "tool" (using the theme "classic") is still alive.

This PR should be cherry-picked to MOODLE_401|402|403_STABLE too.