### PR TITLE
Unified the acquisition of $edit at the beginning of the file

### DIFF
--- a/classes/reportbase.php
+++ b/classes/reportbase.php
@@ -94,15 +94,6 @@ abstract class reportbase {
     abstract public static function get_displayusernames();
 
     /**
-     * Get child reports.
-     *
-     * @return boolean
-     */
-    public function get_haschildrenreports() {
-        return false;
-    }
-
-    /**
      * Prevent direct user input.
      *
      * @return void
@@ -233,6 +224,15 @@ abstract class reportbase {
     // MARK set.
 
     /**
+     * set_additionalparams.
+     *
+     * Sets the parameters to be supplied to the url to call the specific report page
+     */
+    public function set_additionalparams() {
+        $this->additionalparams = ['optional' => [], 'required' => []];
+    }
+
+    /**
      * Set the groupid.
      *
      * @param int $groupid
@@ -242,6 +242,15 @@ abstract class reportbase {
     }
 
     // MARK get.
+
+    /**
+     * Get child reports.
+     *
+     * @return boolean
+     */
+    public function get_haschildrenreports() {
+        return false;
+    }
 
     /**
      * Get the list of groups the user is allowed to browse
@@ -328,15 +337,6 @@ abstract class reportbase {
 
         $whereparams = array_merge($whereparams, $eparams);
         return [$sql, $whereparams];
-    }
-
-    /**
-     * set_additionalparams.
-     *
-     * Sets the parameters to be supplied to the url to call the specific report page
-     */
-    public function set_additionalparams() {
-        $this->additionalparams = ['optional' => [], 'required' => []];
     }
 
     /**

--- a/classes/submissions_form.php
+++ b/classes/submissions_form.php
@@ -623,6 +623,7 @@ class submissions_form extends formbase {
                 }
             }
         }
+        // End of: get the list of all mandatory fields.
 
         // Make only ONE query taking ALL the answer provided in the frame of this submission.
         // (and, implicitally, for this surveypro).

--- a/layout.php
+++ b/layout.php
@@ -43,6 +43,7 @@ require_once(dirname(__FILE__).'/../../config.php');
 $id = optional_param('id', 0, PARAM_INT);                          // Course_module id.
 $s = optional_param('s', 0, PARAM_INT);                            // Surveypro instance id.
 $section = optional_param('section', 'itemslist', PARAM_ALPHAEXT); // The section of code to execute.
+$edit = optional_param('edit', -1, PARAM_BOOL);
 
 // Verify I used correct names all along the module code.
 $validsections = ['preview', 'itemslist', 'itemsetup', 'branchingvalidation'];
@@ -72,7 +73,6 @@ $utilitypageman = new utility_page($cm, $surveypro);
 // MARK preview.
 if ($section == 'preview') { // It was layout_validation.php
     // Get additional specific params.
-    $edit = optional_param('edit', -1, PARAM_BOOL);
     $submissionid = optional_param('submissionid', 0, PARAM_INT);
     $formpage = optional_param('formpage', 1, PARAM_INT); // Form page number.
     $overflowpage = optional_param('overflowpage', 0, PARAM_INT); // Went the user to a overflow page?
@@ -175,7 +175,6 @@ if ($section == 'preview') { // It was layout_validation.php
 
 // MARK itemslist.
 if ($section == 'itemslist') { // It was layout_itemlist.php.
-    $edit = optional_param('edit', -1, PARAM_BOOL);
     // Get additional specific params.
     $type = optional_param('type', null, PARAM_TEXT);
     $plugin = optional_param('plugin', null, PARAM_TEXT);
@@ -229,7 +228,7 @@ if ($section == 'itemslist') { // It was layout_itemlist.php.
     $basecondition = $basecondition && empty($surveypro->template);
     $basecondition = $basecondition && (!$hassubmissions || $riskyediting);
 
-    // New item form.
+    // Begin of: New item form.
     $newitemcondition = $basecondition && has_capability('mod/surveypro:additems', $context);
     if ($newitemcondition) {
         $paramurl = ['s' => $cm->instance, 'section' => 'itemsetup', 'mode' => SURVEYPRO_NEWITEM];
@@ -244,7 +243,7 @@ if ($section == 'itemslist') { // It was layout_itemlist.php.
     $templatecondition = $basecondition && (!$itemcount);
     $templatecondition = $templatecondition && has_capability('mod/surveypro:manageitems', $context);
     if ($templatecondition) {
-        // User templates form.
+        // Begin of: User templates form.
         $utemplateman = new usertemplate($cm, $context, $surveypro);
         $utemplates = $utemplateman->get_utemplates_items();
         if (count($utemplates)) {
@@ -257,7 +256,7 @@ if ($section == 'itemslist') { // It was layout_itemlist.php.
         }
         // End of: User templates form.
 
-        // Master templates form.
+        // Begin of: Master templates form.
         $mtemplateman = new mastertemplate($cm, $context, $surveypro);
         $mtemplates = $mtemplateman->get_mtemplates();
         if (count($mtemplates)) {
@@ -272,7 +271,7 @@ if ($section == 'itemslist') { // It was layout_itemlist.php.
     }
     // End of: Templates.
 
-    // Bulk action form.
+    // Begin of: Bulk action form.
     $bulkactioncondition = $basecondition && $itemcount;
     $bulkactioncondition = $bulkactioncondition && has_capability('mod/surveypro:manageitems', $context);
     if ($bulkactioncondition) {
@@ -287,6 +286,7 @@ if ($section == 'itemslist') { // It was layout_itemlist.php.
             $layoutman->set_action($formdata->bulkaction);
         }
     }
+    // End of: Bulk action form.
 
     // Output starts here.
     $url = new \moodle_url('/mod/surveypro/layout.php', ['s' => $surveypro->id, 'section' => 'itemslist']);
@@ -353,7 +353,6 @@ if ($section == 'itemslist') { // It was layout_itemlist.php.
 // MARK itemsetup.
 if ($section == 'itemsetup') { // It was layout_itemsetup.php
     // Get additional specific params.
-    $edit = optional_param('edit', -1, PARAM_BOOL);
     $typeplugin = optional_param('typeplugin', null, PARAM_TEXT);
     $type = optional_param('type', null, PARAM_TEXT);
     $plugin = optional_param('plugin', null, PARAM_TEXT);
@@ -494,7 +493,6 @@ if ($section == 'itemsetup') { // It was layout_itemsetup.php
 // MARK branchingvalidation.
 if ($section == 'branchingvalidation') { // It was layout_validation.php
     // Get additional specific params.
-    $edit = optional_param('edit', -1, PARAM_BOOL);
 
     // Required capability.
     require_capability('mod/surveypro:additems', $context);

--- a/mtemplates.php
+++ b/mtemplates.php
@@ -37,6 +37,7 @@ require_once(dirname(__FILE__).'/../../config.php');
 $id = optional_param('id', 0, PARAM_INT); // Course_module id.
 $s = optional_param('s', 0, PARAM_INT);   // Surveypro instance id.
 $section = optional_param('section', 'save', PARAM_ALPHAEXT); // The section of code to execute.
+$edit = optional_param('edit', -1, PARAM_BOOL);
 
 // Verify I used correct names all along the module code.
 $validsections = ['save', 'apply'];
@@ -66,7 +67,6 @@ $utilitypageman = new utility_page($cm, $surveypro);
 // MARK save.
 if ($section == 'save') { // It was mtemplate_save.php
     // Get additional specific params.
-    $edit = optional_param('edit', -1, PARAM_BOOL);
 
     // Required capability.
     require_capability('mod/surveypro:savemastertemplates', $context);
@@ -114,7 +114,6 @@ if ($section == 'save') { // It was mtemplate_save.php
 // MARK apply.
 if ($section == 'apply') { // It was mtemplate_apply.php
     // Get additional specific params.
-    $edit = optional_param('edit', -1, PARAM_BOOL);
 
     // Required capability.
     require_capability('mod/surveypro:applymastertemplates', $context);

--- a/report/attachments/classes/report.php
+++ b/report/attachments/classes/report.php
@@ -45,30 +45,12 @@ class report extends reportbase {
     public $outputtable = null;
 
     /**
-     * Is this report equipped with student reports.
-     *
-     * @return boolean
-     */
-    public static function get_hasstudentreport() {
-        return false;
-    }
-
-    /**
      * Does the current report apply to the passed mastertemplates?
      *
      * @param string $mastertemplate
      * @return boolean
      */
     public function report_applies_to($mastertemplate) {
-        return true;
-    }
-
-    /**
-     * Get if this report displays user names.
-     *
-     * @return boolean
-     */
-    public static function get_displayusernames() {
         return true;
     }
 
@@ -188,32 +170,6 @@ class report extends reportbase {
     }
 
     /**
-     * Get_submissions_sql
-     *
-     * @return [$sql, $whereparams];
-     */
-    public function get_submissions_sql() {
-        global $COURSE, $DB;
-
-        $userfieldsapi = \core_user\fields::for_userpic()->get_sql('u');
-        $whereparams = [];
-        $sql = 'SELECT s.id as submissionid'.$userfieldsapi->selects.'
-                FROM {user} u
-                JOIN {surveypro_submission} s ON s.userid = u.id';
-
-        [$middlesql, $whereparams] = $this->get_middle_sql();
-        $sql .= $middlesql;
-
-        if ($this->outputtable->get_sql_sort()) {
-            $sql .= ' ORDER BY '.$this->outputtable->get_sql_sort().', submissionid ASC';
-        } else {
-            $sql .= ' ORDER BY u.lastname ASC, submissionid ASC';
-        }
-
-        return [$sql, $whereparams];
-    }
-
-    /**
      * Output_data.
      *
      * @return void
@@ -243,6 +199,8 @@ class report extends reportbase {
         }
     }
 
+    // MARK set.
+
     /**
      * set_additionalparams.
      *
@@ -257,5 +215,51 @@ class report extends reportbase {
                 'section' => PARAM_ALPHA,
             ],
         ];
+    }
+
+    // MARK get.
+
+    /**
+     * Is this report equipped with student reports.
+     *
+     * @return boolean
+     */
+    public static function get_hasstudentreport() {
+        return false;
+    }
+
+    /**
+     * Get if this report displays user names.
+     *
+     * @return boolean
+     */
+    public static function get_displayusernames() {
+        return true;
+    }
+
+    /**
+     * Get_submissions_sql
+     *
+     * @return [$sql, $whereparams];
+     */
+    public function get_submissions_sql() {
+        global $COURSE, $DB;
+
+        $userfieldsapi = \core_user\fields::for_userpic()->get_sql('u');
+        $whereparams = [];
+        $sql = 'SELECT s.id as submissionid'.$userfieldsapi->selects.'
+                FROM {user} u
+                JOIN {surveypro_submission} s ON s.userid = u.id';
+
+        [$middlesql, $whereparams] = $this->get_middle_sql();
+        $sql .= $middlesql;
+
+        if ($this->outputtable->get_sql_sort()) {
+            $sql .= ' ORDER BY '.$this->outputtable->get_sql_sort().', submissionid ASC';
+        } else {
+            $sql .= ' ORDER BY u.lastname ASC, submissionid ASC';
+        }
+
+        return [$sql, $whereparams];
     }
 }

--- a/report/attachments/view.php
+++ b/report/attachments/view.php
@@ -22,6 +22,8 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use mod_surveypro\utility_page;
+
 // Needed only if $section == 'view'.
 use surveyproreport_attachments\groupjumperform;
 use surveyproreport_attachments\report;
@@ -36,6 +38,7 @@ require_once($CFG->libdir.'/tablelib.php');
 $id = optional_param('id', 0, PARAM_INT);
 $s = optional_param('s', 0, PARAM_INT);
 $section = optional_param('section', 'view', PARAM_TEXT); // The section of code to execute.
+$edit = optional_param('edit', -1, PARAM_BOOL);
 
 // Verify I used correct names all along the module code.
 $validsections = ['view', 'details'];
@@ -59,6 +62,9 @@ $cm = cm_info::create($cm);
 require_course_login($course, false, $cm);
 $context = \context_module::instance($cm->id);
 
+// Utilitypage is going to be used in each section. This is the reason why I load it here.
+$utilitypageman = new utility_page($cm, $surveypro);
+
 // MARK view.
 if ($section == 'view') { // It was view_cover.php
     $groupid = optional_param('groupid', 0, PARAM_INT);
@@ -75,6 +81,8 @@ if ($section == 'view') { // It was view_cover.php
     $PAGE->set_heading($course->shortname);
     // Is it useful? $PAGE->add_body_class('mediumwidth');.
     // End of: set $PAGE deatils.
+
+    $utilitypageman->manage_editbutton($edit);
 
     $reportman = new report($cm, $context, $surveypro);
     $reportman->set_groupid($groupid);
@@ -156,6 +164,8 @@ if ($section == 'details') { // It was report/attachments/uploads.php
     $PAGE->set_heading($course->shortname);
     // Is it useful? $PAGE->add_body_class('mediumwidth');.
     // End of: set $PAGE deatils.
+
+    $utilitypageman->manage_editbutton($edit);
 
     // Calculations.
     $uploadsformman = new form($cm, $context, $surveypro);

--- a/report/colles/view.php
+++ b/report/colles/view.php
@@ -22,6 +22,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use mod_surveypro\utility_page;
 use surveyproreport_colles\report;
 use surveyproreport_colles\groupjumperform;
 
@@ -31,6 +32,7 @@ require_once($CFG->libdir.'/tablelib.php');
 
 $id = optional_param('id', 0, PARAM_INT);
 $s = optional_param('s', 0, PARAM_INT);
+$edit = optional_param('edit', -1, PARAM_BOOL);
 
 if (!empty($id)) {
     $cm = get_coursemodule_from_id('surveypro', $id, 0, false, MUST_EXIST);
@@ -50,6 +52,8 @@ $groupid = optional_param('groupid', false, PARAM_INT);  // Group ID.
 $cm = cm_info::create($cm);
 require_course_login($course, false, $cm);
 $context = \context_module::instance($cm->id);
+
+$utilitypageman = new utility_page($cm, $surveypro);
 
 if ($type == 'summary') {
     if (!has_capability('mod/surveypro:accessreports', $context)) {
@@ -102,6 +106,8 @@ $PAGE->set_cm($cm);
 $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 // Is it useful? $PAGE->add_body_class('mediumwidth');.
+
+$utilitypageman->manage_editbutton($edit);
 
 echo $OUTPUT->header();
 

--- a/report/frequency/view.php
+++ b/report/frequency/view.php
@@ -22,6 +22,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use mod_surveypro\utility_page;
 use mod_surveypro\utility_layout;
 use surveyproreport_frequency\filterform;
 use surveyproreport_frequency\report;
@@ -32,6 +33,7 @@ require_once($CFG->libdir.'/tablelib.php');
 
 $id = optional_param('id', 0, PARAM_INT);
 $s = optional_param('s', 0, PARAM_INT);
+$edit = optional_param('edit', -1, PARAM_BOOL);
 
 if (!empty($id)) {
     $cm = get_coursemodule_from_id('surveypro', $id, 0, false, MUST_EXIST);
@@ -47,6 +49,8 @@ $cm = cm_info::create($cm);
 require_course_login($course, false, $cm);
 $context = \context_module::instance($cm->id);
 
+$utilitypageman = new utility_page($cm, $surveypro);
+
 // Required capability.
 require_capability('mod/surveypro:accessreports', $context);
 
@@ -59,6 +63,8 @@ $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 // Is it useful? $PAGE->add_body_class('mediumwidth');.
 // End of: set $PAGE deatils.
+
+$utilitypageman->manage_editbutton($edit);
 
 $reportman = new report($cm, $context, $surveypro);
 

--- a/report/lateusers/view.php
+++ b/report/lateusers/view.php
@@ -22,6 +22,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use mod_surveypro\utility_page;
 use surveyproreport_lateusers\groupjumperform;
 use surveyproreport_lateusers\report;
 
@@ -30,6 +31,7 @@ require_once($CFG->libdir.'/tablelib.php');
 
 $id = optional_param('id', 0, PARAM_INT);
 $s = optional_param('s', 0, PARAM_INT);
+$edit = optional_param('edit', -1, PARAM_BOOL);
 
 if (!empty($id)) {
     $cm = get_coursemodule_from_id('surveypro', $id, 0, false, MUST_EXIST);
@@ -48,6 +50,8 @@ $cm = cm_info::create($cm);
 require_course_login($course, false, $cm);
 $context = \context_module::instance($cm->id);
 
+$utilitypageman = new utility_page($cm, $surveypro);
+
 // Required capability.
 require_capability('mod/surveypro:accessreports', $context);
 
@@ -60,6 +64,8 @@ $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 // Is it useful? $PAGE->add_body_class('mediumwidth');.
 // End of: set $PAGE deatils.
+
+$utilitypageman->manage_editbutton($edit);
 
 $reportman = new report($cm, $context, $surveypro);
 $reportman->set_groupid($groupid);

--- a/report/responsesperuser/view.php
+++ b/report/responsesperuser/view.php
@@ -22,6 +22,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use mod_surveypro\utility_page;
 use surveyproreport_responsesperuser\groupjumperform;
 use surveyproreport_responsesperuser\report;
 
@@ -30,6 +31,7 @@ require_once($CFG->libdir.'/tablelib.php');
 
 $id = optional_param('id', 0, PARAM_INT);
 $s = optional_param('s', 0, PARAM_INT);
+$edit = optional_param('edit', -1, PARAM_BOOL);
 
 if (!empty($id)) {
     $cm = get_coursemodule_from_id('surveypro', $id, 0, false, MUST_EXIST);
@@ -47,6 +49,8 @@ $groupid = optional_param('groupid', 0, PARAM_INT);
 $cm = cm_info::create($cm);
 require_course_login($course, false, $cm);
 $context = \context_module::instance($cm->id);
+
+$utilitypageman = new utility_page($cm, $surveypro);
 
 // Required capability.
 require_capability('mod/surveypro:accessreports', $context);
@@ -88,6 +92,8 @@ $PAGE->set_cm($cm);
 $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 // Is it useful? $PAGE->add_body_class('mediumwidth');.
+
+$utilitypageman->manage_editbutton($edit);
 
 echo $OUTPUT->header();
 

--- a/report/userspercount/view.php
+++ b/report/userspercount/view.php
@@ -22,6 +22,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use mod_surveypro\utility_page;
 use surveyproreport_userspercount\groupjumperform;
 use surveyproreport_userspercount\report;
 
@@ -30,6 +31,7 @@ require_once($CFG->libdir.'/tablelib.php');
 
 $id = optional_param('id', 0, PARAM_INT);
 $s = optional_param('s', 0, PARAM_INT);
+$edit = optional_param('edit', -1, PARAM_BOOL);
 
 if (!empty($id)) {
     $cm = get_coursemodule_from_id('surveypro', $id, 0, false, MUST_EXIST);
@@ -47,6 +49,8 @@ $groupid = optional_param('groupid', 0, PARAM_INT);
 $cm = cm_info::create($cm);
 require_course_login($course, false, $cm);
 $context = \context_module::instance($cm->id);
+
+$utilitypageman = new utility_page($cm, $surveypro);
 
 // Required capability.
 require_capability('mod/surveypro:accessreports', $context);
@@ -88,6 +92,8 @@ $PAGE->set_cm($cm);
 $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
 // Is it useful? $PAGE->add_body_class('mediumwidth');.
+
+$utilitypageman->manage_editbutton($edit);
 
 echo $OUTPUT->header();
 

--- a/reports.php
+++ b/reports.php
@@ -26,6 +26,7 @@ require_once(dirname(__FILE__).'/../../config.php');
 
 $id = optional_param('id', 0, PARAM_INT); // Course_module id.
 $s = optional_param('s', 0, PARAM_INT);   // Surveypro instance id.
+$report = optional_param('report', null, PARAM_TEXT); // Requested report.
 
 if (!empty($id)) {
     $cm = get_coursemodule_from_id('surveypro', $id, 0, false, MUST_EXIST);
@@ -36,9 +37,6 @@ if (!empty($id)) {
     $course = $DB->get_record('course', ['id' => $surveypro->course], '*', MUST_EXIST);
     $cm = get_coursemodule_from_instance('surveypro', $surveypro->id, $course->id, false, MUST_EXIST);
 }
-
-// Get additional specific params.
-$report = optional_param('report', null, PARAM_TEXT);   // Surveypro instance id.
 
 $cm = cm_info::create($cm);
 require_course_login($course, false, $cm);

--- a/tools.php
+++ b/tools.php
@@ -37,6 +37,7 @@ require_once(dirname(__FILE__).'/../../config.php');
 $id = optional_param('id', 0, PARAM_INT);                       // Course_module id.
 $s = optional_param('s', 0, PARAM_INT);                         // Surveypro instance id.
 $section = optional_param('section', 'export', PARAM_ALPHAEXT); // The section of code to execute.
+$edit = optional_param('edit', -1, PARAM_BOOL);
 
 // Verify I used correct names all along the module code.
 $validsections = ['export', 'import'];
@@ -66,7 +67,6 @@ $utilitypageman = new utility_page($cm, $surveypro);
 // MARK export.
 if ($section == 'export') { // It was tools_export.php
     // Get additional specific params.
-    $edit = optional_param('edit', -1, PARAM_BOOL);
 
     // Required capability.
     require_capability('mod/surveypro:exportresponses', $context);
@@ -138,7 +138,6 @@ if ($section == 'export') { // It was tools_export.php
 // MARK import.
 if ($section == 'import') { // It was tools_import.php
     // Get additional specific params.
-    $edit = optional_param('edit', -1, PARAM_BOOL);
 
     // Required capability.
     require_capability('mod/surveypro:importresponses', $context);

--- a/utemplates.php
+++ b/utemplates.php
@@ -42,6 +42,7 @@ require_once(dirname(__FILE__).'/../../config.php');
 $id = optional_param('id', 0, PARAM_INT);                       // Course_module id.
 $s = optional_param('s', 0, PARAM_INT);                         // Surveypro instance id.
 $section = optional_param('section', 'manage', PARAM_ALPHAEXT); // The section of code to execute.
+$edit = optional_param('edit', -1, PARAM_BOOL);
 
 // Verify I used correct names all along the module code.
 $validsections = ['manage', 'save', 'import', 'apply'];
@@ -71,7 +72,6 @@ $utilitypageman = new utility_page($cm, $surveypro);
 // MARK manage.
 if ($section == 'manage') { // It was utemplate_manage.php
     // Get additional specific params.
-    $edit = optional_param('edit', -1, PARAM_BOOL);
     $utemplateid = optional_param('fid', 0, PARAM_INT);
     $action = optional_param('act', SURVEYPRO_NOACTION, PARAM_INT);
     $confirm = optional_param('cnf', SURVEYPRO_UNCONFIRMED, PARAM_INT);
@@ -116,7 +116,6 @@ if ($section == 'manage') { // It was utemplate_manage.php
 // MARK save.
 if ($section == 'save') { // It was utemplate_save.php
     // Get additional specific params.
-    $edit = optional_param('edit', -1, PARAM_BOOL);
     $utemplateid = optional_param('fid', 0, PARAM_INT);
 
     // Required capability.
@@ -183,7 +182,6 @@ if ($section == 'save') { // It was utemplate_save.php
 // MARK import.
 if ($section == 'import') { // It was utemplate_import.php
     // Get additional specific params.
-    $edit = optional_param('edit', -1, PARAM_BOOL);
     $utemplateid = optional_param('fid', 0, PARAM_INT);
 
     // Required capability.
@@ -245,7 +243,6 @@ if ($section == 'import') { // It was utemplate_import.php
 // MARK apply.
 if ($section == 'apply') { // It was utemplate_apply.php
     // Get additional specific params.
-    $edit = optional_param('edit', -1, PARAM_BOOL);
     $utemplateid = optional_param('fid', 0, PARAM_INT);
     $action = optional_param('act', SURVEYPRO_NOACTION, PARAM_INT);
     $confirm = optional_param('cnf', SURVEYPRO_UNCONFIRMED, PARAM_INT);

--- a/view.php
+++ b/view.php
@@ -45,6 +45,7 @@ require_once(dirname(__FILE__).'/../../config.php');
 $id = optional_param('id', 0, PARAM_INT);                      // Course_module id.
 $s = optional_param('s', 0, PARAM_INT);                        // Surveypro instance id.
 $section = optional_param('section', 'cover', PARAM_ALPHAEXT); // The section of code to execute.
+$edit = optional_param('edit', -1, PARAM_BOOL);
 
 // Verify I used correct names all along the module code.
 $validsections = ['cover', 'submissionslist', 'submissionform', 'searchsubmissions'];
@@ -74,7 +75,6 @@ $utilitypageman = new utility_page($cm, $surveypro);
 // MARK cover.
 if ($section == 'cover') { // It was view_cover.php
     // Get additional specific params.
-    $edit = optional_param('edit', -1, PARAM_BOOL);
 
     // Required capability.
     $canmanageitems = has_capability('mod/surveypro:manageitems', $context);
@@ -122,7 +122,6 @@ if ($section == 'cover') { // It was view_cover.php
 // - print to PDF a submission.
 if ($section == 'submissionslist') { // It was view_submissions.php
     // Get additional specific params.
-    $edit = optional_param('edit', -1, PARAM_BOOL);
     $tifirst = optional_param('tifirst', '', PARAM_ALPHA); // First letter of the name.
     $tilast = optional_param('tilast', '', PARAM_ALPHA);   // First letter of the surname.
     // $tsort = optional_param('tsort', '', PARAM_ALPHA);     // Field asked to sort the table for.
@@ -189,7 +188,6 @@ if ($section == 'submissionslist') { // It was view_submissions.php
 // - view in readonly mode.
 if ($section == 'submissionform') { // It was view_form.php
     // Get additional specific params.
-    $edit = optional_param('edit', -1, PARAM_BOOL);
     $submissionid = optional_param('submissionid', 0, PARAM_INT);
     $formpage = optional_param('formpage', 1, PARAM_INT); // Form page number.
     $mode = optional_param('mode', SURVEYPRO_NOMODE, PARAM_INT);
@@ -338,7 +336,6 @@ if ($section == 'submissionform') { // It was view_form.php
 // MARK searchsubmissions.
 if ($section == 'searchsubmissions') { // It was view_search.php
     // Get additional specific params.
-    $edit = optional_param('edit', -1, PARAM_BOOL);
     $formpage = optional_param('formpage', 1, PARAM_INT); // Form page number.
 
     // Required capability.


### PR DESCRIPTION
This branch has been built on top of wrong_condition_in_manage_editbutton to let it pass GHA.

In the frame of this fix I also:
- verified the presence of "Blocks editing on" in each page (it was missing from report pages)
- moved set_additionalparams close to the other set_* methods in classes/reportbase.php
- reordered methods in a report/attachments/classes/report.php

This PR needs wrong_condition_in_manage_editbutton to work properly.

It should be merged to MOODLE_401|402|403_STABLE too.