### PR TITLE
Changed returned variable in case of error

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -875,7 +875,7 @@ function surveypro_get_link_visibility_condition($linkid) {
     global $PAGE, $DB;
 
     if (!$cm = $PAGE->cm) {
-        return;
+        return  [false, '', ''];
     }
 
     $context = \context_module::instance($cm->id);


### PR DESCRIPTION
Made coherent with the supposed return value what is returned by the function surveypro_get_link_visibility_condition in case of error.