### PR TITLE
Breadrumbs and company

### DIFF
--- a/classes/cover.php
+++ b/classes/cover.php
@@ -156,6 +156,7 @@ class cover {
             $paramurl = [];
             $paramurl['s'] = $this->cm->instance;
             $paramurl['mode'] = SURVEYPRO_NEWRESPONSEMODE;
+            $paramurl['area'] = 'surveypro';
             $paramurl['section'] = 'submissionform';
             $paramurl['begin'] = 1;
             $url = new \moodle_url('/mod/surveypro/view.php', $paramurl);
@@ -192,13 +193,14 @@ class cover {
 
         // Begin of: report section.
         $surveyproreportlist = get_plugin_list('surveyproreport');
-        $paramurl = ['s' => $this->cm->instance];
+        $paramurl = ['s' => $this->cm->instance, 'area' => 'reports', 'section' => 'apply'];
 
         foreach ($surveyproreportlist as $reportname => $pluginpath) {
             $classname = 'surveyproreport_'.$reportname.'\report';
             $reportman = new $classname($this->cm, $this->context, $this->surveypro);
+            $reportman->setup();
 
-            if ($reportman->is_report_allowed($reportname)) {
+            if ($reportman->is_report_allowed()) {
                 if ($childrenreports = $reportman->get_haschildrenreports()) {
                     $linklabel = get_string('pluginname', 'surveyproreport_'.$reportname);
                     $this->add_report_link($childrenreports, $reportname, $messages, $linklabel);
@@ -217,6 +219,7 @@ class cover {
         // End of: report section.
 
         // Begin of: user templates section.
+        $paramurl = ['s' => $this->cm->instance, 'area' => 'utemplates'];
         if ($canmanageusertemplates) {
             $paramurl['section'] = 'manage';
             $url = new \moodle_url('/mod/surveypro/utemplates.php', $paramurl);

--- a/classes/layout_itemsetup.php
+++ b/classes/layout_itemsetup.php
@@ -402,6 +402,7 @@ class layout_itemsetup {
                         if ($reserved) {
                             $paramurl['act'] = SURVEYPRO_MAKEAVAILABLE;
                             $paramurl['sortindex'] = $sortindex;
+                            $paramurl['area'] = 'layout';
                             $paramurl['section'] = 'itemslist';
                             $paramurl['sesskey'] = sesskey();
 
@@ -412,6 +413,7 @@ class layout_itemsetup {
                         } else {
                             $paramurl['act'] = SURVEYPRO_MAKERESERVED;
                             $paramurl['sortindex'] = $sortindex;
+                            $paramurl['area'] = 'layout';
                             $paramurl['section'] = 'itemslist';
                             $paramurl['sesskey'] = sesskey();
 
@@ -487,6 +489,7 @@ class layout_itemsetup {
                 // SURVEYPRO_EDITITEM.
                 $paramurl = $paramurlbase;
                 $paramurl['mode'] = SURVEYPRO_EDITITEM;
+                $paramurl['area'] = 'layout';
                 $paramurl['section'] = 'itemsetup';
 
                 $link = new \moodle_url('/mod/surveypro/layout.php', $paramurl);
@@ -517,6 +520,7 @@ class layout_itemsetup {
                     $paramurl = $paramurlbase;
                     $paramurl['act'] = SURVEYPRO_DELETEITEM;
                     $paramurl['sortindex'] = $sortindex;
+                    $paramurl['area'] = 'layout';
                     $paramurl['section'] = 'itemslist';
                     $paramurl['sesskey'] = sesskey();
 
@@ -551,6 +555,7 @@ class layout_itemsetup {
                     if ($currentindent !== false) { // It may be false like for labels with fullwidth == 1.
                         $paramurl = $paramurlbase;
                         $paramurl['act'] = SURVEYPRO_CHANGEINDENT;
+                        $paramurl['area'] = 'layout';
                         $paramurl['section'] = 'itemslist';
                         $paramurl['sesskey'] = sesskey();
 
@@ -604,6 +609,7 @@ class layout_itemsetup {
                 if (!empty($drawmoveherebox)) {
                     $paramurl = $paramurlmove;
                     $paramurl['lib'] = $sortindex;
+                    $paramurl['area'] = 'layout';
                     $paramurl['section'] = 'itemslist';
                     $paramurl['sesskey'] = sesskey();
 

--- a/classes/submissions_list.php
+++ b/classes/submissions_list.php
@@ -672,7 +672,7 @@ class submissions_list {
             $table->initialbars(true);
         }
 
-        $paramurl = ['s' => $this->cm->instance, 'section' => 'submissionslist'];
+        $paramurl = ['s' => $this->cm->instance, 'area' => 'surveypro', 'section' => 'submissionslist'];
         if ($this->searchquery) {
             $paramurl['searchquery'] = $this->searchquery;
         }
@@ -788,7 +788,7 @@ class submissions_list {
             }
 
             $tablerowcounter = 0;
-            $paramurlbase = ['s' => $this->cm->instance];
+            $paramurlbase = ['s' => $this->cm->instance, 'area' => 'surveypro', 'section' => 'submissionslist'];
 
             foreach ($submissions as $submission) {
                 // Count each submission.
@@ -1018,6 +1018,7 @@ class submissions_list {
         if ($addnew) {
             $paramurl['mode'] = SURVEYPRO_NEWRESPONSEMODE;
             $paramurl['begin'] = 1;
+            $paramurl['area'] = 'surveypro';
             $paramurl['section'] = 'submissionform';
 
             $addurl = new \moodle_url('/mod/surveypro/view.php', $paramurl);
@@ -1049,7 +1050,7 @@ class submissions_list {
             }
         } else {
             $class = ['class' => 'buttons'];
-            $addbutton = new \single_button($addurl, get_string('addnewsubmission', 'mod_surveypro'), 'post', 'primary');
+            $addbutton = new \single_button($addurl, get_string('addnewsubmission', 'mod_surveypro'), 'get', 'primary');
             $class = ['class' => 'buttons btn-secondary'];
             $deleteallbutton = new \single_button($deleteurl, get_string('deleteallsubmissions', 'mod_surveypro'));
 

--- a/index.php
+++ b/index.php
@@ -46,6 +46,7 @@ $PAGE->set_title($strsurveypro);
 $PAGE->set_heading($course->fullname);
 // Is it useful? $PAGE->add_body_class('mediumwidth');.
 
+// Output starts here.
 echo $OUTPUT->header();
 echo $OUTPUT->heading($strdataplural, 2);
 

--- a/layout.php
+++ b/layout.php
@@ -39,10 +39,13 @@ use mod_surveypro\utility_mform;
 use mod_surveypro\local\form\userform;
 
 require_once(dirname(__FILE__).'/../../config.php');
+require_once(dirname(__FILE__).'/lib.php');
 
-$id = optional_param('id', 0, PARAM_INT);                          // Course_module id.
-$s = optional_param('s', 0, PARAM_INT);                            // Surveypro instance id.
-$section = optional_param('section', 'itemslist', PARAM_ALPHAEXT); // The section of code to execute.
+$defaultsection = surveypro_get_defaults_section_per_area('layout');
+
+$id = optional_param('id', 0, PARAM_INT);                              // Course_module id.
+$s = optional_param('s', 0, PARAM_INT);                                // Surveypro instance id.
+$section = optional_param('section', $defaultsection, PARAM_ALPHAEXT); // The section of code to execute.
 $edit = optional_param('edit', -1, PARAM_BOOL);
 
 // Verify I used correct names all along the module code.
@@ -135,8 +138,8 @@ if ($section == 'preview') { // It was layout_validation.php
     }
     // End of: manage form submission.
 
-    // Output starts here.
-    $paramurl = ['s' => $surveypro->id, 'section' => 'preview'];
+    // Set $PAGE params.
+    $paramurl = ['s' => $surveypro->id, 'area' => 'layout', 'section' => 'preview'];
     if (!empty($submissionid)) {
         $paramurl['submissionid'] = $submissionid;
     }
@@ -146,11 +149,11 @@ if ($section == 'preview') { // It was layout_validation.php
     $PAGE->set_cm($cm);
     $PAGE->set_title($surveypro->name);
     $PAGE->set_heading($course->shortname);
-    $PAGE->navbar->add(get_string('layout', 'mod_surveypro'), $url);
     $PAGE->navbar->add(get_string('layout_preview', 'mod_surveypro'));
     // Is it useful? $PAGE->add_body_class('mediumwidth');.
     $utilitypageman->manage_editbutton($edit);
 
+    // Output starts here.
     echo $OUTPUT->header();
 
     $actionbar = new \mod_surveypro\output\action_bar($cm, $context, $surveypro);
@@ -286,18 +289,19 @@ if ($section == 'itemslist') { // It was layout_itemlist.php.
     }
     // End of: Bulk action form.
 
-    // Output starts here.
-    $url = new \moodle_url('/mod/surveypro/layout.php', ['s' => $surveypro->id, 'section' => 'itemslist']);
+    // Set $PAGE params.
+    $paramurl = ['s' => $surveypro->id, 'area' => 'layout', 'section' => 'itemslist'];
+    $url = new \moodle_url('/mod/surveypro/layout.php', $paramurl);
     $PAGE->set_url($url);
     $PAGE->set_context($context);
     $PAGE->set_cm($cm);
     $PAGE->set_title($surveypro->name);
     $PAGE->set_heading($course->shortname);
-    // Q: $PAGE->navbar->add(get_string('layout', 'mod_surveypro'), $url); // WHY it is already onboard?
     $PAGE->navbar->add(get_string('layout_items', 'mod_surveypro'));
     // Is it useful? $PAGE->add_body_class('mediumwidth');.
     $utilitypageman->manage_editbutton($edit);
 
+    // Output starts here.
     echo $OUTPUT->header();
 
     // If you are changing the order of items, move them and don't think to edit blocks.
@@ -415,6 +419,26 @@ if ($section == 'itemsetup') { // It was layout_itemsetup.php
     $item->set_editor();
     // End of: get item.
 
+    // Set $PAGE params.
+    $paramurl = [];
+    $paramurl['s'] = $surveypro->id;
+    $paramurl['area'] = 'layout';
+    $paramurl['section'] = 'itemsetup';
+    $paramurl['itemid'] = $itemid;
+    $paramurl['type'] = $layoutman->get_type();
+    $paramurl['plugin'] = $layoutman->get_plugin();
+    $paramurl['mode'] = $mode;
+
+    $url = new \moodle_url('/mod/surveypro/layout.php', $paramurl);
+    $PAGE->set_url($url);
+    $PAGE->set_context($context);
+    $PAGE->set_cm($cm);
+    $PAGE->set_title($surveypro->name);
+    $PAGE->set_heading($course->shortname);
+    $PAGE->navbar->add(get_string('layout_itemsetup', 'mod_surveypro'));
+    // Is it useful? $PAGE->add_body_class('mediumwidth');.
+    $utilitypageman->manage_editbutton($edit);
+
     // Begin of: define $itemform return url.
     $paramurl = ['s' => $cm->instance, 'section' => 'itemsetup'];
     $formurl = new \moodle_url('/mod/surveypro/layout.php', $paramurl);
@@ -451,25 +475,6 @@ if ($section == 'itemsetup') { // It was layout_itemsetup.php
     // End of: manage form submission.
 
     // Output starts here.
-    $paramurl = [];
-    $paramurl['s'] = $surveypro->id;
-    $paramurl['itemid'] = $itemid;
-    $paramurl['type'] = $layoutman->get_type();
-    $paramurl['plugin'] = $layoutman->get_plugin();
-    $paramurl['mode'] = $mode;
-    $paramurl['section'] = 'itemsetup';
-
-    $url = new \moodle_url('/mod/surveypro/layout.php', $paramurl);
-    $PAGE->set_url($url);
-    $PAGE->set_context($context);
-    $PAGE->set_cm($cm);
-    $PAGE->set_title($surveypro->name);
-    $PAGE->set_heading($course->shortname);
-    $PAGE->navbar->add(get_string('layout', 'mod_surveypro'), $url);
-    $PAGE->navbar->add(get_string('layout_itemsetup', 'mod_surveypro'));
-    // Is it useful? $PAGE->add_body_class('mediumwidth');.
-    $utilitypageman->manage_editbutton($edit);
-
     echo $OUTPUT->header();
 
     $actionbar = new \mod_surveypro\output\action_bar($cm, $context, $surveypro);
@@ -496,7 +501,6 @@ if ($section == 'branchingvalidation') { // It was layout_validation.php
     require_capability('mod/surveypro:additems', $context);
 
     // Calculations.
-
     $layoutman = new layout_itemsetup($cm, $context, $surveypro);
 
     // Property type is useless, do not set it.
@@ -538,18 +542,19 @@ if ($section == 'branchingvalidation') { // It was layout_validation.php
     // Property itemcount is useless (it is set to its default), do not set it.
     // So, jump: $layoutman->set_itemcount($itemcount);
 
-    // Output starts here.
-    $url = new \moodle_url('/mod/surveypro/layout.php', ['s' => $surveypro->id, 'section' => 'branchingvalidation']);
+    // Set $PAGE params.
+    $paramurl = ['s' => $surveypro->id, 'area' => 'layout', 'section' => 'branchingvalidation'];
+    $url = new \moodle_url('/mod/surveypro/layout.php', $paramurl);
     $PAGE->set_url($url);
     $PAGE->set_context($context);
     $PAGE->set_cm($cm);
     $PAGE->set_title($surveypro->name);
     $PAGE->set_heading($course->shortname);
-    $PAGE->navbar->add(get_string('layout', 'mod_surveypro'), $url);
     $PAGE->navbar->add(get_string('layout_branchingvalidation', 'mod_surveypro'));
     // Is it useful? $PAGE->add_body_class('mediumwidth');.
     $utilitypageman->manage_editbutton($edit);
 
+    // Output starts here.
     echo $OUTPUT->header();
 
     $actionbar = new \mod_surveypro\output\action_bar($cm, $context, $surveypro);

--- a/mtemplates.php
+++ b/mtemplates.php
@@ -33,10 +33,13 @@ use mod_surveypro\utility_submission;
 use mod_surveypro\local\form\mtemplate_applyform;
 
 require_once(dirname(__FILE__).'/../../config.php');
+require_once(dirname(__FILE__).'/lib.php');
+
+$defaultsection = surveypro_get_defaults_section_per_area('mtemplates');
 
 $id = optional_param('id', 0, PARAM_INT); // Course_module id.
 $s = optional_param('s', 0, PARAM_INT);   // Surveypro instance id.
-$section = optional_param('section', 'save', PARAM_ALPHAEXT); // The section of code to execute.
+$section = optional_param('section', $defaultsection, PARAM_ALPHAEXT); // The section of code to execute.
 $edit = optional_param('edit', -1, PARAM_BOOL);
 
 // Verify I used correct names all along the module code.
@@ -85,16 +88,19 @@ if ($section == 'save') { // It was mtemplate_save.php
     }
     // End of: manage form submission.
 
-    // Output starts here.
-    $url = new \moodle_url('/mod/surveypro/mtemplates.php', ['s' => $surveypro->id, 'section' => 'save']);
+    // Set $PAGE params.
+    $paramurl = ['s' => $surveypro->id, 'area' => 'mtemplates', 'section' => 'save'];
+    $url = new \moodle_url('/mod/surveypro/mtemplates.php', $paramurl);
     $PAGE->set_url($url);
     $PAGE->set_context($context);
     $PAGE->set_cm($cm);
     $PAGE->set_title($surveypro->name);
     $PAGE->set_heading($course->shortname);
+    $PAGE->navbar->add(get_string('mtemplate_save', 'mod_surveypro'));
     // Is it useful? $PAGE->add_body_class('mediumwidth');.
     $utilitypageman->manage_editbutton($edit);
 
+    // Output starts here.
     echo $OUTPUT->header();
 
     $actionbar = new \mod_surveypro\output\action_bar($cm, $context, $surveypro);
@@ -138,16 +144,19 @@ if ($section == 'apply') { // It was mtemplate_apply.php
     }
     // End of: manage form submission.
 
-    // Output starts here.
-    $url = new \moodle_url('/mod/surveypro/mtemplates.php', ['s' => $surveypro->id, 'section' => 'apply']);
+    // Set $PAGE params.
+    $paramurl = ['s' => $surveypro->id, 'area' => 'mtemplates', 'section' => 'apply'];
+    $url = new \moodle_url('/mod/surveypro/mtemplates.php', $paramurl);
     $PAGE->set_url($url);
     $PAGE->set_context($context);
     $PAGE->set_cm($cm);
     $PAGE->set_title($surveypro->name);
     $PAGE->set_heading($course->shortname);
+    $PAGE->navbar->add(get_string('mtemplate_apply', 'mod_surveypro'));
     // Is it useful? $PAGE->add_body_class('mediumwidth');.
     $utilitypageman->manage_editbutton($edit);
 
+    // Output starts here.
     echo $OUTPUT->header();
 
     $actionbar = new \mod_surveypro\output\action_bar($cm, $context, $surveypro);

--- a/report/attachments/classes/report.php
+++ b/report/attachments/classes/report.php
@@ -220,15 +220,6 @@ class report extends reportbase {
     // MARK get.
 
     /**
-     * Is this report equipped with student reports.
-     *
-     * @return boolean
-     */
-    public static function get_hasstudentreport() {
-        return false;
-    }
-
-    /**
      * Get if this report displays user names.
      *
      * @return boolean
@@ -243,7 +234,7 @@ class report extends reportbase {
      * @return [$sql, $whereparams];
      */
     public function get_submissions_sql() {
-        global $COURSE, $DB;
+        global $COURSE, $DB, $USER;
 
         $userfieldsapi = \core_user\fields::for_userpic()->get_sql('u');
         $whereparams = [];
@@ -253,6 +244,11 @@ class report extends reportbase {
 
         [$middlesql, $whereparams] = $this->get_middle_sql();
         $sql .= $middlesql;
+
+        if ($this->onlypersonaldata) {
+            $sql .= ' AND u.id = :userid';
+            $whereparams['userid'] = $USER->id;
+        }
 
         if ($this->outputtable->get_sql_sort()) {
             $sql .= ' ORDER BY '.$this->outputtable->get_sql_sort().', submissionid ASC';

--- a/report/attachments/view.php
+++ b/report/attachments/view.php
@@ -64,25 +64,25 @@ $context = \context_module::instance($cm->id);
 $utilitypageman = new utility_page($cm, $surveypro);
 
 // MARK view.
-if ($section == 'view') { // It was view_cover.php
+if ($section == 'view') {
     $groupid = optional_param('groupid', 0, PARAM_INT);
 
-    // Required capability.
-    require_capability('mod/surveypro:accessreports', $context);
-
-    // Begin of: set $PAGE deatils.
-    $url = new \moodle_url('/mod/surveypro/reports.php', ['s' => $surveypro->id, 'report' => 'attachments', 'section' => 'view']);
+    // Set $PAGE params.
+    $paramurl = ['s' => $surveypro->id, 'area' => 'reports', 'report' => 'attachments', 'section' => 'view'];
+    $url = new \moodle_url('/mod/surveypro/reports.php', $paramurl);
     $PAGE->set_url($url);
     $PAGE->set_context($context);
     $PAGE->set_cm($cm);
     $PAGE->set_title($surveypro->name);
     $PAGE->set_heading($course->shortname);
+    $PAGE->navbar->add(get_string('pluginname', 'surveyproreport_attachments'));
     // Is it useful? $PAGE->add_body_class('mediumwidth');.
     // End of: set $PAGE deatils.
 
     $utilitypageman->manage_editbutton($edit);
 
     $reportman = new report($cm, $context, $surveypro);
+    $reportman->setup();
     $reportman->set_groupid($groupid);
     $reportman->setup_outputtable();
 
@@ -139,6 +139,26 @@ if ($section == 'details') { // It was report/attachments/uploads.php
     $canaccessreserveditems = has_capability('mod/surveypro:accessreserveditems', $context);
     $canviewhiddenactivities = has_capability('moodle/course:viewhiddenactivities', $context);
 
+    // Set $PAGE params.
+    $paramurl = [];
+    $paramurl['s'] = $surveypro->id;
+    $paramurl['area'] = 'reports';
+    $paramurl['report'] = 'attachments';
+    $paramurl['section'] = 'details';
+    $paramurl['container'] = $container;
+
+    $url = new \moodle_url('/mod/surveypro/reports.php', $paramurl);
+    $PAGE->set_url($url);
+    $PAGE->set_context($context);
+    $PAGE->set_cm($cm);
+    $PAGE->set_title($surveypro->name);
+    $PAGE->set_heading($course->shortname);
+    $PAGE->navbar->add(get_string('pluginname', 'surveyproreport_attachments'));
+    // Is it useful? $PAGE->add_body_class('mediumwidth');.
+    // End of: set $PAGE deatils.
+
+    $utilitypageman->manage_editbutton($edit);
+
     if ($changeuser) {
         $returnurl = new \moodle_url('/mod/surveypro/report/attachments/view.php', ['s' => $cm->instance]);
         redirect($returnurl);
@@ -151,19 +171,6 @@ if ($section == 'details') { // It was report/attachments/uploads.php
     if (!$submissionid) {
         $submissionid = $DB->get_field('surveypro_submission', 'MIN(id)', ['userid' => $userid, 'surveyproid' => $surveypro->id]);
     }
-
-    // Begin of: set $PAGE deatils.
-    $paramurl = ['s' => $surveypro->id, 'report' => 'attachments', 'section' => 'details', 'container' => $container];
-    $url = new \moodle_url('/mod/surveypro/reports.php', $paramurl);
-    $PAGE->set_url($url);
-    $PAGE->set_context($context);
-    $PAGE->set_cm($cm);
-    $PAGE->set_title($surveypro->name);
-    $PAGE->set_heading($course->shortname);
-    // Is it useful? $PAGE->add_body_class('mediumwidth');.
-    // End of: set $PAGE deatils.
-
-    $utilitypageman->manage_editbutton($edit);
 
     // Calculations.
     $uploadsformman = new form($cm, $context, $surveypro);

--- a/report/colles/graph.php
+++ b/report/colles/graph.php
@@ -42,7 +42,7 @@ if (!empty($id)) {
 }
 
 $groupid = optional_param('groupid', 0, PARAM_INT); // Group ID.
-$area = optional_param('area', 0, PARAM_INT);  // Report area.
+$areaidx = optional_param('areaidx', 0, PARAM_INT);  // Report areaidx.
 $qid = optional_param('qid', 0, PARAM_INT);  // Question ID.
 
 require_login($course, false, $cm);
@@ -53,12 +53,11 @@ if ($type == 'summary') {
     if (!has_capability('mod/surveypro:accessreports', $context)) {
         require_capability('mod/surveypro:accessownreports', $context);
     }
-} else {
-    require_capability('mod/surveypro:accessreports', $context);
 }
 
 $reportman = new report($cm, $context, $surveypro);
-$reportman->set_area($area);
+$reportman->setup();
+$reportman->set_areaidx($areaidx);
 $reportman->set_groupid($groupid);
 
 $graph = new graph(SURVEYPROREPORT_COLLES_GWIDTH, SURVEYPROREPORT_COLLES_GHEIGHT);
@@ -185,7 +184,7 @@ if ($type == 'summary') {
 }
 
 if ($type == 'scales') {
-    $reportman->fetch_scalesdata($area);
+    $reportman->fetch_scalesdata($areaidx);
 
     // Legend for $y_format_params.
     if ($reportman->template == 'collesactualpreferred') {
@@ -269,7 +268,7 @@ if ($type == 'scales') {
 }
 
 if ($type == 'questions') {
-    $reportman->fetch_questionsdata($area, $qid);
+    $reportman->fetch_questionsdata($areaidx, $qid);
 
     // Legend for $y_format_params.
     if ($reportman->template == 'collesactualpreferred') {

--- a/report/frequency/classes/report.php
+++ b/report/frequency/classes/report.php
@@ -45,15 +45,6 @@ class report extends reportbase {
     public $outputtable = null;
 
     /**
-     * Is this report equipped with student reports.
-     *
-     * @return boolean
-     */
-    public static function get_hasstudentreport() {
-        return false;
-    }
-
-    /**
      * Does the current report apply to the passed mastertemplates?
      *
      * @param string $mastertemplate
@@ -207,7 +198,7 @@ class report extends reportbase {
      * @return [$sql, $whereparams];
      */
     public function get_submissions_sql($itemid) {
-        global $COURSE, $DB;
+        global $COURSE, $DB, $USER;
 
         $whereparams = [];
         $sql = 'SELECT '.$DB->sql_compare_text('a.content', 255).', MIN(a.id) as id, COUNT(a.id) as absolute
@@ -217,9 +208,12 @@ class report extends reportbase {
 
         [$middlesql, $whereparams] = $this->get_middle_sql();
         $sql .= $middlesql;
-
         $sql .= ' AND a.itemid = :itemid';
         $whereparams['itemid'] = $itemid;
+        if ($this->onlypersonaldata) {
+            $sql .= ' AND u.id = :userid';
+            $whereparams['userid'] = $USER->id;
+        }
 
         $sql .= ' GROUP BY '.$DB->sql_compare_text('a.content', 255);
 
@@ -240,7 +234,7 @@ class report extends reportbase {
      * @return [$sql, $whereparams];
      */
     public function get_answercount_sql($itemid) {
-        global $COURSE, $DB;
+        global $COURSE, $DB, $USER;
 
         $sql = 'SELECT COUNT(\'x\')
                 FROM {user} u
@@ -249,9 +243,12 @@ class report extends reportbase {
 
         [$middlesql, $whereparams] = $this->get_middle_sql();
         $sql .= $middlesql;
-
         $sql .= ' AND a.itemid = :itemid';
         $whereparams['itemid'] = $itemid;
+        if ($this->onlypersonaldata) {
+            $sql .= ' AND u.id = :userid';
+            $whereparams['userid'] = $USER->id;
+        }
 
         return [$sql, $whereparams];
     }

--- a/report/frequency/graph.php
+++ b/report/frequency/graph.php
@@ -40,10 +40,9 @@ $groupid = optional_param('groupid', 0, PARAM_INT); // Group ID.
 require_login($course, false, $cm);
 $context = \context_module::instance($cm->id);
 
-// Required capability.
-require_capability('mod/surveypro:accessreports', $context);
-
 $reportman = new report($cm, $context, $surveypro);
+$reportman->setup();
+$reportman->prevent_direct_user_input();
 $reportman->set_groupid($groupid);
 
 list($sql, $whereparams) = $reportman->get_submissions_sql($itemid);

--- a/report/frequency/view.php
+++ b/report/frequency/view.php
@@ -49,22 +49,23 @@ $context = \context_module::instance($cm->id);
 
 $utilitypageman = new utility_page($cm, $surveypro);
 
-// Required capability.
-require_capability('mod/surveypro:accessreports', $context);
-
-// Begin of: set $PAGE deatils.
-$url = new \moodle_url('/mod/surveypro/reports.php', ['s' => $surveypro->id, 'report' => 'frequency']);
+// Set $PAGE params.
+// $url = new \moodle_url('/mod/surveypro/reports.php', ['s' => $surveypro->id, 'report' => 'frequency']);
+$paramurl = ['s' => $surveypro->id, 'area' => 'reports', 'report' => 'frequency', 'section' => 'view'];
+$url = new \moodle_url('/mod/surveypro/reports.php', $paramurl);
 $PAGE->set_url($url);
 $PAGE->set_context($context);
 $PAGE->set_cm($cm);
 $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
+$PAGE->navbar->add(get_string('pluginname', 'surveyproreport_frequency'));
 // Is it useful? $PAGE->add_body_class('mediumwidth');.
 // End of: set $PAGE deatils.
 
 $utilitypageman->manage_editbutton($edit);
 
 $reportman = new report($cm, $context, $surveypro);
+$reportman->setup();
 
 // Begin of: instance filterform.
 $showjumper = $reportman->is_groupjumper_needed();

--- a/report/lateusers/classes/report.php
+++ b/report/lateusers/classes/report.php
@@ -45,15 +45,6 @@ class report extends reportbase {
     public $outputtable = null;
 
     /**
-     * Is this report equipped with student reports.
-     *
-     * @return boolean
-     */
-    public static function get_hasstudentreport() {
-        return false;
-    }
-
-    /**
      * Does the current report apply to the passed mastertemplates?
      *
      * @param string $mastertemplate
@@ -162,6 +153,8 @@ class report extends reportbase {
      * @return [$sql, $whereparams];
      */
     public function get_submissions_sql() {
+        global $USER;
+
         $whereparams = [];
         $userfieldsapi = \core_user\fields::for_userpic()->get_sql('u');
 
@@ -183,6 +176,10 @@ class report extends reportbase {
         [$middlesql, $middleparams] = $this->get_middle_sql(false);
         $sql .= $middlesql;
         $whereparams = array_merge($whereparams, $middleparams);
+        if ($this->onlypersonaldata) {
+            $sql .= ' AND u.id = :userid';
+            $whereparams['userid'] = $USER->id;
+        }
         unset($whereparams['surveyproid']);
 
         if ($this->outputtable->get_sql_sort()) {

--- a/report/lateusers/view.php
+++ b/report/lateusers/view.php
@@ -50,22 +50,22 @@ $context = \context_module::instance($cm->id);
 
 $utilitypageman = new utility_page($cm, $surveypro);
 
-// Required capability.
-require_capability('mod/surveypro:accessreports', $context);
-
-// Begin of: set $PAGE deatils.
-$url = new \moodle_url('/mod/surveypro/reports.php', ['s' => $surveypro->id, 'report' => 'lateusers']);
+// Set $PAGE params.
+$paramurl = ['s' => $surveypro->id, 'area' => 'reports', 'report' => 'lateusers', 'section' => 'view'];
+$url = new \moodle_url('/mod/surveypro/reports.php', $paramurl);
 $PAGE->set_url($url);
 $PAGE->set_context($context);
 $PAGE->set_cm($cm);
 $PAGE->set_title($surveypro->name);
 $PAGE->set_heading($course->shortname);
+$PAGE->navbar->add(get_string('pluginname', 'surveyproreport_lateusers'));
 // Is it useful? $PAGE->add_body_class('mediumwidth');.
 // End of: set $PAGE deatils.
 
 $utilitypageman->manage_editbutton($edit);
 
 $reportman = new report($cm, $context, $surveypro);
+$reportman->setup();
 $reportman->set_groupid($groupid);
 $reportman->setup_outputtable();
 

--- a/report/responsesperuser/view.php
+++ b/report/responsesperuser/view.php
@@ -50,10 +50,21 @@ $context = \context_module::instance($cm->id);
 
 $utilitypageman = new utility_page($cm, $surveypro);
 
-// Required capability.
-require_capability('mod/surveypro:accessreports', $context);
+// Set $PAGE params.
+$paramurl = ['s' => $surveypro->id, 'area' => 'reports', 'report' => 'responsesperuser', 'section' => 'view'];
+$url = new \moodle_url('/mod/surveypro/reports.php', $paramurl);
+$PAGE->set_url($url);
+$PAGE->set_context($context);
+$PAGE->set_cm($cm);
+$PAGE->set_title($surveypro->name);
+$PAGE->set_heading($course->shortname);
+$PAGE->navbar->add(get_string('pluginname', 'surveyproreport_responsesperuser'));
+// Is it useful? $PAGE->add_body_class('mediumwidth');.
+
+$utilitypageman->manage_editbutton($edit);
 
 $reportman = new report($cm, $context, $surveypro);
+$reportman->setup();
 $reportman->set_groupid($groupid);
 $reportman->setup_outputtable();
 
@@ -83,16 +94,6 @@ if ($showjumper) {
 // End of: prepare params for the form.
 
 // Output starts here.
-$url = new \moodle_url('/mod/surveypro/reports.php', ['s' => $surveypro->id, 'report' => 'responsesperuser']);
-$PAGE->set_url($url);
-$PAGE->set_context($context);
-$PAGE->set_cm($cm);
-$PAGE->set_title($surveypro->name);
-$PAGE->set_heading($course->shortname);
-// Is it useful? $PAGE->add_body_class('mediumwidth');.
-
-$utilitypageman->manage_editbutton($edit);
-
 echo $OUTPUT->header();
 
 $actionbar = new \mod_surveypro\output\action_bar($cm, $context, $surveypro);

--- a/report/userspercount/classes/report.php
+++ b/report/userspercount/classes/report.php
@@ -45,15 +45,6 @@ class report extends reportbase {
     public $outputtable = null;
 
     /**
-     * Is this report equipped with student reports.
-     *
-     * @return boolean
-     */
-    public static function get_hasstudentreport() {
-        return false;
-    }
-
-    /**
      * Does the current report apply to the passed mastertemplates?
      *
      * @param string $mastertemplate
@@ -157,14 +148,19 @@ class report extends reportbase {
      * @return [$sql, $whereparams];
      */
     public function get_submissions_sql() {
+        global $USER;
 
         [$middlesql, $whereparams] = $this->get_middle_sql();
 
         $subquery = 'SELECT s.userid, COUNT(s.userid) as userresponses
                 FROM {surveypro_submission} s
                     JOIN {user} u ON u.id = s.userid
-                    '.$middlesql.'
-                GROUP BY s.userid';
+                    '.$middlesql;
+        if ($this->onlypersonaldata) {
+            $subquery .= ' AND s.userid = :userid';
+            $whereparams['userid'] = $USER->id;
+        }
+        $subquery .= ' GROUP BY s.userid';
 
         $sql = 'SELECT userresponses, count(userresponses) as usercount
                 FROM ('.$subquery.') as rpu

--- a/report/userspercount/view.php
+++ b/report/userspercount/view.php
@@ -50,10 +50,21 @@ $context = \context_module::instance($cm->id);
 
 $utilitypageman = new utility_page($cm, $surveypro);
 
-// Required capability.
-require_capability('mod/surveypro:accessreports', $context);
+// Set $PAGE params.
+$paramurl = ['s' => $surveypro->id, 'area' => 'reports', 'report' => 'userspercount', 'section' => 'view'];
+$url = new \moodle_url('/mod/surveypro/reports.php', $paramurl);
+$PAGE->set_url($url);
+$PAGE->set_context($context);
+$PAGE->set_cm($cm);
+$PAGE->set_title($surveypro->name);
+$PAGE->set_heading($course->shortname);
+$PAGE->navbar->add(get_string('pluginname', 'surveyproreport_userspercount'));
+// Is it useful? $PAGE->add_body_class('mediumwidth');.
+
+$utilitypageman->manage_editbutton($edit);
 
 $reportman = new report($cm, $context, $surveypro);
+$reportman->setup();
 $reportman->set_groupid($groupid);
 $reportman->setup_outputtable();
 
@@ -83,16 +94,6 @@ if ($showjumper) {
 // End of: prepare params for the form.
 
 // Output starts here.
-$url = new \moodle_url('/mod/surveypro/reports.php', ['s' => $surveypro->id, 'report' => 'userspercount']);
-$PAGE->set_url($url);
-$PAGE->set_context($context);
-$PAGE->set_cm($cm);
-$PAGE->set_title($surveypro->name);
-$PAGE->set_heading($course->shortname);
-// Is it useful? $PAGE->add_body_class('mediumwidth');.
-
-$utilitypageman->manage_editbutton($edit);
-
 echo $OUTPUT->header();
 
 $actionbar = new \mod_surveypro\output\action_bar($cm, $context, $surveypro);

--- a/template/collesactual/lang/en/surveyprotemplate_collesactual.php
+++ b/template/collesactual/lang/en/surveyprotemplate_collesactual.php
@@ -27,7 +27,7 @@ $string['privacy:metadata'] = 'The "COLLES (Actual)" template plugin does not st
 
 $string['summary'] = 'Summary';
 $string['scales'] = 'Scales';
-$string['areas'] = 'Questions';
+$string['areaidxs'] = 'Questions';
 
 $string['useritem'] = 'Style of the choice elements';
 $string['useritem_desc'] = 'This option let you choose the style of the elemets for the choices of the survey. "Radio buttons" is the standard, "Drop down menu" is better for not huge monitors.<br>Changes will take effect with new surveypro';

--- a/template/collesactual/lang/es_mx/surveyprotemplate_collesactual.php
+++ b/template/collesactual/lang/es_mx/surveyprotemplate_collesactual.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$string['areas'] = 'Preguntas';
+$string['areaidxs'] = 'Preguntas';
 $string['fieldset_content_01'] = 'Relevancia';
 $string['fieldset_content_02'] = 'Pensamiento reflectivo';
 $string['fieldset_content_03'] = 'Interactividad';

--- a/template/collesactual/lang/it/surveyprotemplate_collesactual.php
+++ b/template/collesactual/lang/it/surveyprotemplate_collesactual.php
@@ -25,7 +25,7 @@
 $string['pluginname'] = 'COLLES (Actual)';
 $string['summary'] = 'Riepilogo';
 $string['scales'] = 'Valutazioni';
-$string['areas'] = 'Aree';
+$string['areaidxs'] = 'Aree';
 
 $string['useritem'] = 'Tipo di selettore';
 $string['useritem_desc'] = 'Questa opzione consente di scegliere il tipo di selettore per rispondere al sondaggio. "Bottoni radio" è lo standard, "Menu a tendina" è consigliato per i monitor di modeste dimensioni.<br>Le modifiche avranno effetto sui prossimi nuovi somdaggi.';

--- a/template/collesactualpreferred/lang/en/surveyprotemplate_collesactualpreferred.php
+++ b/template/collesactualpreferred/lang/en/surveyprotemplate_collesactualpreferred.php
@@ -27,7 +27,7 @@ $string['privacy:metadata'] = 'The "COLLES (Preferred and Actual)" template plug
 
 $string['summary'] = 'Summary';
 $string['scales'] = 'Scales';
-$string['areas'] = 'Questions';
+$string['areaidxs'] = 'Questions';
 
 $string['useritem'] = 'Style of the choice elements';
 $string['useritem_desc'] = 'This option let you choose the style of the elemets for the choices of the survey. "Radio buttons" is the standard, "Drop down menu" is better for not huge monitors.<br>Changes will take effect with new surveypro';

--- a/template/collesactualpreferred/lang/es_mx/surveyprotemplate_collesactualpreferred.php
+++ b/template/collesactualpreferred/lang/es_mx/surveyprotemplate_collesactualpreferred.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$string['areas'] = 'Preguntas';
+$string['areaidxs'] = 'Preguntas';
 $string['fieldset_content_01'] = 'Relevancia';
 $string['fieldset_content_02'] = 'Pensamiento reflectivo';
 $string['fieldset_content_03'] = 'Interactividad';

--- a/template/collesactualpreferred/lang/it/surveyprotemplate_collesactualpreferred.php
+++ b/template/collesactualpreferred/lang/it/surveyprotemplate_collesactualpreferred.php
@@ -25,7 +25,7 @@
 $string['pluginname'] = 'COLLES (Ideale e Reale)';
 $string['summary'] = 'Riepilogo';
 $string['scales'] = 'Valutazioni';
-$string['areas'] = 'Aree';
+$string['areaidxs'] = 'Aree';
 
 $string['useritem'] = 'Tipo di selettore';
 $string['useritem_desc'] = 'Questa opzione consente di scegliere il tipo di selettore per rispondere al sondaggio. "Bottoni radio" è lo standard, "Menu a tendina" è consigliato per i monitor di modeste dimensioni.<br>Le modifiche avranno effetto sui prossimi nuovi somdaggi.';

--- a/template/collespreferred/lang/en/surveyprotemplate_collespreferred.php
+++ b/template/collespreferred/lang/en/surveyprotemplate_collespreferred.php
@@ -27,7 +27,7 @@ $string['privacy:metadata'] = 'The "COLLES (Preferred)" template plugin does not
 
 $string['summary'] = 'Summary';
 $string['scales'] = 'Scales';
-$string['areas'] = 'Questions';
+$string['areaidxs'] = 'Questions';
 
 $string['useritem'] = 'Style of the choice elements';
 $string['useritem_desc'] = 'This option let you choose the style of the elemets for the choices of the survey. "Radio buttons" is the standard, "Drop down menu" is better for not huge monitors.<br>Changes will take effect with new surveypro';

--- a/template/collespreferred/lang/es_mx/surveyprotemplate_collespreferred.php
+++ b/template/collespreferred/lang/es_mx/surveyprotemplate_collespreferred.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$string['areas'] = 'Preguntas';
+$string['areaidxs'] = 'Preguntas';
 $string['fieldset_content_01'] = 'Relevancia';
 $string['fieldset_content_02'] = 'Pensamiento reflectivo';
 $string['fieldset_content_03'] = 'Interactividad';

--- a/template/collespreferred/lang/it/surveyprotemplate_collespreferred.php
+++ b/template/collespreferred/lang/it/surveyprotemplate_collespreferred.php
@@ -25,7 +25,7 @@
 $string['pluginname'] = 'COLLES (Ideale)';
 $string['summary'] = 'Riepilogo';
 $string['scales'] = 'Valutazioni';
-$string['areas'] = 'Aree';
+$string['areaidxs'] = 'Aree';
 
 $string['useritem'] = 'Tipo di selettore';
 $string['useritem_desc'] = 'Questa opzione consente di scegliere il tipo di selettore per rispondere al sondaggio. "Bottoni radio" è lo standard, "Menu a tendina" è consigliato per i monitor di modeste dimensioni.<br>Le modifiche avranno effetto sui prossimi nuovi somdaggi.';

--- a/tools.php
+++ b/tools.php
@@ -33,10 +33,13 @@ use mod_surveypro\tools_import;
 use mod_surveypro\local\form\submissions_importform;
 
 require_once(dirname(__FILE__).'/../../config.php');
+require_once(dirname(__FILE__).'/lib.php');
+
+$defaultsection = surveypro_get_defaults_section_per_area('tools');
 
 $id = optional_param('id', 0, PARAM_INT);                       // Course_module id.
 $s = optional_param('s', 0, PARAM_INT);                         // Surveypro instance id.
-$section = optional_param('section', 'export', PARAM_ALPHAEXT); // The section of code to execute.
+$section = optional_param('section', $defaultsection, PARAM_ALPHAEXT); // The section of code to execute.
 $edit = optional_param('edit', -1, PARAM_BOOL);
 
 // Verify I used correct names all along the module code.
@@ -98,8 +101,9 @@ if ($section == 'export') { // It was tools_export.php
     }
     // End of: manage form submission.
 
-    // Output starts here.
-    $url = new \moodle_url('/mod/surveypro/tools.php', ['s' => $surveypro->id, 'section' => 'export']);
+    // Set $PAGE params.
+    $paramurl = ['s' => $surveypro->id, 'area' => 'tools', 'section' => 'export'];
+    $url = new \moodle_url('/mod/surveypro/tools.php', $paramurl);
     $PAGE->set_url($url);
     // $PAGE->set_pagetype();
     // $PAGE->set_pagelayout('incourse');
@@ -107,11 +111,11 @@ if ($section == 'export') { // It was tools_export.php
     $PAGE->set_cm($cm);
     $PAGE->set_title($surveypro->name);
     $PAGE->set_heading($course->shortname);
-    // $PAGE->navbar->add(get_string('tools', 'mod_surveypro'), $url); // WHY it is already onboard?
     $PAGE->navbar->add(get_string('tools_export', 'mod_surveypro'));
     // Is it useful? $PAGE->add_body_class('mediumwidth');.
     $utilitypageman->manage_editbutton($edit);
 
+    // Output starts here.
     echo $OUTPUT->header();
 
     $actionbar = new \mod_surveypro\output\action_bar($cm, $context, $surveypro);
@@ -162,8 +166,9 @@ if ($section == 'import') { // It was tools_import.php
     }
     // End of: manage form submission.
 
-    // Output starts here.
-    $url = new \moodle_url('/mod/surveypro/tools.php', ['s' => $surveypro->id, 'section' => 'import']);
+    // Set $PAGE params.
+    $paramurl = ['s' => $surveypro->id, 'area' => 'tools', 'section' => 'import'];
+    $url = new \moodle_url('/mod/surveypro/tools.php', $paramurl);
     $PAGE->set_url($url);
     // $PAGE->set_pagetype();
     // $PAGE->set_pagelayout('incourse');
@@ -171,11 +176,11 @@ if ($section == 'import') { // It was tools_import.php
     $PAGE->set_cm($cm);
     $PAGE->set_title($surveypro->name);
     $PAGE->set_heading($course->shortname);
-    $PAGE->navbar->add(get_string('tools', 'mod_surveypro'), $url);
     $PAGE->navbar->add(get_string('tools_import', 'mod_surveypro'));
     // Is it useful? $PAGE->add_body_class('mediumwidth');.
     $utilitypageman->manage_editbutton($edit);
 
+    // Output starts here.
     echo $OUTPUT->header();
 
     $actionbar = new \mod_surveypro\output\action_bar($cm, $context, $surveypro);

--- a/utemplates.php
+++ b/utemplates.php
@@ -38,10 +38,13 @@ use mod_surveypro\templatebase;
 use mod_surveypro\local\form\utemplate_applyform;
 
 require_once(dirname(__FILE__).'/../../config.php');
+require_once(dirname(__FILE__).'/lib.php');
+
+$defaultsection = surveypro_get_defaults_section_per_area('utemplates');
 
 $id = optional_param('id', 0, PARAM_INT);                       // Course_module id.
 $s = optional_param('s', 0, PARAM_INT);                         // Surveypro instance id.
-$section = optional_param('section', 'manage', PARAM_ALPHAEXT); // The section of code to execute.
+$section = optional_param('section', $defaultsection, PARAM_ALPHAEXT); // The section of code to execute.
 $edit = optional_param('edit', -1, PARAM_BOOL);
 
 // Verify I used correct names all along the module code.
@@ -88,18 +91,19 @@ if ($section == 'manage') { // It was utemplate_manage.php
         die();
     }
 
-    // Output starts here.
-    $url = new \moodle_url('/mod/surveypro/utemplates.php', ['s' => $surveypro->id, 'section' => 'manage']);
+    // Set $PAGE params.
+    $paramurl = ['s' => $surveypro->id, 'area' => 'utemplates', 'section' => 'manage'];
+    $url = new \moodle_url('/mod/surveypro/utemplates.php', $paramurl);
     $PAGE->set_url($url);
     $PAGE->set_context($context);
     $PAGE->set_cm($cm);
     $PAGE->set_title($surveypro->name);
     $PAGE->set_heading($course->shortname);
-    $PAGE->navbar->add(get_string('utemplate', 'mod_surveypro'), $url);
     $PAGE->navbar->add(get_string('utemplate_manage', 'mod_surveypro'));
     // Is it useful? $PAGE->add_body_class('mediumwidth');.
     $utilitypageman->manage_editbutton($edit);
 
+    // Output starts here.
     echo $OUTPUT->header();
 
     $actionbar = new \mod_surveypro\output\action_bar($cm, $context, $surveypro);
@@ -128,7 +132,7 @@ if ($section == 'save') { // It was utemplate_save.php
     $utemplateman->setup($utemplateid, $action, $confirm);
 
     // $utemplateman->prevent_direct_user_input();
-    // is not needed because the check has already been done here with: require_capability('mod/surveypro:saveusertemplates', $context);
+    // is not needed because the check has already been done here with: require_capability('mod/surveypro:saveusertemplates',...
 
     // Begin of: define $createutemplate return url.
     $formurl = new \moodle_url('/mod/surveypro/utemplates.php', ['s' => $surveypro->id, 'section' => 'save']);
@@ -151,18 +155,19 @@ if ($section == 'save') { // It was utemplate_save.php
     }
     // End of: manage form submission.
 
-    // Output starts here.
-    $url = new \moodle_url('/mod/surveypro/utemplates.php', ['s' => $surveypro->id, 'section' => 'save']);
+    // Set $PAGE params.
+    $paramurl = ['s' => $surveypro->id, 'area' => 'utemplates', 'section' => 'save'];
+    $url = new \moodle_url('/mod/surveypro/utemplates.php', $paramurl);
     $PAGE->set_url($url);
     $PAGE->set_context($context);
     $PAGE->set_cm($cm);
     $PAGE->set_title($surveypro->name);
     $PAGE->set_heading($course->shortname);
-    $PAGE->navbar->add(get_string('utemplate', 'mod_surveypro'), $url);
     $PAGE->navbar->add(get_string('utemplate_save', 'mod_surveypro'));
     // Is it useful? $PAGE->add_body_class('mediumwidth');.
     $utilitypageman->manage_editbutton($edit);
 
+    // Output starts here.
     echo $OUTPUT->header();
 
     $actionbar = new \mod_surveypro\output\action_bar($cm, $context, $surveypro);
@@ -217,18 +222,19 @@ if ($section == 'import') { // It was utemplate_import.php
     }
     // End of: manage form submission.
 
-    // Output starts here.
-    $url = new \moodle_url('/mod/surveypro/utemplates.php', ['s' => $surveypro->id, 'section' => 'import']);
+    // Set $PAGE params.
+    $paramurl = ['s' => $surveypro->id, 'area' => 'utemplates', 'section' => 'import'];
+    $url = new \moodle_url('/mod/surveypro/utemplates.php', $paramurl);
     $PAGE->set_url($url);
     $PAGE->set_context($context);
     $PAGE->set_cm($cm);
     $PAGE->set_title($surveypro->name);
     $PAGE->set_heading($course->shortname);
-    $PAGE->navbar->add(get_string('utemplate', 'mod_surveypro'), $url);
     $PAGE->navbar->add(get_string('utemplate_import', 'mod_surveypro'));
     // Is it useful? $PAGE->add_body_class('mediumwidth');.
     $utilitypageman->manage_editbutton($edit);
 
+    // Output starts here.
     echo $OUTPUT->header();
 
     $actionbar = new \mod_surveypro\output\action_bar($cm, $context, $surveypro);
@@ -275,16 +281,19 @@ if ($section == 'apply') { // It was utemplate_apply.php
     }
     // End of: manage form submission.
 
-    // Output starts here.
-    $url = new \moodle_url('/mod/surveypro/utemplates.php', ['s' => $surveypro->id, 'section' => 'apply']);
+    // Set $PAGE params.
+    $paramurl = ['s' => $surveypro->id, 'area' => 'utemplates', 'section' => 'apply'];
+    $url = new \moodle_url('/mod/surveypro/utemplates.php', $paramurl);
     $PAGE->set_url($url);
     $PAGE->set_context($context);
     $PAGE->set_cm($cm);
     $PAGE->set_title($surveypro->name);
     $PAGE->set_heading($course->shortname);
+    $PAGE->navbar->add(get_string('utemplate_apply', 'mod_surveypro'));
     // Is it useful? $PAGE->add_body_class('mediumwidth');.
     $utilitypageman->manage_editbutton($edit);
 
+    // Output starts here.
     echo $OUTPUT->header();
 
     $actionbar = new \mod_surveypro\output\action_bar($cm, $context, $surveypro);


### PR DESCRIPTION
The original target of this work was the normalisation of breadcrumbs. At the end of this work, the only aspect that has not yet been definitively put in order is the normalisation of breadcrumbs. The MDL-80602 solution will probably show how to deal with this problem correctly.

Using the classic theme, all pages in the module when selected are now highlighted in bold in the navigation block and the administration block.

Surveypro logical structure is, as known:
[Spro area] surveypro (managed in view.php)
    - [Area section] cover
    - [Area section] submissionslist
    - [Area section] submissionform
    - [Area section] searchsubmissions
[Spro area] layout (managed in layout.php)
    - [Area section] itemslist
    - [Area section] itemsetup
    - [Area section] branchingvalidation
    - [Area section] preview
[Spro area] reports (managed in reports.php)
    - [report] attachement overview
    - [report] frequency distribution
    - [report] late users
    - [report] responses per user
    - [report] users per count of responses
[Spro area] tools (managed in tools.php)
    - [Area section] export
    - [Area section] import
[Spro area] user templates (managed in utemplates.php)
    - [Area section] manage
    - [Area section] save
    - [Area section] import
    - [Area section] apply
[Spro area] master templates (managed in mtemplates.php)
    - [Area section] save
    - [Area section] apply

Link highlighting in the two blocks is extended to each section of each area. The links of the blocks in 'standard' conditions refer to each area in its default section. To define the default section of each area I introduced the function: surveypro_get_defaults_section_per_area on lib.php.

To display links in bold I introduced the two variables $area and $section throughout all the code.

While writing this code, I realised that the reports listed in the page of [area]: surveypro [section]: cover were different from those listed in the jump menu of [area]: report. Because of this I standardised the procedure for identifying the reports allowed based on the user's capability. The definition is in $reportbase->is_report_allowed().

In order to prevent any past or future errors from displaying data into the reports that the generic user is not supposed to see (GDPR, EU regulation 2016/679), I introduced, at reportbase class level, the property $onlypersonaldata. This property is true if the user does not have the capability 'mod/surveypro:accessreports' but does have the capability 'mod/surveypro:accessownreports'.

With this correction, a report is shown IF, AND ONLY IF, the user requesting it has one of these two capabilities: 'mod/surveypro:accessreports' or 'mod/surveypro:accessownreports'. The truth table for accessing reports is the following:

```
|                    | accessownreports: yes    | accessownreports: no   |
| accessreports: yes | display general report   | display general report |
| accessreports: no  | $onlypersonaldata = true | reports are denied     |
```
If $onlypersonaldata == true, a report is shown using, as referring database, ONLY THE PERSONAL SUBMISSIONS OF THE USER.

Because of the introduction of $onlypersonaldata I removed the method $reportman->get_hasstudentreport() as it has not any more meaning. Each report is accessible to students. In the worst case students will see the report of their own submissions only if $onlypersonaldata = true.

Because of the relevance of this update, I believe it should also be cherry-picked to MOODLE_401|402|403_STABLE.

Finally I think this PR definitivly kills #907.

Please cherry-pick this to (m401|m402|m403) too.