### PR TITLE
Run the tests with both the highest and the lowers PHP versions (403)

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -28,12 +28,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: 8.1
+          - php: 8.0
             moodle-branch: MOODLE_403_STABLE
             database: mariadb
             suite: classic
             profile: default
-          - php: 8.1
+          - php: 8.2
             moodle-branch: MOODLE_403_STABLE
             database: pgsql
             suite: default


### PR DESCRIPTION
That way we can detect any problem with the supported versions for a given Moodle branch.

Let's see if 403_STABLE passes with both php80 and php82 (the min and max PHP versions supported for that branch)