### PR TITLE
Run the tests with both the highest and the lowers PHP versions (401)

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: 8.1
+          - php: 7.4
             moodle-branch: MOODLE_401_STABLE
             database: mariadb
             suite: classic


### PR DESCRIPTION
That way we can detect any problem with the supported versions for a given Moodle branch.

Let's see if 401_STABLE passes with both php74 and php81 (the min and max PHP versions supported for that branch)