### PR TITLE
Second release of the PR already submitted some weeks ago

### DIFF
--- a/classes/local/form/userform.php
+++ b/classes/local/form/userform.php
@@ -133,7 +133,7 @@ class userform extends \moodleform {
                         $itemname = $item->get_itemname().'_extrarow';
                         $content = $item->get_contentwithnumber();
                         $option = ['class' => 'indent-'.$item->get_indent()];
-                        $mform->addElement('mod_surveypro_label', $itemname, $elementnumber, $content, $option);
+                        $mform->addElement('mod_surveypro_label', $itemname, '', $content, $option);
 
                         $item->item_add_color_unifier($mform);
                     }

--- a/field/rate/classes/item.php
+++ b/field/rate/classes/item.php
@@ -156,7 +156,6 @@ class item extends itembase {
 
         // List of fields I do not want to have in the item definition form.
         $this->insetupform['insearchform'] = false;
-        $this->insetupform['position'] = SURVEYPRO_POSITIONLEFT;
 
         if (!empty($itemid)) {
             $this->item_load($itemid, $getparentcontent);
@@ -249,12 +248,11 @@ class item extends itembase {
         // Nothing to do: they don't exist in this plugin.
 
         // 2. Override few values.
-        // Position and hideinstructions are set by design.
-        $record->position = SURVEYPRO_POSITIONTOP;
+        // Nothing to do: no need to overwrite variables.
 
         // 3. Set values corresponding to checkboxes.
         // Take care: 'required', 'hideinstructions' were already considered in get_common_settings.
-        $checkboxes = ['hideinstructions', 'differentrates'];
+        $checkboxes = ['differentrates'];
         foreach ($checkboxes as $checkbox) {
             $record->{$checkbox} = (isset($record->{$checkbox})) ? 1 : 0;
         }


### PR DESCRIPTION
I am not allowed to force the property "position" of a rate item because I included, in its item setup form, the user item to allow course creators to choose the content position. So I have to decide:
    I drop the user item to allow course creators to choose the content position
    I no longer force the property "position"

I choosed the second option.