### PR TITLE
Do not avoid item_custom_field_to form even if value is empty

### DIFF
--- a/field/age/classes/item.php
+++ b/field/age/classes/item.php
@@ -269,9 +269,6 @@ class item extends itembase
         // 1. Special management for composite fields.
         $fieldlist = $this->get_composite_fields();
         foreach ($fieldlist as $field) {
-            if (!$this->{$field}) {
-                continue;
-            }
             $agearray = $this->item_split_unix_time($this->{$field});
             $this->{$field . 'year'} = $agearray['year'];
             $this->{$field . 'month'} = $agearray['mon'];

--- a/field/date/classes/item.php
+++ b/field/date/classes/item.php
@@ -256,9 +256,6 @@ class item extends itembase
         // 1. Special management for composite fields.
         $fieldlist = $this->get_composite_fields();
         foreach ($fieldlist as $field) {
-            if (!$this->{$field}) {
-                continue;
-            }
             $datearray = $this->item_split_unix_time($this->{$field});
             $this->{$field . 'year'} = $datearray['year'];
             $this->{$field . 'month'} = $datearray['mon'];

--- a/field/datetime/classes/item.php
+++ b/field/datetime/classes/item.php
@@ -296,10 +296,6 @@ class item extends itembase
         // 1. Special management for composite fields.
         $fieldlist = $this->get_composite_fields();
         foreach ($fieldlist as $field) {
-            if (!$this->{$field}) {
-                continue;
-            }
-
             $datetimearray = $this->item_split_unix_time($this->{$field});
             $this->{$field . 'year'} = $datetimearray['year'];
             $this->{$field . 'month'} = $datetimearray['mon'];

--- a/field/recurrence/classes/item.php
+++ b/field/recurrence/classes/item.php
@@ -220,9 +220,6 @@ class item extends itembase
         // 1. Special management for composite fields.
         $fieldlist = $this->get_composite_fields();
         foreach ($fieldlist as $field) {
-            if (!$this->{$field}) {
-                continue;
-            }
             $recurrencearray = $this->item_split_unix_time($this->{$field});
             $this->{$field . 'month'} = $recurrencearray['mon'];
             $this->{$field . 'day'} = $recurrencearray['mday'];

--- a/field/shortdate/classes/item.php
+++ b/field/shortdate/classes/item.php
@@ -219,9 +219,6 @@ class item extends itembase
         // 1. Special management for composite fields.
         $fieldlist = $this->get_composite_fields();
         foreach ($fieldlist as $field) {
-            if (!$this->{$field}) {
-                continue;
-            }
             $shortdatearray = $this->item_split_unix_time($this->{$field});
             $this->{$field . 'month'} = $shortdatearray['mon'];
             $this->{$field . 'year'} = $shortdatearray['year'];


### PR DESCRIPTION
Do not avoid item_custom_field_to_form even if value is empty

For age, date, datetime, recurrence, shortdate and time element,
the value of the element is saved in unix time but must be displayed using
hour, minute in the item form... depending on the element.
A silly
            if (!$this->{$field}) {
                continue;
            }
very rerely, but incorrectly, stops the evaluation of form elements.