### PR TITLE
Test weird behat

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15
+        image: postgres:16
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -32,12 +32,12 @@ jobs:
       matrix:
         include:
           - php: 8.4
-            moodle-branch: MOODLE_501_STABLE
+            moodle-branch: main
             database: mariadb
             suite: classic
             profile: default
-          - php: 8.2
-            moodle-branch: MOODLE_501_STABLE
+          - php: 8.3
+            moodle-branch: main
             database: pgsql
             suite: default
             profile: chrome
@@ -68,6 +68,7 @@ jobs:
       - name: Install moodle-plugin-ci
         run: moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
         env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
           DB: ${{ matrix.database }}
           MOODLE_BRANCH: ${{ matrix.moodle-branch }}
 

--- a/field/age/tests/behat/itemform.feature
+++ b/field/age/tests/behat/itemform.feature
@@ -25,7 +25,7 @@ Feature: Create an age item
 
     # add an age item
     And I set the field "typeplugin" to "Age [yy/mm]"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/age/tests/behat/search.feature
+++ b/field/age/tests/behat/search.feature
@@ -24,7 +24,7 @@ Feature: Search using one and two age items
 
     # Create a two items long surveypro
     And I set the field "typeplugin" to "Age"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     Given I set the following fields to these values:
@@ -45,7 +45,7 @@ Feature: Search using one and two age items
     And I press "Add"
 
     And I set the field "typeplugin" to "Age"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     Given I set the following fields to these values:

--- a/field/age/tests/behat/submit_age.feature
+++ b/field/age/tests/behat/submit_age.feature
@@ -23,7 +23,7 @@ Feature: Submit using an age item
     And I am on the "Age test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Age"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/age/tests/behat/use_advanced_elements.feature
+++ b/field/age/tests/behat/use_advanced_elements.feature
@@ -24,7 +24,7 @@ Feature: Use reserved elements
 
     # add the first age item generally available
     And I set the field "typeplugin" to "Age [yy/mm]"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:
@@ -41,7 +41,7 @@ Feature: Use reserved elements
 
     # add the second age item (as reserved element)
     And I set the field "typeplugin" to "Age [yy/mm]"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/autofill/tests/behat/itemform.feature
+++ b/field/autofill/tests/behat/itemform.feature
@@ -25,7 +25,7 @@ Feature: Create an autofill item
 
     # add an autofill item
     And I set the field "typeplugin" to "Autofill"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/autofill/tests/behat/preserve_autofillpersonaldata.feature
+++ b/field/autofill/tests/behat/preserve_autofillpersonaldata.feature
@@ -42,7 +42,7 @@ Feature: Editing a submission, autofill userID is not overwritten
     And I press "Save and display"
 
     And I set the field "typeplugin" to "Autofill"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:
@@ -54,7 +54,7 @@ Feature: Editing a submission, autofill userID is not overwritten
     And I press "Add"
 
     And I set the field "typeplugin" to "Autofill"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:
@@ -65,7 +65,7 @@ Feature: Editing a submission, autofill userID is not overwritten
     And I press "Add"
 
     And I set the field "typeplugin" to "Autofill"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:
@@ -76,7 +76,7 @@ Feature: Editing a submission, autofill userID is not overwritten
     And I press "Add"
 
     And I set the field "typeplugin" to "Boolean"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/autofill/tests/behat/search.feature
+++ b/field/autofill/tests/behat/search.feature
@@ -24,7 +24,7 @@ Feature: Search using one and two autofill items
 
     # Create a two items long surveypro
     And I set the field "typeplugin" to "Autofill"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     And I set the following fields to these values:
@@ -36,7 +36,7 @@ Feature: Search using one and two autofill items
     And I press "Add"
 
     And I set the field "typeplugin" to "Autofill"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/autofill/tests/behat/submit_autofill.feature
+++ b/field/autofill/tests/behat/submit_autofill.feature
@@ -23,7 +23,7 @@ Feature: Submit using an autofill item
     And I am on the "Autofill test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Autofill"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/boolean/tests/behat/itemform.feature
+++ b/field/boolean/tests/behat/itemform.feature
@@ -25,7 +25,7 @@ Feature: Create a boolean item
 
     # add an boolean item
     And I set the field "typeplugin" to "Boolean"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/boolean/tests/behat/search.feature
+++ b/field/boolean/tests/behat/search.feature
@@ -24,7 +24,7 @@ Feature: Search using one and two boolean items
 
     # Create a two items long surveypro
     And I set the field "typeplugin" to "Boolean"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     And I set the following fields to these values:
@@ -35,7 +35,7 @@ Feature: Search using one and two boolean items
     And I press "Add"
 
     And I set the field "typeplugin" to "Boolean"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/boolean/tests/behat/submit_boolean.feature
+++ b/field/boolean/tests/behat/submit_boolean.feature
@@ -23,7 +23,7 @@ Feature: Submit using a boolean item
     And I am on the "Boolean test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Boolean"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:
@@ -36,7 +36,7 @@ Feature: Submit using a boolean item
     And I press "Add"
 
     And I set the field "typeplugin" to "Boolean"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:
@@ -49,7 +49,7 @@ Feature: Submit using a boolean item
     And I press "Add"
 
     And I set the field "typeplugin" to "Boolean"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/character/tests/behat/itemform.feature
+++ b/field/character/tests/behat/itemform.feature
@@ -25,7 +25,7 @@ Feature: Create a character item
 
     # add an character item
     And I set the field "typeplugin" to "Text (short)"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/character/tests/behat/search.feature
+++ b/field/character/tests/behat/search.feature
@@ -24,7 +24,7 @@ Feature: Search using one and two short text items
 
     # Create a two items long surveypro
     And I set the field "typeplugin" to "Text (short)"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     Given I set the following fields to these values:
@@ -34,7 +34,7 @@ Feature: Search using one and two short text items
     And I press "Add"
 
     And I set the field "typeplugin" to "Text (short)"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     Given I set the following fields to these values:

--- a/field/character/tests/behat/settings_configuration_01.feature
+++ b/field/character/tests/behat/settings_configuration_01.feature
@@ -23,7 +23,7 @@ Feature: Submit using character item and check form validation (1 of 7)
     And I am on the "Surveypro test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Text (short)"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
   @javascript

--- a/field/character/tests/behat/settings_configuration_02.feature
+++ b/field/character/tests/behat/settings_configuration_02.feature
@@ -23,7 +23,7 @@ Feature: Submit using character item and check form validation (2 of 7)
     And I am on the "Surveypro test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Text (short)"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
   @javascript

--- a/field/character/tests/behat/settings_configuration_03.feature
+++ b/field/character/tests/behat/settings_configuration_03.feature
@@ -23,7 +23,7 @@ Feature: Submit using character item and check form validation (3 of 7)
     And I am on the "Surveypro test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Text (short)"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
   @javascript

--- a/field/character/tests/behat/settings_configuration_04.feature
+++ b/field/character/tests/behat/settings_configuration_04.feature
@@ -23,7 +23,7 @@ Feature: Submit using character item and check form validation (4 of 7)
     And I am on the "Surveypro test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Text (short)"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
   @javascript

--- a/field/character/tests/behat/settings_configuration_05.feature
+++ b/field/character/tests/behat/settings_configuration_05.feature
@@ -23,7 +23,7 @@ Feature: Submit using character item and check form validation (5 of 7)
     And I am on the "Surveypro test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Text (short)"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
   @javascript

--- a/field/character/tests/behat/settings_configuration_06.feature
+++ b/field/character/tests/behat/settings_configuration_06.feature
@@ -23,7 +23,7 @@ Feature: Submit using character item and check form validation (6 of 7)
     And I am on the "Surveypro test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Text (short)"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
   @javascript

--- a/field/character/tests/behat/settings_configuration_07.feature
+++ b/field/character/tests/behat/settings_configuration_07.feature
@@ -23,7 +23,7 @@ Feature: Submit using character item and check form validation (7 of 7)
     And I am on the "Surveypro test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Text (short)"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
   @javascript

--- a/field/character/tests/behat/trim.feature
+++ b/field/character/tests/behat/trim.feature
@@ -24,7 +24,7 @@ Feature: Test the use of character trim
 
     # add an character item
     And I set the field "typeplugin" to "Text (short)"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:
@@ -39,7 +39,7 @@ Feature: Test the use of character trim
 
     # add one more character item
     And I set the field "typeplugin" to "Text (short)"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/checkbox/tests/behat/itemform.feature
+++ b/field/checkbox/tests/behat/itemform.feature
@@ -25,7 +25,7 @@ Feature: Create a checkbox item
 
     # add an checkbox item
     And I set the field "typeplugin" to "Checkbox"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/checkbox/tests/behat/search.feature
+++ b/field/checkbox/tests/behat/search.feature
@@ -24,7 +24,7 @@ Feature: Search using one and two checkbox items
 
     # Create a two items long surveypro
     And I set the field "typeplugin" to "Checkbox"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     Given I set the following fields to these values:
@@ -38,7 +38,7 @@ Feature: Search using one and two checkbox items
     And I press "Add"
 
     And I set the field "typeplugin" to "Checkbox"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     And I set the following fields to these values:

--- a/field/checkbox/tests/behat/settings_configuration_01.feature
+++ b/field/checkbox/tests/behat/settings_configuration_01.feature
@@ -24,7 +24,7 @@ Feature: Submit using checkbox item and check form validation (1 of 4)
     And I am on the "Surveypro test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Checkbox"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
   @javascript

--- a/field/checkbox/tests/behat/settings_configuration_02.feature
+++ b/field/checkbox/tests/behat/settings_configuration_02.feature
@@ -24,7 +24,7 @@ Feature: Submit using checkbox item and check form validation (2 of 4)
     And I am on the "Surveypro test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Checkbox"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
   @javascript

--- a/field/checkbox/tests/behat/settings_configuration_03.feature
+++ b/field/checkbox/tests/behat/settings_configuration_03.feature
@@ -24,7 +24,7 @@ Feature: Submit using checkbox item and check form validation (3 of 4)
     And I am on the "Surveypro test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Checkbox"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
   @javascript

--- a/field/checkbox/tests/behat/settings_configuration_04.feature
+++ b/field/checkbox/tests/behat/settings_configuration_04.feature
@@ -24,7 +24,7 @@ Feature: Submit using checkbox item and check form validation (4 of 4)
     And I am on the "Surveypro test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Checkbox"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
   @javascript

--- a/field/checkbox/tests/behat/settings_configuration_05.feature
+++ b/field/checkbox/tests/behat/settings_configuration_05.feature
@@ -21,7 +21,7 @@ Feature: Submit using checkbox item and check form validation
     And I am on the "Surveypro test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Checkbox"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
   @javascript

--- a/field/date/tests/behat/itemform.feature
+++ b/field/date/tests/behat/itemform.feature
@@ -25,7 +25,7 @@ Feature: Create a date item
 
     # add an date item
     And I set the field "typeplugin" to "Date [dd/mm/yyyy]"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/date/tests/behat/search.feature
+++ b/field/date/tests/behat/search.feature
@@ -24,7 +24,7 @@ Feature: Search using one and two date items
 
     # Create a two items long surveypro
     And I set the field "typeplugin" to "Date [dd/mm/yyyy]"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     Given I set the following fields to these values:
@@ -44,7 +44,7 @@ Feature: Search using one and two date items
     And I press "Add"
 
     And I set the field "typeplugin" to "Date [dd/mm/yyyy]"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     Given I set the following fields to these values:

--- a/field/date/tests/behat/submit_date.feature
+++ b/field/date/tests/behat/submit_date.feature
@@ -23,7 +23,7 @@ Feature: Submit using a date item
     And I am on the "Date test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Date [dd/mm/yyyy]"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/datetime/tests/behat/itemform.feature
+++ b/field/datetime/tests/behat/itemform.feature
@@ -25,7 +25,7 @@ Feature: Create a datetime item
 
     # add an datetime item
     And I set the field "typeplugin" to "Date and time [dd/mm/yyyy;hh:mm]"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/datetime/tests/behat/search.feature
+++ b/field/datetime/tests/behat/search.feature
@@ -24,7 +24,7 @@ Feature: Search using one and two datetime items
 
     # Create a two items long surveypro
     And I set the field "typeplugin" to "Date and time [dd/mm/yyyy;hh:mm]"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     Given I set the following fields to these values:
@@ -48,7 +48,7 @@ Feature: Search using one and two datetime items
     And I press "Add"
 
     And I set the field "typeplugin" to "Date and time [dd/mm/yyyy;hh:mm]"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     Given I set the following fields to these values:

--- a/field/datetime/tests/behat/submit_datetime.feature
+++ b/field/datetime/tests/behat/submit_datetime.feature
@@ -23,7 +23,7 @@ Feature: Submit using a datetime item
     And I am on the "Datetime test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Date and time [dd/mm/yyyy;hh:mm]"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/fileupload/tests/behat/itemform.feature
+++ b/field/fileupload/tests/behat/itemform.feature
@@ -25,7 +25,7 @@ Feature: Create a fileupload item
 
     # add an fileupload item
     And I set the field "typeplugin" to "Attachment"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/fileupload/tests/behat/submit_attachment.feature
+++ b/field/fileupload/tests/behat/submit_attachment.feature
@@ -26,7 +26,7 @@ Feature: Submit using a fileupload item
     And I am on the "Attachment test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Attachment"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/integer/tests/behat/itemform.feature
+++ b/field/integer/tests/behat/itemform.feature
@@ -25,7 +25,7 @@ Feature: Create an integer item
 
     # add an integer item
     And I set the field "typeplugin" to "Integer"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/integer/tests/behat/search.feature
+++ b/field/integer/tests/behat/search.feature
@@ -24,7 +24,7 @@ Feature: Search using one and two integer items
 
     # Create a two items long surveypro
     And I set the field "typeplugin" to "Integer (small)"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     Given I set the following fields to these values:
@@ -37,7 +37,7 @@ Feature: Search using one and two integer items
     And I press "Add"
 
     And I set the field "typeplugin" to "Integer (small)"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     Given I set the following fields to these values:

--- a/field/integer/tests/behat/submit_integer.feature
+++ b/field/integer/tests/behat/submit_integer.feature
@@ -23,7 +23,7 @@ Feature: Submit using an integer item
     And I am on the "Integer test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Integer (small)"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/multiselect/tests/behat/itemform.feature
+++ b/field/multiselect/tests/behat/itemform.feature
@@ -25,7 +25,7 @@ Feature: Create a multiselect item
 
     # add an multiselect item
     And I set the field "typeplugin" to "Multiple selection"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/multiselect/tests/behat/search.feature
+++ b/field/multiselect/tests/behat/search.feature
@@ -24,7 +24,7 @@ Feature: Search using one and two multiselect items
 
     # Create a two items long surveypro
     And I set the field "typeplugin" to "Multiple selection"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     Given I set the following fields to these values:
@@ -38,7 +38,7 @@ Feature: Search using one and two multiselect items
     And I press "Add"
 
     And I set the field "typeplugin" to "Multiple selection"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     Given I set the following fields to these values:

--- a/field/multiselect/tests/behat/settings_configuration_01.feature
+++ b/field/multiselect/tests/behat/settings_configuration_01.feature
@@ -24,7 +24,7 @@ Feature: Submit using multiselect item and check form validation (1 of 4)
     And I am on the "Surveypro test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Multiple selection"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
   @javascript

--- a/field/multiselect/tests/behat/settings_configuration_02.feature
+++ b/field/multiselect/tests/behat/settings_configuration_02.feature
@@ -24,7 +24,7 @@ Feature: Submit using multiselect item and check form validation (2 of 4)
     And I am on the "Surveypro test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Multiple selection"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
   @javascript

--- a/field/multiselect/tests/behat/settings_configuration_03.feature
+++ b/field/multiselect/tests/behat/settings_configuration_03.feature
@@ -24,7 +24,7 @@ Feature: Submit using multiselect item and check form validation (3 of 4)
     And I am on the "Surveypro test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Multiple selection"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
   @javascript

--- a/field/multiselect/tests/behat/settings_configuration_04.feature
+++ b/field/multiselect/tests/behat/settings_configuration_04.feature
@@ -24,7 +24,7 @@ Feature: Submit using multiselect item and check form validation (4 of 4)
     And I am on the "Surveypro test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Multiple selection"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
   @javascript

--- a/field/multiselect/tests/behat/settings_configuration_05.feature
+++ b/field/multiselect/tests/behat/settings_configuration_05.feature
@@ -21,7 +21,7 @@ Feature: Submit using multiselect item and check form validation
     And I am on the "Surveypro test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Multiple selection"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
   @javascript

--- a/field/numeric/tests/behat/itemform.feature
+++ b/field/numeric/tests/behat/itemform.feature
@@ -25,7 +25,7 @@ Feature: Create a numeric item
 
     # add an numeric item
     And I set the field "typeplugin" to "Numeric"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/numeric/tests/behat/search.feature
+++ b/field/numeric/tests/behat/search.feature
@@ -24,7 +24,7 @@ Feature: Search using one and two numeric items
 
     # Create a two items long surveypro
     And I set the field "typeplugin" to "Numeric"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     Given I set the following fields to these values:
@@ -40,7 +40,7 @@ Feature: Search using one and two numeric items
     And I press "Add"
 
     And I set the field "typeplugin" to "Numeric"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     Given I set the following fields to these values:

--- a/field/numeric/tests/behat/submit_numeric.feature
+++ b/field/numeric/tests/behat/submit_numeric.feature
@@ -23,7 +23,7 @@ Feature: Submit using a numeric item
     And I am on the "Numeric test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Numeric"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/radiobutton/tests/behat/itemform.feature
+++ b/field/radiobutton/tests/behat/itemform.feature
@@ -25,7 +25,7 @@ Feature: Create a radiobutton item
 
     # add an radiobutton item
     And I set the field "typeplugin" to "Radio buttons"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/radiobutton/tests/behat/search.feature
+++ b/field/radiobutton/tests/behat/search.feature
@@ -24,7 +24,7 @@ Feature: Search using one and two radiobutton items
 
     # Create a two items long surveypro
     And I set the field "typeplugin" to "Radio buttons"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     Given I set the following fields to these values:
@@ -37,7 +37,7 @@ Feature: Search using one and two radiobutton items
     And I press "Add"
 
     And I set the field "typeplugin" to "Radio buttons"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     Given I set the following fields to these values:

--- a/field/radiobutton/tests/behat/submit_radiobutton.feature
+++ b/field/radiobutton/tests/behat/submit_radiobutton.feature
@@ -23,7 +23,7 @@ Feature: Submit using a radiobutton item
     And I am on the "Radiobutton test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Radio buttons"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:
@@ -37,7 +37,7 @@ Feature: Submit using a radiobutton item
     And I press "Add"
 
     And I set the field "typeplugin" to "Radio buttons"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/rate/tests/behat/itemform.feature
+++ b/field/rate/tests/behat/itemform.feature
@@ -25,7 +25,7 @@ Feature: Create a rate item
 
     # add an rate item
     And I set the field "typeplugin" to "Rate"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/rate/tests/behat/submit_rate.feature
+++ b/field/rate/tests/behat/submit_rate.feature
@@ -23,7 +23,7 @@ Feature: Submit using a rate item
     And I am on the "Rate test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Rate"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:
@@ -37,7 +37,7 @@ Feature: Submit using a rate item
     And I press "Add"
 
     And I set the field "typeplugin" to "Rate"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/recurrence/tests/behat/itemform.feature
+++ b/field/recurrence/tests/behat/itemform.feature
@@ -25,7 +25,7 @@ Feature: Create a recurrence item
 
     # add an recurrence item
     And I set the field "typeplugin" to "Recurrence"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/recurrence/tests/behat/search.feature
+++ b/field/recurrence/tests/behat/search.feature
@@ -24,7 +24,7 @@ Feature: Search using one and two recurrence items
 
     # Create a two items long surveypro
     And I set the field "typeplugin" to "Recurrence [dd/mm]"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     Given I set the following fields to these values:
@@ -42,7 +42,7 @@ Feature: Search using one and two recurrence items
     And I press "Add"
 
     And I set the field "typeplugin" to "Recurrence [dd/mm]"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     Given I set the following fields to these values:

--- a/field/recurrence/tests/behat/submit_recurrence.feature
+++ b/field/recurrence/tests/behat/submit_recurrence.feature
@@ -23,7 +23,7 @@ Feature: Submit using a recurrence item
     And I am on the "Recurrence test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Recurrence [dd/mm]"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/select/tests/behat/itemform.feature
+++ b/field/select/tests/behat/itemform.feature
@@ -25,7 +25,7 @@ Feature: Create a select item
 
     # add an select item
     And I set the field "typeplugin" to "Select"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/select/tests/behat/search.feature
+++ b/field/select/tests/behat/search.feature
@@ -24,7 +24,7 @@ Feature: Search using one and two select items
 
     # Create a two items long surveypro
     And I set the field "typeplugin" to "Select"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     Given I set the following fields to these values:
@@ -37,7 +37,7 @@ Feature: Search using one and two select items
     And I press "Add"
 
     And I set the field "typeplugin" to "Select"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     Given I set the following fields to these values:

--- a/field/select/tests/behat/submit_select.feature
+++ b/field/select/tests/behat/submit_select.feature
@@ -23,7 +23,7 @@ Feature: Submit using a select item
     And I am on the "Select test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Select"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/shortdate/tests/behat/itemform.feature
+++ b/field/shortdate/tests/behat/itemform.feature
@@ -25,7 +25,7 @@ Feature: Create a shortdate item
 
     # add an shortdate item
     And I set the field "typeplugin" to "Date (short) [mm/yyyy]"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/shortdate/tests/behat/search.feature
+++ b/field/shortdate/tests/behat/search.feature
@@ -24,7 +24,7 @@ Feature: Search using one and two shortdate items
 
     # Create a two items long surveypro
     And I set the field "typeplugin" to "Date (short) [mm/yyyy]"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     Given I set the following fields to these values:
@@ -42,7 +42,7 @@ Feature: Search using one and two shortdate items
     And I press "Add"
 
     And I set the field "typeplugin" to "Date (short) [mm/yyyy]"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     Given I set the following fields to these values:

--- a/field/shortdate/tests/behat/submit_shortdate.feature
+++ b/field/shortdate/tests/behat/submit_shortdate.feature
@@ -23,7 +23,7 @@ Feature: Submit using a shortdate item
     And I am on the "Shortdate test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Date (short) [mm/yyyy]"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/textarea/tests/behat/itemform.feature
+++ b/field/textarea/tests/behat/itemform.feature
@@ -25,7 +25,7 @@ Feature: Create a textarea item
 
     # add an textarea item
     And I set the field "typeplugin" to "Text (long)"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/textarea/tests/behat/search.feature
+++ b/field/textarea/tests/behat/search.feature
@@ -24,7 +24,7 @@ Feature: Search using one and two textarea items
 
     # Create a two items long surveypro
     And I set the field "typeplugin" to "Text (long)"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     Given I set the following fields to these values:
@@ -41,7 +41,7 @@ Feature: Search using one and two textarea items
     And I press "Add"
 
     And I set the field "typeplugin" to "Text (long)"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     Given I set the following fields to these values:

--- a/field/textarea/tests/behat/settings_configuration.feature
+++ b/field/textarea/tests/behat/settings_configuration.feature
@@ -24,7 +24,7 @@ Feature: Submit using textarea item and check form validation
     And I am on the "Surveypro test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Text (long)"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
   @javascript

--- a/field/textarea/tests/behat/trim.feature
+++ b/field/textarea/tests/behat/trim.feature
@@ -27,7 +27,7 @@ Feature: Trim textarea content
 
     # add an textarea item
     And I set the field "typeplugin" to "Text (long)"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:
@@ -41,7 +41,7 @@ Feature: Trim textarea content
 
     # add one more textarea item
     And I set the field "typeplugin" to "Text (long)"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/time/tests/behat/itemform.feature
+++ b/field/time/tests/behat/itemform.feature
@@ -25,7 +25,7 @@ Feature: Create a time item
 
     # add an time item
     And I set the field "typeplugin" to "Time"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/field/time/tests/behat/search.feature
+++ b/field/time/tests/behat/search.feature
@@ -24,7 +24,7 @@ Feature: Search using one and two time items
 
     # Create a two items long surveypro
     And I set the field "typeplugin" to "Time"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     Given I set the following fields to these values:
@@ -42,7 +42,7 @@ Feature: Search using one and two time items
     And I press "Add"
 
     And I set the field "typeplugin" to "Time"
-    And I press "Add"
+    And I press "typeplugin_button"
     And I expand all fieldsets
 
     Given I set the following fields to these values:

--- a/field/time/tests/behat/submit_time.feature
+++ b/field/time/tests/behat/submit_time.feature
@@ -23,7 +23,7 @@ Feature: Submit using a time item
     And I am on the "Time test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Time"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/format/fieldset/tests/behat/add_fieldset.feature
+++ b/format/fieldset/tests/behat/add_fieldset.feature
@@ -21,7 +21,7 @@ Feature: Create a fieldset item
     And I am on the "Fieldset test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Fieldset"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the field "Content" to "A bunch of items"

--- a/format/fieldsetend/tests/behat/add_fieldsetend.feature
+++ b/format/fieldsetend/tests/behat/add_fieldsetend.feature
@@ -21,6 +21,6 @@ Feature: Create a fieldsetend item
     And I am on the "Fieldset test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Fieldset closure"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I press "Add"

--- a/format/label/tests/behat/add_label.feature
+++ b/format/label/tests/behat/add_label.feature
@@ -21,7 +21,7 @@ Feature: Create a label item
     And I am on the "Label test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Label"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the field "Content" to "This is just a comment"

--- a/format/pagebreak/tests/behat/add_pagebreak.feature
+++ b/format/pagebreak/tests/behat/add_pagebreak.feature
@@ -21,6 +21,6 @@ Feature: Create a pagebreak item
     And I am on the "Pagebreak test" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Page break"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I press "Add"

--- a/tests/behat/parent_boolean.feature
+++ b/tests/behat/parent_boolean.feature
@@ -27,7 +27,7 @@ Feature: Set boolean as parent item
 
     # add an boolean item
     And I set the field "typeplugin" to "Text (short)"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/tests/behat/parent_checkbox.feature
+++ b/tests/behat/parent_checkbox.feature
@@ -27,7 +27,7 @@ Feature: Set checkbox as parent item
 
     # add a short text item
     And I set the field "typeplugin" to "Text (short)"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/tests/behat/parent_integer.feature
+++ b/tests/behat/parent_integer.feature
@@ -27,7 +27,7 @@ Feature: Set integer as parent item
 
     # add a short text item
     And I set the field "typeplugin" to "Text (short)"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/tests/behat/parent_multiselect.feature
+++ b/tests/behat/parent_multiselect.feature
@@ -27,7 +27,7 @@ Feature: Set multiselect as parent item
 
     # add a short text item
     And I set the field "typeplugin" to "Text (short)"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/tests/behat/parent_radiobutton.feature
+++ b/tests/behat/parent_radiobutton.feature
@@ -27,7 +27,7 @@ Feature: Set radiobutton as parent item
 
     # add a short text item
     And I set the field "typeplugin" to "Text (short)"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/tests/behat/parent_select.feature
+++ b/tests/behat/parent_select.feature
@@ -27,7 +27,7 @@ Feature: Set select as parent item
 
     # add a short text item
     And I set the field "typeplugin" to "Text (short)"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/tests/behat/see_groupsubmissions_part01.feature
+++ b/tests/behat/see_groupsubmissions_part01.feature
@@ -35,7 +35,7 @@ Feature: Submissions seen from students not divided into groups (Part 01)
     And I am on the "Verify submission selection" "surveypro activity" page
 
     And I set the field "typeplugin" to "Text (short)"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/tests/behat/see_groupsubmissions_part02.feature
+++ b/tests/behat/see_groupsubmissions_part02.feature
@@ -41,7 +41,7 @@ Feature: Submissions seen from students divided into groups (Part 02)
     And I am on the "Verify submission selection" "surveypro activity" page
 
     And I set the field "typeplugin" to "Text (short)"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/tests/behat/see_groupsubmissions_part03.feature
+++ b/tests/behat/see_groupsubmissions_part03.feature
@@ -44,7 +44,7 @@ Feature: Submissions seen from students divided into groups (Part 03)
     And I am on the "Verify submission selection" "surveypro activity" page
 
     And I set the field "typeplugin" to "Text (short)"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/tests/behat/see_groupsubmissions_part04.feature
+++ b/tests/behat/see_groupsubmissions_part04.feature
@@ -51,7 +51,7 @@ Feature: Submissions seen from students divided into groups (Part 04)
     And I am on the "Verify submission selection" "surveypro activity" page
 
     And I set the field "typeplugin" to "Text (short)"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/tests/behat/see_onlypersonalsubmissions.feature
+++ b/tests/behat/see_onlypersonalsubmissions.feature
@@ -25,7 +25,7 @@ Feature: Test each student sees only personal submissions
     And I am on the "Get only my own submissions" "mod_surveypro > Layout from secondary navigation" page logged in as teacher1
 
     And I set the field "typeplugin" to "Text (short)"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:
@@ -38,7 +38,7 @@ Feature: Test each student sees only personal submissions
     And I press "Add"
 
     And I set the field "typeplugin" to "Boolean"
-    And I press "Add"
+    And I press "typeplugin_button"
 
     And I expand all fieldsets
     And I set the following fields to these values:

--- a/version.php
+++ b/version.php
@@ -26,6 +26,6 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_surveypro';
 $plugin->maturity = MATURITY_BETA;
-$plugin->version = 2026031000;
+$plugin->version = 2026042000;
 $plugin->requires = 2025100600;
-$plugin->release = '5.1';
+$plugin->release = '5.2';


### PR DESCRIPTION
Running
vendor/bin/behat --config /Applications/MAMP/data/m502/behat/behatrun/behat/behat.yml --tags=@mod_surveypro --profile=firefox --name="Add fieldset item"
or
vendor/bin/behat --config /Applications/MAMP/data/m502/behat/behatrun/behat/behat.yml --tags=@mod_surveypro --profile=chrome --name="Add fieldset item"
behat fails!

This is strange because it has never been failing before.
The execution goes to:
http://localhost:8888/m502_behat/course/view.php?id=195000
instead of
http://localhost:8888/m502_behat/mod/surveypro/layout.php

In the same page there are two form and behat executes the action of the second form instead of the action of the form with the pressed button.
It seems behat submits a wrong form.

Interpreting the text of the test and performing actions manually, all is fine.
It seems this issue happen only in php8.3 and not in php8.4.
In order to avoid this strange behaviour, I replace each occurrence of:
And I press "Add"
with
And I press "typeplugin_button"
in that page with two forms.