### PR TITLE
Enforced quesry on surveypro_submission

### DIFF
--- a/report/attachments/classes/form.php
+++ b/report/attachments/classes/form.php
@@ -142,12 +142,12 @@ class form
     public function display_attachment($submissionid, $itemid) {
         global $DB, $OUTPUT, $PAGE;
 
-        $submission = $DB->get_record('surveypro_submission', ['id' => $submissionid], '*', MUST_EXIST);
+        $submission = $DB->get_record('surveypro_submission', ['id' => $submissionid, 'surveyproid' => $this->surveypro->id], '*', MUST_EXIST);
         $user = $DB->get_record('user', ['id' => $submission->userid], '*', MUST_EXIST);
 
         $renderer = $PAGE->get_renderer('surveyproreport_attachments');
 
-        // Separation at the beginning.
+        // Separator at the beginning.
         echo \html_writer::tag('div', '<br>', ['id' => 'global_container', 'class' => 'mb3 row fitem']);
 
         $data = [];


### PR DESCRIPTION
  In `report/attachments/classes/form.php` (`display_attachment`), the submission is loaded by `id` alone and is not tied to the current `surveypro`; the item/answer query does not enforce `i.surveyproid`.
  Risk: data disclosure between instances (horizontal IDOR) when testing the `submissionid` of other surveys.